### PR TITLE
EZP-24649: Solr: Index Locations as nested documents of Content

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ matrix:
         - php: 5.6
           env: TEST_CONFIG="phpunit.xml"
         - php: 5.4
-          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="4.10.4" CORES_SETUP="dedicated" SOLR_CORES="core0 core1 core2 core3 core4 core5 core6 core7" SOLR_CONFS="lib/eZ/Publish/Core/Search/Solr/Content/Resources/schema.xml"
+          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="4.10.4" CORES_SETUP="dedicated" SOLR_CORES="core0 core1 core2 core3" SOLR_CONFS="lib/eZ/Publish/Core/Search/Solr/Content/Resources/schema.xml"
         - php: 5.5
-          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="4.10.4" CORES_SETUP="shared" SOLR_CORES="core0 core1 core2 core3 core4" SOLR_CONFS="lib/eZ/Publish/Core/Search/Solr/Content/Resources/schema.xml"
+          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="4.10.4" CORES_SETUP="shared" SOLR_CORES="core0 core1 core2 core3" SOLR_CONFS="lib/eZ/Publish/Core/Search/Solr/Content/Resources/schema.xml"
         - php: 5.6
           env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="4.10.4" CORES_SETUP="single" SOLR_CONFS="lib/eZ/Publish/Core/Search/Solr/Content/Resources/schema.xml"
 

--- a/bundle/EzPublishSolrSearchEngineBundle/DependencyInjection/Configuration.php
+++ b/bundle/EzPublishSolrSearchEngineBundle/DependencyInjection/Configuration.php
@@ -150,11 +150,10 @@ class Configuration implements ConfigurationInterface
                     )
                     ->then(
                         function ($v) {
-                            // If single endpoint is set for cluster, use it as default mapping
-                            // for both Content and Location clusters
+                            // If single endpoint is set for cluster, use it as default mapping for
+                            // Content index
                             $v['cluster'] = array(
                                 'content' => $v['cluster'],
-                                'location' => $v['cluster'],
                             );
 
                             return $v;
@@ -173,30 +172,9 @@ class Configuration implements ConfigurationInterface
                     ->then(
                         function ($v) {
                             // If single endpoint is set for Content cluster, use it as default
-                            // mapping for Content cluster
+                            // mapping for Content index
                             $v['cluster']['content'] = array(
                                 'default' => $v['cluster']['content'],
-                            );
-
-                            return $v;
-                        }
-                    )
-                ->end()
-                ->beforeNormalization()
-                    ->ifTrue(
-                        function ($v) {
-                            return (
-                                !empty($v['cluster']['location']) &&
-                                !is_array($v['cluster']['location'])
-                            );
-                        }
-                    )
-                    ->then(
-                        function ($v) {
-                            // If single endpoint is set for Location cluster, use it as default
-                            // mapping for Location cluster
-                            $v['cluster']['location'] = array(
-                                'default' => $v['cluster']['location'],
                             );
 
                             return $v;
@@ -240,43 +218,6 @@ class Configuration implements ConfigurationInterface
                         }
                     )
                 ->end()
-                ->beforeNormalization()
-                    ->ifTrue(
-                        function ($v) {
-                            return (
-                                empty($v['entry_endpoints']['location']) &&
-                                (
-                                    !empty($v['cluster']['location']['translations']) ||
-                                    !empty($v['cluster']['location']['default']) ||
-                                    !empty($v['cluster']['location']['main_translations'])
-                                )
-                            );
-                        }
-                    )
-                    ->then(
-                        // If Location search entry endpoints are not provided use
-                        // cluster endpoints
-                        function ($v) {
-                            $endpointSet = array();
-
-                            if (!empty($v['cluster']['location']['translations'])) {
-                                $endpointSet = array_flip($v['cluster']['location']['translations']);
-                            }
-
-                            if (!empty($v['cluster']['location']['default'])) {
-                                $endpointSet[$v['cluster']['location']['default']] = true;
-                            }
-
-                            if (!empty($v['cluster']['location']['main_translations'])) {
-                                $endpointSet[$v['cluster']['location']['main_translations']] = true;
-                            }
-
-                            $v['entry_endpoints']['location'] = array_keys($endpointSet);
-
-                            return $v;
-                        }
-                    )
-                ->end()
                 ->children()
                     ->arrayNode('entry_endpoints')
                         ->info('A set of entry endpoint names, per search type')
@@ -284,10 +225,6 @@ class Configuration implements ConfigurationInterface
                         ->example(
                             array(
                                 'content' => array(
-                                    'endpoint1',
-                                    'endpoint2',
-                                ),
-                                'location' => array(
                                     'endpoint1',
                                     'endpoint2',
                                 ),
@@ -308,45 +245,23 @@ class Configuration implements ConfigurationInterface
                                 ->prototype('scalar')
                                 ->end()
                             ->end()
-                            ->arrayNode('location')
-                                ->info(
-                                    "A set of entry endpoint names for the Location index.\n\n" .
-                                    'If not set, cluster endpoints will be used.'
-                                )
-                                ->example(
-                                    array(
-                                        'endpoint1',
-                                        'endpoint2',
-                                    )
-                                )
-                                ->prototype('scalar')
-                                ->end()
-                            ->end()
                         ->end()
                     ->end()
                     ->arrayNode('cluster')
                         ->info(
                             'Defines a map of translation language codes and Solr ' .
-                            "endpoint names for Content and Location indexes.\n\n" .
-                            'Optionally, you can define default and always available ' .
+                            "endpoint names for Content index.\n\n" .
+                            'Optionally, you can define default and main translations ' .
                             'endpoints. Default one will be used for a translation if it ' .
-                            'is not explicitly mapped, and always available will be used ' .
-                            "for indexing translations that are always available.\n\n" .
+                            'is not explicitly mapped, and main translations will be used ' .
+                            "for indexing translations in the main languages.\n\n" .
                             'If single endpoint name is given, it will be used as a ' .
-                            'shortcut to define the default endpoint for both indexes.'
+                            'shortcut to define the default endpoint.'
                         )
                         ->addDefaultsIfNotSet()
                         ->example(
                             array(
                                 'content' => array(
-                                    'translations' => array(
-                                        'cro-HR' => 'endpoint1',
-                                        'eng-GB' => 'endpoint2',
-                                    ),
-                                    'default' => 'endpoint3',
-                                    'main_translations' => 'endpoint4',
-                                ),
-                                'location' => array(
                                     'translations' => array(
                                         'cro-HR' => 'endpoint1',
                                         'eng-GB' => 'endpoint2',
@@ -364,7 +279,7 @@ class Configuration implements ConfigurationInterface
                                     'Optionally, you can define default and main translations ' .
                                     'endpoints. Default one will be used for a translation if it ' .
                                     'is not explicitly mapped, and main translations will be ' .
-                                    "used for indexing translations in the main language.\n\n" .
+                                    "used for indexing translations in the main languages.\n\n" .
                                     'If single endpoint name is given, it will be used as a ' .
                                     'shortcut to define the default endpoint.'
                                 )
@@ -413,68 +328,7 @@ class Configuration implements ConfigurationInterface
                                             'This setting is optional. Use it to reduce the ' .
                                             'number of Solr endpoints that the query is ' .
                                             'distributed to when using always available fallback ' .
-                                            'or searching only main languages.'
-                                        )
-                                    ->end()
-                                ->end()
-                            ->end()
-                            ->arrayNode('location')
-                                ->info(
-                                    'Defines a map of translation language codes and Solr ' .
-                                    "endpoint names for Location index.\n\n" .
-                                    'Optionally, you can define default and main translations ' .
-                                    'endpoints. Default one will be used for a translation if it ' .
-                                    'is not explicitly mapped, and main translations will be ' .
-                                    "used for indexing translations in the main language.\n\n" .
-                                    'If single endpoint name is given, it will be used as a ' .
-                                    'shortcut to define the default endpoint.'
-                                )
-                                ->addDefaultsIfNotSet()
-                                ->example(
-                                    array(
-                                        'translations' => array(
-                                            'cro-HR' => 'endpoint1',
-                                            'eng-GB' => 'endpoint2',
-                                        ),
-                                        'default' => 'endpoint3',
-                                        'main_translations' => 'endpoint4',
-                                    )
-                                )
-                                ->children()
-                                    ->arrayNode('translations')
-                                        ->normalizeKeys(false)
-                                        ->useAttributeAsKey('language_code')
-                                            ->info(
-                                                'A map of translation language codes and Solr ' .
-                                                'endpoint names for Location index.'
-                                            )
-                                            ->example(
-                                                array(
-                                                    'cro-HR' => 'endpoint1',
-                                                    'eng-GB' => 'endpoint2',
-                                                )
-                                            )
-                                        ->prototype('scalar')
-                                        ->end()
-                                    ->end()
-                                    ->scalarNode('default')
-                                        ->defaultNull()
-                                        ->info(
-                                            'Default endpoint will be used for indexing ' .
-                                            'documents of a translation that is not explicitly ' .
-                                            "mapped.\n\n" .
-                                            'This setting is optional.'
-                                        )
-                                    ->end()
-                                    ->scalarNode('main_translations')
-                                        ->defaultNull()
-                                        ->info(
-                                            'Main translations endpoint will be used to index ' .
-                                            "documents of translations in the main languages\n\n" .
-                                            'This setting is optional. Use it to reduce the ' .
-                                            'number of Solr endpoints that the query is ' .
-                                            'distributed to when using always available fallback ' .
-                                            'or searching only main languages.'
+                                            'or searching only on the main languages.'
                                         )
                                     ->end()
                                 ->end()

--- a/bundle/EzPublishSolrSearchEngineBundle/DependencyInjection/EzPublishSolrSearchEngineExtension.php
+++ b/bundle/EzPublishSolrSearchEngineBundle/DependencyInjection/EzPublishSolrSearchEngineExtension.php
@@ -27,7 +27,6 @@ class EzPublishSolrSearchEngineExtension extends Extension
     const CONTENT_ENDPOINT_RESOLVER_ID = 'ezpublish.search.solr.content.gateway.endpoint_resolver.native.content';
     const LOCATION_SEARCH_HANDLER_ID = 'ezpublish.spi.search.solr.location_handler';
     const LOCATION_SEARCH_GATEWAY_ID = 'ezpublish.search.solr.location.gateway.native';
-    const LOCATION_ENDPOINT_RESOLVER_ID = 'ezpublish.search.solr.content.gateway.endpoint_resolver.native.location';
 
     /**
      * Endpoint class.
@@ -146,18 +145,9 @@ class EzPublishSolrSearchEngineExtension extends Extension
         $container->setDefinition($contentSearchHandlerId, $contentSearchHandlerDefinition);
         $container->setParameter("$alias.connection.$connectionName.content_handler_id", $contentSearchHandlerId);
 
-        // Location endpoint resolver
-        $locationEndpointResolverId = static::LOCATION_ENDPOINT_RESOLVER_ID . ".$connectionName";
-        $locationEndpointResolverDef = new DefinitionDecorator(self::CONTENT_ENDPOINT_RESOLVER_ID);
-        $locationEndpointResolverDef->replaceArgument(0, $connectionParams['entry_endpoints']['location']);
-        $locationEndpointResolverDef->replaceArgument(1, $connectionParams['cluster']['location']['translations']);
-        $locationEndpointResolverDef->replaceArgument(2, $connectionParams['cluster']['location']['default']);
-        $locationEndpointResolverDef->replaceArgument(3, $connectionParams['cluster']['location']['main_translations']);
-        $container->setDefinition($locationEndpointResolverId, $locationEndpointResolverDef);
-
         // Location search gateway
         $locationSearchGatewayDef = new DefinitionDecorator(self::LOCATION_SEARCH_GATEWAY_ID);
-        $locationSearchGatewayDef->replaceArgument(1, new Reference($locationEndpointResolverId));
+        $locationSearchGatewayDef->replaceArgument(1, new Reference($contentEndpointResolverId));
         $locationSearchGatewayId = self::LOCATION_SEARCH_GATEWAY_ID . ".$connectionName";
         $container->setDefinition($locationSearchGatewayId, $locationSearchGatewayDef);
 

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "ezsystems/ezpublish-kernel": "~6.0@dev"
+        "ezsystems/ezpublish-kernel": "dev-EZP-24649-nested-locations"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.7",

--- a/lib/eZ/Publish/API/Repository/Tests/SetupFactory/LegacySolr.php
+++ b/lib/eZ/Publish/API/Repository/Tests/SetupFactory/LegacySolr.php
@@ -122,15 +122,10 @@ class LegacySolr extends Legacy
         $stmt->execute();
 
         $contentObjects = array();
-        $locations = array();
         while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
             $contentObjects[] = $persistenceHandler->contentHandler()->load(
                 $row['id'],
                 $row['current_version']
-            );
-            $locations = array_merge(
-                $locations,
-                $persistenceHandler->locationHandler()->loadLocationsByContent($row['id'])
             );
         }
 
@@ -138,13 +133,8 @@ class LegacySolr extends Legacy
         $contentSearchHandler = $searchHandler->contentSearchHandler();
         $contentSearchHandler->purgeIndex();
         $contentSearchHandler->setCommit(true);
-        /** @var \eZ\Publish\Core\Search\Elasticsearch\Content\Location\Handler $locationSearchHandler */
-        $locationSearchHandler = $searchHandler->locationSearchHandler();
-        $locationSearchHandler->purgeIndex();
-        $locationSearchHandler->setCommit(true);
 
         $contentSearchHandler->bulkIndexContent($contentObjects);
-        $locationSearchHandler->bulkIndexLocations($locations);
     }
 
     protected function getTestConfigurationFile()

--- a/lib/eZ/Publish/Core/Search/Solr/Content/CriterionVisitor.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Content/CriterionVisitor.php
@@ -63,8 +63,8 @@ abstract class CriterionVisitor
         $endValue = '*';
         $endBrace = ']';
 
-        $start = $this->prepareValue($start);
-        $end = $this->prepareValue($end);
+        $start = '"' . $this->escapeQuote($this->toString($start), true) . '"';
+        $end = '"' . $this->escapeQuote($this->toString($end), true) . '"';
 
         switch ($operator) {
             case Operator::GT:
@@ -98,25 +98,37 @@ abstract class CriterionVisitor
     }
 
     /**
-     * Converts given $value to the appropriate Solr representation.
-     *
-     * The value will be converted to string representation and escaped if needed.
+     * Converts given $value to the appropriate Solr string representation.
      *
      * @param mixed $value
      *
      * @return string
      */
-    protected function prepareValue($value)
+    protected function toString($value)
     {
         switch (gettype($value)) {
             case 'boolean':
                 return ($value ? 'true' : 'false');
 
-            case 'string':
-                return '"' . preg_replace('/("|\\\)/', '\\\$1', $value) . '"';
-
             default:
                 return (string)$value;
         }
+    }
+
+    /**
+     * Escapes given $string for wrapping inside single or double quotes.
+     *
+     * Does not include quotes in the returned string, this needs to be done by the consumer code.
+     *
+     * @param string $string
+     * @param bool $doubleQuote
+     *
+     * @return string
+     */
+    protected function escapeQuote($string, $doubleQuote=false)
+    {
+        $pattern = ($doubleQuote ? '/("|\\\)/' : '/(\'|\\\)/');
+
+        return preg_replace($pattern, '\\\$1', $string);
     }
 }

--- a/lib/eZ/Publish/Core/Search/Solr/Content/CriterionVisitor/CustomField/CustomFieldIn.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Content/CriterionVisitor/CustomField/CustomFieldIn.php
@@ -52,7 +52,9 @@ class CustomFieldIn extends CriterionVisitor
         $values = (array)$criterion->value;
 
         foreach ($values as $value) {
-            $queries[] = $criterion->target . ':' . $this->prepareValue($value);
+            $preparedValue = $this->escapeQuote($this->toString($value), true);
+
+            $queries[] = $criterion->target . ':"' . $preparedValue . '"';
         }
 
         return '(' . implode(' OR ', $queries) . ')';

--- a/lib/eZ/Publish/Core/Search/Solr/Content/CriterionVisitor/Field/FieldIn.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Content/CriterionVisitor/Field/FieldIn.php
@@ -63,10 +63,10 @@ class FieldIn extends Field
 
         $queries = array();
         foreach ($criterion->value as $value) {
-            $preparedValue = $this->prepareValue($value);
+            $preparedValue = $this->escapeQuote($this->toString($value), true);
 
             foreach ($fieldNames as $name) {
-                $queries[] = $name . ':' . $preparedValue;
+                $queries[] = $name . ':"' . $preparedValue . '"';
             }
         }
 

--- a/lib/eZ/Publish/Core/Search/Solr/Content/DocumentMapper.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Content/DocumentMapper.php
@@ -15,7 +15,7 @@ use eZ\Publish\SPI\Persistence\Content;
 use eZ\Publish\SPI\Persistence\Content\Location;
 
 /**
- * Mapper maps Content and Location objects to a Document object, representing a
+ * Mapper maps Content and Location objects to a Document objects, representing a
  * document in Solr index storage.
  *
  * Note that custom implementations might need to be accompanied by custom schema.
@@ -23,20 +23,44 @@ use eZ\Publish\SPI\Persistence\Content\Location;
 interface DocumentMapper
 {
     /**
-     * Maps given Content to a Document.
+     * Maps given Content and it's Locations to a collection of nested Documents,
+     * one per translation.
+     *
+     * Each Content Document contains nested Documents representing it's Locations.
      *
      * @param \eZ\Publish\SPI\Persistence\Content $content
      *
      * @return \eZ\Publish\SPI\Search\Document[]
      */
-    public function mapContent(Content $content);
+    public function mapContentBlock(Content $content);
 
     /**
-     * Maps given Location to a Document.
+     * Generates the Solr backend document ID for Content object.
      *
-     * @param \eZ\Publish\SPI\Persistence\Content\Location $location
+     * If $language code is not provided, the method will return prefix of the IDs
+     * of all Content's documents (there will be one document per translation).
+     * The above is useful when targeting all Content's documents, without
+     * the knowledge of it's translations.
      *
-     * @return \eZ\Publish\SPI\Search\Document[]
+     * @param int|string $contentId
+     * @param string $languageCode
+     *
+     * @return string
      */
-    public function mapLocation(Location $location);
+    public function generateContentDocumentId($contentId, $languageCode = null);
+
+    /**
+     * Generates the Solr backend document ID for Location object.
+     *
+     * If $language code is not provided, the method will return prefix of the IDs
+     * of all Location's documents (there will be one document per translation).
+     * The above is useful when targeting all Location's documents, without
+     * the knowledge of it's Content's translations.
+     *
+     * @param int|string $locationId
+     * @param string $languageCode
+     *
+     * @return string
+     */
+    public function generateLocationDocumentId($locationId, $languageCode = null);
 }

--- a/lib/eZ/Publish/Core/Search/Solr/Content/Gateway/CoreFilter/NativeCoreFilter.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Content/Gateway/CoreFilter/NativeCoreFilter.php
@@ -22,7 +22,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
 use eZ\Publish\Core\Search\Solr\Content\Gateway\EndpointResolver;
 
 /**
- * Native core filter handles:.
+ * Native core filter handles:
  *
  * - search type (Content and Location)
  * - prioritized languages fallback
@@ -134,7 +134,7 @@ class NativeCoreFilter extends CoreFilter
      * @param string[] $languageCodes
      * @param bool $useAlwaysAvailable
      *
-     * @return string
+     * @return \eZ\Publish\API\Repository\Values\Content\Query\Criterion
      */
     private function getCoreCriterion(array $languageCodes, $useAlwaysAvailable)
     {

--- a/lib/eZ/Publish/Core/Search/Solr/Content/Gateway/Native.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Content/Gateway/Native.php
@@ -301,6 +301,7 @@ class Native extends Gateway
     {
         // Clone to prevent mutation
         $document = clone $document;
+        $subDocuments = array();
 
         $document->id .= 'mt';
         $document->fields[] = new Field(
@@ -308,6 +309,23 @@ class Native extends Gateway
             true,
             new FieldType\BooleanField()
         );
+
+        foreach ($document->documents as $subDocument)
+        {
+            // Clone to prevent mutation
+            $subDocument = clone $subDocument;
+
+            $subDocument->id .= 'mt';
+            $subDocument->fields[] = new Field(
+                'meta_indexed_main_translation',
+                true,
+                new FieldType\BooleanField()
+            );
+
+            $subDocuments[] = $subDocument;
+        }
+
+        $document->documents = $subDocuments;
 
         return $document;
     }
@@ -446,6 +464,10 @@ class Native extends Gateway
 
         foreach ($document->fields as $field) {
             $this->writeField($xmlWriter, $field);
+        }
+
+        foreach ($document->documents as $subDocument) {
+            $this->writeDocument($xmlWriter, $subDocument);
         }
 
         $xmlWriter->endElement();

--- a/lib/eZ/Publish/Core/Search/Solr/Content/Gateway/Native.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Content/Gateway/Native.php
@@ -261,14 +261,14 @@ class Native extends Gateway
     {
         $documentMap = array();
         $mainTranslationsEndpoint = $this->endpointResolver->getMainLanguagesEndpoint();
-        $alwaysAvailableDocuments = array();
+        $mainTranslationsDocuments = array();
 
         foreach ($documents as $translationDocuments) {
             foreach ($translationDocuments as $document) {
                 $documentMap[$document->languageCode][] = $document;
 
                 if ($mainTranslationsEndpoint !== null && $document->isMainTranslation) {
-                    $alwaysAvailableDocuments[] = $this->getAlwaysAvailableDocument($document);
+                    $mainTranslationsDocuments[] = $this->getMainTranslationDocument($document);
                 }
             }
         }
@@ -282,10 +282,10 @@ class Native extends Gateway
             );
         }
 
-        if (!empty($alwaysAvailableDocuments)) {
+        if (!empty($mainTranslationsDocuments)) {
             $this->doBulkIndexDocuments(
                 $this->endpointRegistry->getEndpoint($mainTranslationsEndpoint),
-                $alwaysAvailableDocuments
+                $mainTranslationsDocuments
             );
         }
     }
@@ -297,7 +297,7 @@ class Native extends Gateway
      *
      * @return \eZ\Publish\SPI\Search\Document
      */
-    protected function getAlwaysAvailableDocument(Document $document)
+    protected function getMainTranslationDocument(Document $document)
     {
         // Clone to prevent mutation
         $document = clone $document;

--- a/lib/eZ/Publish/Core/Search/Solr/Content/Handler.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Content/Handler.php
@@ -169,7 +169,7 @@ class Handler implements SearchHandlerInterface
      */
     public function indexContent(Content $content)
     {
-        $this->gateway->bulkIndexDocuments(array($this->mapper->mapContent($content)));
+        $this->gateway->bulkIndexDocuments(array($this->mapper->mapContentBlock($content)));
     }
 
     /**
@@ -186,7 +186,7 @@ class Handler implements SearchHandlerInterface
         $documents = array();
 
         foreach ($contentObjects as $content) {
-            $documents[] = $this->mapper->mapContent($content);
+            $documents[] = $this->mapper->mapContentBlock($content);
         }
 
         if (!empty($documents)) {
@@ -202,7 +202,9 @@ class Handler implements SearchHandlerInterface
      */
     public function deleteContent($contentId, $versionId = null)
     {
-        $this->gateway->deleteByQuery("content_id:{$contentId}");
+        $idPrefix = $this->mapper->generateContentDocumentId($contentId);
+
+        $this->gateway->deleteByQuery("_root_:content{$idPrefix}*");
     }
 
     /**
@@ -213,7 +215,9 @@ class Handler implements SearchHandlerInterface
      */
     public function deleteLocation($locationId, $contentId)
     {
-        $this->gateway->deleteByQuery("content_id:{$contentId}");
+        $idPrefix = $this->mapper->generateContentDocumentId($contentId);
+
+        $this->gateway->deleteByQuery("_root_:{$idPrefix}*");
 
         // TODO it seems this part of location deletion (not last location) misses integration tests
         try {

--- a/lib/eZ/Publish/Core/Search/Solr/Content/Location/Handler.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Content/Location/Handler.php
@@ -101,29 +101,6 @@ class Handler implements SearchHandlerInterface
      */
     public function indexLocation(Location $location)
     {
-        $this->bulkIndexLocations(array($location));
-    }
-
-    /**
-     * Indexes several content objects.
-     *
-     * @todo: This function and setCommit() is needed for Persistence\Solr for test speed but not part
-     *       of interface for the reason described in Solr\Content\Search\Gateway\Native::bulkIndexContent
-     *       Short: Bulk handling should be properly designed before added to the interface.
-     *
-     * @param \eZ\Publish\SPI\Persistence\Content\Location[] $locations
-     */
-    public function bulkIndexLocations(array $locations)
-    {
-        $documents = array();
-
-        foreach ($locations as $location) {
-            $documents[] = $this->mapper->mapLocation($location);
-        }
-
-        if (!empty($documents)) {
-            $this->gateway->bulkIndexDocuments($documents);
-        }
     }
 
     /**
@@ -133,7 +110,6 @@ class Handler implements SearchHandlerInterface
      */
     public function deleteLocation($locationId)
     {
-        $this->gateway->deleteByQuery("location_id:{$locationId}");
     }
 
     /**
@@ -143,7 +119,6 @@ class Handler implements SearchHandlerInterface
      */
     public function deleteContent($contentId)
     {
-        $this->gateway->deleteByQuery("content_id_id:{$contentId}");
     }
 
     /**

--- a/lib/eZ/Publish/Core/Search/Solr/Content/Location/SortClauseVisitor/Location/Id.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Content/Location/SortClauseVisitor/Location/Id.php
@@ -40,6 +40,6 @@ class Id extends SortClauseVisitor
      */
     public function visit(SortClause $sortClause)
     {
-        return 'id' . $this->getDirection($sortClause);
+        return 'location_id' . $this->getDirection($sortClause);
     }
 }

--- a/lib/eZ/Publish/Core/Search/Solr/Content/Resources/schema.xml
+++ b/lib/eZ/Publish/Core/Search/Solr/Content/Resources/schema.xml
@@ -83,6 +83,11 @@ should not remove or drastically change the existing definitions.
     -->
     <field name="timestamp" type="date" indexed="true" stored="true" default="NOW" multiValued="false"/>
 
+    <!--
+      Points to the root document of a block of nested documents. Required for nested document support.
+    -->
+    <field name="_root_" type="string" indexed="true" stored="true" required="false"/>
+
     <field name="document_type_id" type="string" indexed="true" stored="true" required="true"/>
 
     <!--

--- a/lib/eZ/Publish/Core/settings/search_engines/solr.yml
+++ b/lib/eZ/Publish/Core/settings/search_engines/solr.yml
@@ -21,16 +21,12 @@ parameters:
     ezpublish.search.solr.content.cluster_endpoints: []
     ezpublish.search.solr.content.default_endpoint: null
     ezpublish.search.solr.content.main_translations_endpoint: null
-    ezpublish.search.solr.location.entry_endpoints: []
-    ezpublish.search.solr.location.cluster_endpoints: []
-    ezpublish.search.solr.location.default_endpoint: null
-    ezpublish.search.solr.location.main_translations_endpoint: null
 
 services:
     ezpublish.search.solr.content.gateway.endpoint_registry:
         class: %ezpublish.search.solr.content.gateway.endpoint_registry.class%
 
-    ezpublish.search.solr.content.gateway.endpoint_resolver.native.content:
+    ezpublish.search.solr.content.gateway.endpoint_resolver.native:
         class: %ezpublish.search.solr.content.gateway.endpoint_resolver.native.class%
         arguments:
             - %ezpublish.search.solr.content.entry_endpoints%
@@ -38,35 +34,16 @@ services:
             - %ezpublish.search.solr.content.default_endpoint%
             - %ezpublish.search.solr.content.main_translations_endpoint%
 
-    ezpublish.search.solr.content.gateway.endpoint_resolver.native.location:
-        class: %ezpublish.search.solr.content.gateway.endpoint_resolver.native.class%
-        arguments:
-            - %ezpublish.search.solr.location.entry_endpoints%
-            - %ezpublish.search.solr.location.cluster_endpoints%
-            - %ezpublish.search.solr.location.default_endpoint%
-            - %ezpublish.search.solr.location.main_translations_endpoint%
+    ezpublish.search.solr.content.gateway.endpoint_resolver:
+        alias: ezpublish.search.solr.content.gateway.endpoint_resolver.native
 
-    ezpublish.search.solr.content.gateway.endpoint_resolver.content:
-        alias: ezpublish.search.solr.content.gateway.endpoint_resolver.native.content
-
-    ezpublish.search.solr.content.gateway.endpoint_resolver.location:
-        alias: ezpublish.search.solr.content.gateway.endpoint_resolver.native.location
-
-    ezpublish.search.solr.content.gateway.core_filter.native.content:
+    ezpublish.search.solr.content.gateway.core_filter.native:
         class: %ezpublish.search.solr.content.gateway.core_filter.native.class%
         arguments:
-            - @ezpublish.search.solr.content.gateway.endpoint_resolver.native.content
+            - @ezpublish.search.solr.content.gateway.endpoint_resolver.native
 
-    ezpublish.search.solr.content.gateway.core_filter.native.location:
-        class: %ezpublish.search.solr.content.gateway.core_filter.native.class%
-        arguments:
-            - @ezpublish.search.solr.content.gateway.endpoint_resolver.native.location
-
-    ezpublish.search.solr.content.gateway.core_filter.content:
-        alias: ezpublish.search.solr.content.gateway.core_filter.native.content
-
-    ezpublish.search.solr.content.gateway.core_filter.location:
-        alias: ezpublish.search.solr.content.gateway.core_filter.native.location
+    ezpublish.search.solr.content.gateway.core_filter:
+        alias: ezpublish.search.solr.content.gateway.core_filter.native
 
     ezpublish.search.solr.content.document_mapper.native:
         class: %ezpublish.search.solr.content.document_mapper.native.class%
@@ -96,9 +73,9 @@ services:
         class: %ezpublish.search.solr.content.gateway.native.class%
         arguments:
             - @ezpublish.search.solr.content.gateway.client.http.stream
-            - @ezpublish.search.solr.content.gateway.endpoint_resolver.content
+            - @ezpublish.search.solr.content.gateway.endpoint_resolver
             - @ezpublish.search.solr.content.gateway.endpoint_registry
-            - @ezpublish.search.solr.content.gateway.core_filter.content
+            - @ezpublish.search.solr.content.gateway.core_filter
             - @ezpublish.search.solr.content.criterion_visitor.aggregate
             - @ezpublish.search.solr.content.sort_clause_visitor.aggregate
             - @ezpublish.search.solr.content.facet_builder_visitor.aggregate
@@ -121,9 +98,9 @@ services:
         class: %ezpublish.search.solr.content.gateway.native.class%
         arguments:
             - @ezpublish.search.solr.content.gateway.client.http.stream
-            - @ezpublish.search.solr.content.gateway.endpoint_resolver.location
+            - @ezpublish.search.solr.content.gateway.endpoint_resolver
             - @ezpublish.search.solr.content.gateway.endpoint_registry
-            - @ezpublish.search.solr.content.gateway.core_filter.location
+            - @ezpublish.search.solr.content.gateway.core_filter
             - @ezpublish.search.solr.location.criterion_visitor.aggregate
             - @ezpublish.search.solr.location.sort_clause_visitor.aggregate
             - @ezpublish.search.solr.location.facet_builder_visitor.aggregate

--- a/lib/eZ/Publish/Core/settings/tests/solr/multicore_dedicated.yml
+++ b/lib/eZ/Publish/Core/settings/tests/solr/multicore_dedicated.yml
@@ -29,15 +29,6 @@ parameters:
           ger-DE: endpoint3
     ezpublish.search.solr.content.default_endpoint: null
     ezpublish.search.solr.content.main_translations_endpoint: null
-    ezpublish.search.solr.location.entry_endpoints:
-          - endpoint0
-    ezpublish.search.solr.location.cluster_endpoints:
-          eng-GB: endpoint4
-          eng-US: endpoint5
-          por-PT: endpoint6
-          ger-DE: endpoint7
-    ezpublish.search.solr.location.default_endpoint: null
-    ezpublish.search.solr.location.main_translations_endpoint: null
 
 services:
     ezpublish.cache_pool.spi.cache.decorator:
@@ -93,51 +84,3 @@ services:
                 core: core3
         tags:
             - {name: ezpublish.search.solr.endpoint, alias: endpoint3}
-
-    ezpublish.search.solr.endpoint.endpoint4:
-        class: %ezpublish.solr.endpoint.class%
-        arguments:
-            -
-                scheme: http
-                host: localhost
-                port: 8983
-                path: /solr
-                core: core4
-        tags:
-            - {name: ezpublish.search.solr.endpoint, alias: endpoint4}
-
-    ezpublish.search.solr.endpoint.endpoint5:
-        class: %ezpublish.solr.endpoint.class%
-        arguments:
-            -
-                scheme: http
-                host: localhost
-                port: 8983
-                path: /solr
-                core: core5
-        tags:
-            - {name: ezpublish.search.solr.endpoint, alias: endpoint5}
-
-    ezpublish.search.solr.endpoint.endpoint6:
-        class: %ezpublish.solr.endpoint.class%
-        arguments:
-            -
-                scheme: http
-                host: localhost
-                port: 8983
-                path: /solr
-                core: core6
-        tags:
-            - {name: ezpublish.search.solr.endpoint, alias: endpoint6}
-
-    ezpublish.search.solr.endpoint.endpoint7:
-        class: %ezpublish.solr.endpoint.class%
-        arguments:
-            -
-                scheme: http
-                host: localhost
-                port: 8983
-                path: /solr
-                core: core7
-        tags:
-            - {name: ezpublish.search.solr.endpoint, alias: endpoint7}

--- a/lib/eZ/Publish/Core/settings/tests/solr/multicore_shared.yml
+++ b/lib/eZ/Publish/Core/settings/tests/solr/multicore_shared.yml
@@ -21,16 +21,11 @@ parameters:
     ezpublish.solr.endpoint.class: eZ\Publish\Core\Search\Solr\Content\Gateway\Endpoint
 
     ezpublish.search.solr.content.entry_endpoints:
-          - endpoint0
-    ezpublish.search.solr.content.cluster_endpoints: []
+          - endpoint1
+    ezpublish.search.solr.content.cluster_endpoints:
+          eng-GB: endpoint3
     ezpublish.search.solr.content.default_endpoint: endpoint2
     ezpublish.search.solr.content.main_translations_endpoint: endpoint0
-    ezpublish.search.solr.location.entry_endpoints:
-          - endpoint3
-    ezpublish.search.solr.location.cluster_endpoints:
-          eng-GB: endpoint4
-    ezpublish.search.solr.location.default_endpoint: endpoint1
-    ezpublish.search.solr.location.main_translations_endpoint: endpoint2
 
 services:
     ezpublish.cache_pool.spi.cache.decorator:
@@ -86,15 +81,3 @@ services:
                 core: core3
         tags:
             - {name: ezpublish.search.solr.endpoint, alias: endpoint3}
-
-    ezpublish.search.solr.endpoint.endpoint4:
-        class: %ezpublish.solr.endpoint.class%
-        arguments:
-            -
-                scheme: http
-                host: localhost
-                port: 8983
-                path: /solr
-                core: core4
-        tags:
-            - {name: ezpublish.search.solr.endpoint, alias: endpoint4}

--- a/tests/bundle/EzPublishSolrSearchEngineBundle/DependencyInjection/EzPublishSolrSearchEngineExtensionTest.php
+++ b/tests/bundle/EzPublishSolrSearchEngineBundle/DependencyInjection/EzPublishSolrSearchEngineExtensionTest.php
@@ -196,11 +196,9 @@ class EzPublishSolrSearchEngineExtensionTest extends AbstractExtensionTestCase
                         'connection1' => array(
                             'entry_endpoints' => array(
                                 'content' => array(),
-                                'location' => array(),
                             ),
                             'cluster' => array(
                                 'content' => array(),
-                                'location' => array(),
                             ),
                         ),
                     ),
@@ -229,9 +227,6 @@ class EzPublishSolrSearchEngineExtensionTest extends AbstractExtensionTestCase
                             'endpoint1',
                             'endpoint2',
                         ),
-                        'location' => array(
-                            'endpoint2',
-                        ),
                     ),
                     'cluster' => array(
                         'content' => array(
@@ -242,13 +237,6 @@ class EzPublishSolrSearchEngineExtensionTest extends AbstractExtensionTestCase
                             ),
                             'default' => 'endpoint4',
                             'main_translations' => 'endpoint5',
-                        ),
-                        'location' => array(
-                            'translations' => array(
-                                'cro-HR' => 'endpoint2',
-                            ),
-                            'default' => 'endpoint3',
-                            'main_translations' => 'endpoint4',
                         ),
                     ),
                 ),
@@ -295,37 +283,6 @@ class EzPublishSolrSearchEngineExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderHasService(
             'ezpublish.spi.search.solr.content_handler.connection1'
         );
-
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
-            'ezpublish.search.solr.content.gateway.endpoint_resolver.native.location.connection1',
-            0,
-            array(
-                'endpoint2',
-            )
-        );
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
-            'ezpublish.search.solr.content.gateway.endpoint_resolver.native.location.connection1',
-            1,
-            array(
-                'cro-HR' => 'endpoint2',
-            )
-        );
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
-            'ezpublish.search.solr.content.gateway.endpoint_resolver.native.location.connection1',
-            2,
-            'endpoint3'
-        );
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
-            'ezpublish.search.solr.content.gateway.endpoint_resolver.native.location.connection1',
-            3,
-            'endpoint4'
-        );
-        $this->assertContainerBuilderHasService(
-            'ezpublish.search.solr.location.gateway.native.connection1'
-        );
-        $this->assertContainerBuilderHasService(
-            'ezpublish.spi.search.solr.location_handler.connection1'
-        );
     }
 
     public function testConnectionEndpointDefaults()
@@ -341,13 +298,6 @@ class EzPublishSolrSearchEngineExtensionTest extends AbstractExtensionTestCase
                             ),
                             'default' => 'endpoint3',
                             'main_translations' => 'endpoint4',
-                        ),
-                        'location' => array(
-                            'translations' => array(
-                                'cro-HR' => 'endpoint5',
-                            ),
-                            'default' => 'endpoint6',
-                            'main_translations' => 'endpoint7',
                         ),
                     ),
                 ),
@@ -395,39 +345,6 @@ class EzPublishSolrSearchEngineExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderHasService(
             'ezpublish.spi.search.solr.content_handler.connection1'
         );
-
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
-            'ezpublish.search.solr.content.gateway.endpoint_resolver.native.location.connection1',
-            0,
-            array(
-                'endpoint5',
-                'endpoint6',
-                'endpoint7',
-            )
-        );
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
-            'ezpublish.search.solr.content.gateway.endpoint_resolver.native.location.connection1',
-            1,
-            array(
-                'cro-HR' => 'endpoint5',
-            )
-        );
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
-            'ezpublish.search.solr.content.gateway.endpoint_resolver.native.location.connection1',
-            2,
-            'endpoint6'
-        );
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
-            'ezpublish.search.solr.content.gateway.endpoint_resolver.native.location.connection1',
-            3,
-            'endpoint7'
-        );
-        $this->assertContainerBuilderHasService(
-            'ezpublish.search.solr.location.gateway.native.connection1'
-        );
-        $this->assertContainerBuilderHasService(
-            'ezpublish.spi.search.solr.location_handler.connection1'
-        );
     }
 
     public function testConnectionEndpointUniqueDefaults()
@@ -443,13 +360,6 @@ class EzPublishSolrSearchEngineExtensionTest extends AbstractExtensionTestCase
                             ),
                             'default' => 'endpoint2',
                             'main_translations' => 'endpoint2',
-                        ),
-                        'location' => array(
-                            'translations' => array(
-                                'cro-HR' => 'endpoint5',
-                            ),
-                            'default' => 'endpoint5',
-                            'main_translations' => 'endpoint5',
                         ),
                     ),
                 ),
@@ -494,37 +404,6 @@ class EzPublishSolrSearchEngineExtensionTest extends AbstractExtensionTestCase
         );
         $this->assertContainerBuilderHasService(
             'ezpublish.spi.search.solr.content_handler.connection1'
-        );
-
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
-            'ezpublish.search.solr.content.gateway.endpoint_resolver.native.location.connection1',
-            0,
-            array(
-                'endpoint5',
-            )
-        );
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
-            'ezpublish.search.solr.content.gateway.endpoint_resolver.native.location.connection1',
-            1,
-            array(
-                'cro-HR' => 'endpoint5',
-            )
-        );
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
-            'ezpublish.search.solr.content.gateway.endpoint_resolver.native.location.connection1',
-            2,
-            'endpoint5'
-        );
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
-            'ezpublish.search.solr.content.gateway.endpoint_resolver.native.location.connection1',
-            3,
-            'endpoint5'
-        );
-        $this->assertContainerBuilderHasService(
-            'ezpublish.search.solr.location.gateway.native.connection1'
-        );
-        $this->assertContainerBuilderHasService(
-            'ezpublish.spi.search.solr.location_handler.connection1'
         );
     }
 
@@ -573,35 +452,6 @@ class EzPublishSolrSearchEngineExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderHasService(
             'ezpublish.spi.search.solr.content_handler.connection1'
         );
-
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
-            'ezpublish.search.solr.content.gateway.endpoint_resolver.native.location.connection1',
-            0,
-            array(
-                'endpoint1',
-            )
-        );
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
-            'ezpublish.search.solr.content.gateway.endpoint_resolver.native.location.connection1',
-            1,
-            array()
-        );
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
-            'ezpublish.search.solr.content.gateway.endpoint_resolver.native.location.connection1',
-            2,
-            'endpoint1'
-        );
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
-            'ezpublish.search.solr.content.gateway.endpoint_resolver.native.location.connection1',
-            3,
-            null
-        );
-        $this->assertContainerBuilderHasService(
-            'ezpublish.search.solr.location.gateway.native.connection1'
-        );
-        $this->assertContainerBuilderHasService(
-            'ezpublish.spi.search.solr.location_handler.connection1'
-        );
     }
 
     public function testConnectionClustersDefault()
@@ -611,7 +461,6 @@ class EzPublishSolrSearchEngineExtensionTest extends AbstractExtensionTestCase
                 'connection1' => array(
                     'cluster' => array(
                         'content' => 'endpoint1',
-                        'location' => 'endpoint2',
                     ),
                 ),
             ),
@@ -651,35 +500,6 @@ class EzPublishSolrSearchEngineExtensionTest extends AbstractExtensionTestCase
         );
         $this->assertContainerBuilderHasService(
             'ezpublish.spi.search.solr.content_handler.connection1'
-        );
-
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
-            'ezpublish.search.solr.content.gateway.endpoint_resolver.native.location.connection1',
-            0,
-            array(
-                'endpoint2',
-            )
-        );
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
-            'ezpublish.search.solr.content.gateway.endpoint_resolver.native.location.connection1',
-            1,
-            array()
-        );
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
-            'ezpublish.search.solr.content.gateway.endpoint_resolver.native.location.connection1',
-            2,
-            'endpoint2'
-        );
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
-            'ezpublish.search.solr.content.gateway.endpoint_resolver.native.location.connection1',
-            3,
-            null
-        );
-        $this->assertContainerBuilderHasService(
-            'ezpublish.search.solr.location.gateway.native.connection1'
-        );
-        $this->assertContainerBuilderHasService(
-            'ezpublish.spi.search.solr.location_handler.connection1'
         );
     }
 }


### PR DESCRIPTION
This PR resolves https://jira.ez.no/browse/EZP-24649
See also: https://github.com/ezsystems/ezpublish-kernel/pull/1358

This implements indexing of Location documents as nested (block joined) documents of Content.
With that change the semantic configuration is simplified, and Location index is no longer separately configured.

### Reasoning

Currently we don't support fulltext search with Location Search. Having Locations as nested documents of Content will enables us implementation of fulltext Location search using block join, for example:

```
{!child of=document_type_id:content v='<fulltext condition>'}
```

That means we don't have to include fulltext field in the Location documents, but can refer to the one in the (parent) Content document. Avoiding that means having better relevancy calculation.

However, since it is not possible to sort and facet using block join, we still must index **all** Content fields in the Location document, same as in the Content document. These will be typically analyzed as keywords and will skew statistics in some measure.