### PR TITLE
Fix: normal document not overwritten by document block

### DIFF
--- a/bundle/EzPublishSolrSearchEngineBundle/ApiLoader/SolrEngineFactory.php
+++ b/bundle/EzPublishSolrSearchEngineBundle/ApiLoader/SolrEngineFactory.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Bundle\EzPublishSolrSearchEngineBundle\ApiLoader;
 
 use eZ\Bundle\EzPublishCoreBundle\ApiLoader\RepositoryConfigurationProvider;
@@ -52,9 +51,9 @@ class SolrEngineFactory extends ContainerAware
 
         return new $this->searchEngineClass(
             $this->container->get("ez_search_engine_solr.connection.$connection.gateway_id"),
-            $this->container->get("ezpublish.spi.persistence.content_handler"),
-            $this->container->get("ezpublish.search.solr.document_mapper"),
-            $this->container->get("ezpublish.search.solr.result_extractor"),
+            $this->container->get('ezpublish.spi.persistence.content_handler'),
+            $this->container->get('ezpublish.search.solr.document_mapper'),
+            $this->container->get('ezpublish.search.solr.result_extractor'),
             $this->container->get("ez_search_engine_solr.connection.$connection.core_filter_id")
         );
     }

--- a/bundle/EzPublishSolrSearchEngineBundle/Command/SolrCreateIndexCommand.php
+++ b/bundle/EzPublishSolrSearchEngineBundle/Command/SolrCreateIndexCommand.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Bundle\EzPublishSolrSearchEngineBundle\Command;
 
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;

--- a/bundle/EzPublishSolrSearchEngineBundle/DependencyInjection/Configuration.php
+++ b/bundle/EzPublishSolrSearchEngineBundle/DependencyInjection/Configuration.php
@@ -6,7 +6,6 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-
 namespace eZ\Bundle\EzPublishSolrSearchEngineBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;

--- a/bundle/EzPublishSolrSearchEngineBundle/DependencyInjection/EzPublishSolrSearchEngineExtension.php
+++ b/bundle/EzPublishSolrSearchEngineBundle/DependencyInjection/EzPublishSolrSearchEngineExtension.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Bundle\EzPublishSolrSearchEngineBundle\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\Definition;

--- a/bundle/EzPublishSolrSearchEngineBundle/EzPublishSolrSearchEngineBundle.php
+++ b/bundle/EzPublishSolrSearchEngineBundle/EzPublishSolrSearchEngineBundle.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Bundle\EzPublishSolrSearchEngineBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;

--- a/lib/eZ/Publish/API/Repository/Tests/SetupFactory/LegacySolr.php
+++ b/lib/eZ/Publish/API/Repository/Tests/SetupFactory/LegacySolr.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\API\Repository\Tests\SetupFactory;
 
 use eZ\Publish\Core\Base\ServiceContainer;

--- a/lib/eZ/Publish/Core/Base/Container/Compiler/Search/Solr/AggregateCriterionVisitorPass.php
+++ b/lib/eZ/Publish/Core/Base/Container/Compiler/Search/Solr/AggregateCriterionVisitorPass.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Base\Container\Compiler\Search\Solr;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;

--- a/lib/eZ/Publish/Core/Base/Container/Compiler/Search/Solr/AggregateFacetBuilderVisitorPass.php
+++ b/lib/eZ/Publish/Core/Base/Container/Compiler/Search/Solr/AggregateFacetBuilderVisitorPass.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Base\Container\Compiler\Search\Solr;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;

--- a/lib/eZ/Publish/Core/Base/Container/Compiler/Search/Solr/AggregateFieldValueMapperPass.php
+++ b/lib/eZ/Publish/Core/Base/Container/Compiler/Search/Solr/AggregateFieldValueMapperPass.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Base\Container\Compiler\Search\Solr;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;

--- a/lib/eZ/Publish/Core/Base/Container/Compiler/Search/Solr/AggregateSortClauseVisitorPass.php
+++ b/lib/eZ/Publish/Core/Base/Container/Compiler/Search/Solr/AggregateSortClauseVisitorPass.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Base\Container\Compiler\Search\Solr;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;

--- a/lib/eZ/Publish/Core/Base/Container/Compiler/Search/Solr/EndpointRegistryPass.php
+++ b/lib/eZ/Publish/Core/Base/Container/Compiler/Search/Solr/EndpointRegistryPass.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Base\Container\Compiler\Search\Solr;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;

--- a/lib/eZ/Publish/Core/Search/Solr/CoreFilter.php
+++ b/lib/eZ/Publish/Core/Search/Solr/CoreFilter.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr;
 
 use eZ\Publish\API\Repository\Values\Content\Query;

--- a/lib/eZ/Publish/Core/Search/Solr/CoreFilter/NativeCoreFilter.php
+++ b/lib/eZ/Publish/Core/Search/Solr/CoreFilter/NativeCoreFilter.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\CoreFilter;
 
 use eZ\Publish\Core\Search\Solr\CoreFilter;
@@ -21,7 +20,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
 use eZ\Publish\Core\Search\Solr\Gateway\EndpointResolver;
 
 /**
- * Native core filter handles:
+ * Native core filter handles:.
  *
  * - search type (Content and Location)
  * - prioritized languages fallback

--- a/lib/eZ/Publish/Core/Search/Solr/DocumentMapper.php
+++ b/lib/eZ/Publish/Core/Search/Solr/DocumentMapper.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr;
 
 use eZ\Publish\SPI\Persistence\Content;
@@ -23,14 +22,14 @@ use eZ\Publish\SPI\Persistence\Content\Location;
 interface DocumentMapper
 {
     /**
-     * Identifier of Content documents
+     * Identifier of Content documents.
      *
      * @var string
      */
     const DOCUMENT_TYPE_IDENTIFIER_CONTENT = 'content';
 
     /**
-     * Identifier of Location documents
+     * Identifier of Location documents.
      *
      * @var string
      */

--- a/lib/eZ/Publish/Core/Search/Solr/DocumentMapper/NativeDocumentMapper.php
+++ b/lib/eZ/Publish/Core/Search/Solr/DocumentMapper/NativeDocumentMapper.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\DocumentMapper;
 
 use eZ\Publish\Core\Search\Solr\DocumentMapper;
@@ -358,7 +357,7 @@ class NativeDocumentMapper implements DocumentMapper
             foreach ($locations as $location) {
                 $translationLocationDocuments[] = new Document(
                     array(
-                        "id" => $this->generateLocationDocumentId($location->id, $languageCode),
+                        'id' => $this->generateLocationDocumentId($location->id, $languageCode),
                         'fields' => array_merge(
                             $locationFields[$location->id],
                             isset($translationFields['regular']) ? $translationFields['regular'] : array(),

--- a/lib/eZ/Publish/Core/Search/Solr/FieldValueMapper.php
+++ b/lib/eZ/Publish/Core/Search/Solr/FieldValueMapper.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr;
 
 use eZ\Publish\SPI\Search\Field;

--- a/lib/eZ/Publish/Core/Search/Solr/FieldValueMapper/Aggregate.php
+++ b/lib/eZ/Publish/Core/Search/Solr/FieldValueMapper/Aggregate.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\FieldValueMapper;
 
 use eZ\Publish\Core\Search\Solr\FieldValueMapper;

--- a/lib/eZ/Publish/Core/Search/Solr/FieldValueMapper/BooleanMapper.php
+++ b/lib/eZ/Publish/Core/Search/Solr/FieldValueMapper/BooleanMapper.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\FieldValueMapper;
 
 use eZ\Publish\Core\Search\Solr\FieldValueMapper;

--- a/lib/eZ/Publish/Core/Search/Solr/FieldValueMapper/DateMapper.php
+++ b/lib/eZ/Publish/Core/Search/Solr/FieldValueMapper/DateMapper.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\FieldValueMapper;
 
 use eZ\Publish\Core\Search\Solr\FieldValueMapper;

--- a/lib/eZ/Publish/Core/Search/Solr/FieldValueMapper/FloatMapper.php
+++ b/lib/eZ/Publish/Core/Search/Solr/FieldValueMapper/FloatMapper.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\FieldValueMapper;
 
 use eZ\Publish\Core\Search\Solr\FieldValueMapper;

--- a/lib/eZ/Publish/Core/Search/Solr/FieldValueMapper/GeoLocationMapper.php
+++ b/lib/eZ/Publish/Core/Search/Solr/FieldValueMapper/GeoLocationMapper.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\FieldValueMapper;
 
 use eZ\Publish\Core\Search\Solr\FieldValueMapper;

--- a/lib/eZ/Publish/Core/Search/Solr/FieldValueMapper/IdentifierMapper.php
+++ b/lib/eZ/Publish/Core/Search/Solr/FieldValueMapper/IdentifierMapper.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\FieldValueMapper;
 
 use eZ\Publish\Core\Search\Solr\FieldValueMapper;

--- a/lib/eZ/Publish/Core/Search/Solr/FieldValueMapper/IntegerMapper.php
+++ b/lib/eZ/Publish/Core/Search/Solr/FieldValueMapper/IntegerMapper.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\FieldValueMapper;
 
 use eZ\Publish\Core\Search\Solr\FieldValueMapper;

--- a/lib/eZ/Publish/Core/Search/Solr/FieldValueMapper/MultipleBooleanMapper.php
+++ b/lib/eZ/Publish/Core/Search/Solr/FieldValueMapper/MultipleBooleanMapper.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\FieldValueMapper;
 
 use eZ\Publish\Core\Search\Solr\FieldValueMapper;

--- a/lib/eZ/Publish/Core/Search/Solr/FieldValueMapper/MultipleIdentifierMapper.php
+++ b/lib/eZ/Publish/Core/Search/Solr/FieldValueMapper/MultipleIdentifierMapper.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\FieldValueMapper;
 
 use eZ\Publish\SPI\Search\Field;

--- a/lib/eZ/Publish/Core/Search/Solr/FieldValueMapper/MultipleIntegerMapper.php
+++ b/lib/eZ/Publish/Core/Search/Solr/FieldValueMapper/MultipleIntegerMapper.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\FieldValueMapper;
 
 use eZ\Publish\SPI\Search\Field;

--- a/lib/eZ/Publish/Core/Search/Solr/FieldValueMapper/MultipleStringMapper.php
+++ b/lib/eZ/Publish/Core/Search/Solr/FieldValueMapper/MultipleStringMapper.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\FieldValueMapper;
 
 use eZ\Publish\SPI\Search\Field;

--- a/lib/eZ/Publish/Core/Search/Solr/FieldValueMapper/PriceMapper.php
+++ b/lib/eZ/Publish/Core/Search/Solr/FieldValueMapper/PriceMapper.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\FieldValueMapper;
 
 use eZ\Publish\Core\Search\Solr\FieldValueMapper;

--- a/lib/eZ/Publish/Core/Search/Solr/FieldValueMapper/StringMapper.php
+++ b/lib/eZ/Publish/Core/Search/Solr/FieldValueMapper/StringMapper.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\FieldValueMapper;
 
 use eZ\Publish\Core\Search\Solr\FieldValueMapper;

--- a/lib/eZ/Publish/Core/Search/Solr/Gateway.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Gateway.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr;
 
 use eZ\Publish\API\Repository\Values\Content\Query;

--- a/lib/eZ/Publish/Core/Search/Solr/Gateway/Endpoint.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Gateway/Endpoint.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Gateway;
 
 use eZ\Publish\SPI\Persistence\ValueObject;

--- a/lib/eZ/Publish/Core/Search/Solr/Gateway/EndpointRegistry.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Gateway/EndpointRegistry.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Gateway;
 
 use OutOfBoundsException;

--- a/lib/eZ/Publish/Core/Search/Solr/Gateway/EndpointResolver.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Gateway/EndpointResolver.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Gateway;
 
 /**

--- a/lib/eZ/Publish/Core/Search/Solr/Gateway/EndpointResolver/NativeEndpointResolver.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Gateway/EndpointResolver/NativeEndpointResolver.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Gateway\EndpointResolver;
 
 use eZ\Publish\Core\Search\Solr\Gateway\EndpointResolver;

--- a/lib/eZ/Publish/Core/Search/Solr/Gateway/HttpClient.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Gateway/HttpClient.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Gateway;
 
 /**

--- a/lib/eZ/Publish/Core/Search/Solr/Gateway/HttpClient/ConnectionException.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Gateway/HttpClient/ConnectionException.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Gateway\HttpClient;
 
 use RuntimeException;

--- a/lib/eZ/Publish/Core/Search/Solr/Gateway/HttpClient/Stream.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Gateway/HttpClient/Stream.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Gateway\HttpClient;
 
 use eZ\Publish\Core\Search\Solr\Gateway\HttpClient;

--- a/lib/eZ/Publish/Core/Search/Solr/Gateway/Message.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Gateway/Message.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Gateway;
 
 /**

--- a/lib/eZ/Publish/Core/Search/Solr/Gateway/Native.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Gateway/Native.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Gateway;
 
 use eZ\Publish\Core\Search\Solr\Gateway;
@@ -282,8 +281,7 @@ class Native extends Gateway
             new FieldType\BooleanField()
         );
 
-        foreach ($document->documents as $subDocument)
-        {
+        foreach ($document->documents as $subDocument) {
             // Clone to prevent mutation
             $subDocument = clone $subDocument;
 

--- a/lib/eZ/Publish/Core/Search/Solr/Handler.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Handler.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr;
 
 use eZ\Publish\SPI\Persistence\Content;
@@ -166,9 +165,9 @@ class Handler implements SearchHandlerInterface
         );
 
         if (!$result->totalCount) {
-            throw new NotFoundException('Content', "findSingle() found no content for given \$filter");
+            throw new NotFoundException('Content', 'findSingle() found no content for given $filter');
         } elseif ($result->totalCount > 1) {
-            throw new InvalidArgumentException('totalCount', "findSingle() found more then one item for given \$filter");
+            throw new InvalidArgumentException('totalCount', 'findSingle() found more then one item for given $filter');
         }
 
         $first = reset($result->searchHits);

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Common/CriterionVisitor/Aggregate.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Common/CriterionVisitor/Aggregate.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Common\CriterionVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\CriterionVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Common/CriterionVisitor/LogicalAnd.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Common/CriterionVisitor/LogicalAnd.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Common\CriterionVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\CriterionVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Common/CriterionVisitor/LogicalNot.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Common/CriterionVisitor/LogicalNot.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Common\CriterionVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\CriterionVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Common/CriterionVisitor/LogicalOr.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Common/CriterionVisitor/LogicalOr.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Common\CriterionVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\CriterionVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Common/CriterionVisitor/MatchAll.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Common/CriterionVisitor/MatchAll.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Common\CriterionVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\CriterionVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Common/CriterionVisitor/MatchNone.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Common/CriterionVisitor/MatchNone.php
@@ -6,7 +6,6 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Common\CriterionVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\CriterionVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Common/FacetBuilderVisitor/Aggregate.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Common/FacetBuilderVisitor/Aggregate.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Common\FacetBuilderVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\FacetBuilderVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Common/QueryConverter/NativeQueryConverter.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Common/QueryConverter/NativeQueryConverter.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Common\QueryConverter;
 
 use eZ\Publish\API\Repository\Values\Content\Query;
@@ -54,8 +53,7 @@ class NativeQueryConverter extends QueryConverter
         CriterionVisitor $criterionVisitor,
         SortClauseVisitor $sortClauseVisitor,
         FacetBuilderVisitor $facetBuilderVisitor
-    )
-    {
+    ) {
         $this->criterionVisitor = $criterionVisitor;
         $this->sortClauseVisitor = $sortClauseVisitor;
         $this->facetBuilderVisitor = $facetBuilderVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Common/SortClauseVisitor/Aggregate.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Common/SortClauseVisitor/Aggregate.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Common\SortClauseVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\SortClauseVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/ContentIdIn.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/ContentIdIn.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Content\CriterionVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\CriterionVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/ContentTypeGroupIdIn.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/ContentTypeGroupIdIn.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Content\CriterionVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\CriterionVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/ContentTypeIdIn.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/ContentTypeIdIn.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Content\CriterionVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\CriterionVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/ContentTypeIdentifierIn.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/ContentTypeIdentifierIn.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Content\CriterionVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\CriterionVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/CustomField/CustomFieldIn.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/CustomField/CustomFieldIn.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Content\CriterionVisitor\CustomField;
 
 use eZ\Publish\Core\Search\Solr\Query\CriterionVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/CustomField/CustomFieldRange.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/CustomField/CustomFieldRange.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Content\CriterionVisitor\CustomField;
 
 use eZ\Publish\Core\Search\Solr\Query\CriterionVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/DateMetadata.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/DateMetadata.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Content\CriterionVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\CriterionVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/DateMetadata/ModifiedBetween.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/DateMetadata/ModifiedBetween.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Content\CriterionVisitor\DateMetadata;
 
 use eZ\Publish\Core\Search\Solr\Query\Content\CriterionVisitor\DateMetadata;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/DateMetadata/ModifiedIn.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/DateMetadata/ModifiedIn.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Content\CriterionVisitor\DateMetadata;
 
 use eZ\Publish\Core\Search\Solr\Query\Content\CriterionVisitor\DateMetadata;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/DateMetadata/PublishedBetween.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/DateMetadata/PublishedBetween.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Content\CriterionVisitor\DateMetadata;
 
 use eZ\Publish\Core\Search\Solr\Query\Content\CriterionVisitor\DateMetadata;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/DateMetadata/PublishedIn.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/DateMetadata/PublishedIn.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Content\CriterionVisitor\DateMetadata;
 
 use eZ\Publish\Core\Search\Solr\Query\Content\CriterionVisitor\DateMetadata;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/DepthBetween.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/DepthBetween.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Content\CriterionVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\CriterionVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/DepthIn.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/DepthIn.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Content\CriterionVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\CriterionVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/Field.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/Field.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Content\CriterionVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\CriterionVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/Field/FieldIn.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/Field/FieldIn.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Content\CriterionVisitor\Field;
 
 use eZ\Publish\Core\Search\Solr\Query\CriterionVisitor;
@@ -54,7 +53,7 @@ class FieldIn extends Field
 
         if (empty($fieldNames)) {
             throw new InvalidArgumentException(
-                "\$criterion->target",
+                '$criterion->target',
                 "No searchable fields found for the given criterion target '{$criterion->target}'."
             );
         }

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/Field/FieldRange.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/Field/FieldRange.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Content\CriterionVisitor\Field;
 
 use eZ\Publish\Core\Search\Solr\Query\CriterionVisitor;
@@ -66,7 +65,7 @@ class FieldRange extends Field
 
         if (empty($fieldNames)) {
             throw new InvalidArgumentException(
-                "\$criterion->target",
+                '$criterion->target',
                 "No searchable fields found for the given criterion target '{$criterion->target}'."
             );
         }

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/FullText.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/FullText.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Content\CriterionVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\CriterionVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/LanguageCodeIn.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/LanguageCodeIn.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Content\CriterionVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\CriterionVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/LocationIdIn.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/LocationIdIn.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Content\CriterionVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\CriterionVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/LocationRemoteIdIn.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/LocationRemoteIdIn.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Content\CriterionVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\CriterionVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/MapLocation.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/MapLocation.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Content\CriterionVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\CriterionVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/MapLocation/MapLocationDistanceIn.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/MapLocation/MapLocationDistanceIn.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Content\CriterionVisitor\MapLocation;
 
 use eZ\Publish\Core\Search\Solr\Query\Content\CriterionVisitor\MapLocation;
@@ -62,7 +61,7 @@ class MapLocationDistanceIn extends MapLocation
 
         if (empty($fieldNames)) {
             throw new InvalidArgumentException(
-                "\$criterion->target",
+                '$criterion->target',
                 "No searchable fields found for the given criterion target '{$criterion->target}'."
             );
         }

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/MapLocation/MapLocationDistanceRange.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/MapLocation/MapLocationDistanceRange.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Content\CriterionVisitor\MapLocation;
 
 use eZ\Publish\Core\Search\Solr\Query\Content\CriterionVisitor\MapLocation;
@@ -72,7 +71,7 @@ class MapLocationDistanceRange extends MapLocation
 
         if (empty($fieldNames)) {
             throw new InvalidArgumentException(
-                "\$criterion->target",
+                '$criterion->target',
                 "No searchable fields found for the given criterion target '{$criterion->target}'."
             );
         }

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/ObjectStateIdIn.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/ObjectStateIdIn.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Content\CriterionVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\CriterionVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/ParentLocationIdIn.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/ParentLocationIdIn.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Content\CriterionVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\CriterionVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/RemoteIdIn.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/RemoteIdIn.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Content\CriterionVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\CriterionVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/SectionIn.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/SectionIn.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Content\CriterionVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\CriterionVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/SubtreeIn.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/SubtreeIn.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Content\CriterionVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\CriterionVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/UserMetadataIn.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/UserMetadataIn.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Content\CriterionVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\CriterionVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/Visibility.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/Visibility.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Content\CriterionVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\CriterionVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Content/FacetBuilderVisitor/ContentType.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Content/FacetBuilderVisitor/ContentType.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Content\FacetBuilderVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\FacetBuilderVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Content/FacetBuilderVisitor/Section.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Content/FacetBuilderVisitor/Section.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Content\FacetBuilderVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\FacetBuilderVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Content/FacetBuilderVisitor/User.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Content/FacetBuilderVisitor/User.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Content\FacetBuilderVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\FacetBuilderVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Content/SortClauseVisitor/ContentId.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Content/SortClauseVisitor/ContentId.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Content\SortClauseVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\SortClauseVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Content/SortClauseVisitor/ContentName.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Content/SortClauseVisitor/ContentName.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Content\SortClauseVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\SortClauseVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Content/SortClauseVisitor/DateModified.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Content/SortClauseVisitor/DateModified.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Content\SortClauseVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\SortClauseVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Content/SortClauseVisitor/DatePublished.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Content/SortClauseVisitor/DatePublished.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Content\SortClauseVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\SortClauseVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Content/SortClauseVisitor/Field.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Content/SortClauseVisitor/Field.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Content\SortClauseVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\SortClauseVisitor;
@@ -93,7 +92,7 @@ class Field extends SortClauseVisitor
 
         if ($fieldName === null) {
             throw new InvalidArgumentException(
-                "\$sortClause->targetData",
+                '$sortClause->targetData',
                 'No searchable fields found for the given sort clause target ' .
                 "'{$target->fieldIdentifier}' on '{$target->typeIdentifier}'."
             );

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Content/SortClauseVisitor/LocationDepth.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Content/SortClauseVisitor/LocationDepth.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Content\SortClauseVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\SortClauseVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Content/SortClauseVisitor/LocationPathString.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Content/SortClauseVisitor/LocationPathString.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Content\SortClauseVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\SortClauseVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Content/SortClauseVisitor/LocationPriority.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Content/SortClauseVisitor/LocationPriority.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Content\SortClauseVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\SortClauseVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Content/SortClauseVisitor/MapLocationDistance.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Content/SortClauseVisitor/MapLocationDistance.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Content\SortClauseVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\SortClauseVisitor;
@@ -105,7 +104,7 @@ class MapLocationDistance extends SortClauseVisitor
 
         if ($fieldName === null) {
             throw new InvalidArgumentException(
-                "\$sortClause->targetData",
+                '$sortClause->targetData',
                 'No searchable fields found for the given sort clause target ' .
                 "'{$target->fieldIdentifier}' on '{$target->typeIdentifier}'."
             );

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Content/SortClauseVisitor/SectionIdentifier.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Content/SortClauseVisitor/SectionIdentifier.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Content\SortClauseVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\SortClauseVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Content/SortClauseVisitor/SectionName.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Content/SortClauseVisitor/SectionName.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Content\SortClauseVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\SortClauseVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/CriterionVisitor.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/CriterionVisitor.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
@@ -125,7 +124,7 @@ abstract class CriterionVisitor
      *
      * @return string
      */
-    protected function escapeQuote($string, $doubleQuote=false)
+    protected function escapeQuote($string, $doubleQuote = false)
     {
         $pattern = ($doubleQuote ? '/("|\\\)/' : '/(\'|\\\)/');
 

--- a/lib/eZ/Publish/Core/Search/Solr/Query/FacetBuilderVisitor.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/FacetBuilderVisitor.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query;
 
 use eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/ContentIdIn.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/ContentIdIn.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Location\CriterionVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\CriterionVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/ContentTypeGroupIdIn.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/ContentTypeGroupIdIn.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Location\CriterionVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\CriterionVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/ContentTypeIdIn.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/ContentTypeIdIn.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Location\CriterionVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\CriterionVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/ContentTypeIdentifierIn.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/ContentTypeIdentifierIn.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Location\CriterionVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\CriterionVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/CustomField/CustomFieldIn.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/CustomField/CustomFieldIn.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Location\CriterionVisitor\CustomField;
 
 use eZ\Publish\Core\Search\Solr\Query\Content\CriterionVisitor\CustomField\CustomFieldIn as ContentCustomFieldIn;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/CustomField/CustomFieldRange.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/CustomField/CustomFieldRange.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Location\CriterionVisitor\CustomField;
 
 use eZ\Publish\Core\Search\Solr\Query\Content\CriterionVisitor\CustomField\CustomFieldRange as ContentCustomFieldRange;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/DateMetadata/ModifiedBetween.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/DateMetadata/ModifiedBetween.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Location\CriterionVisitor\DateMetadata;
 
 use eZ\Publish\Core\Search\Solr\Query\Content\CriterionVisitor\DateMetadata;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/DateMetadata/ModifiedIn.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/DateMetadata/ModifiedIn.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Location\CriterionVisitor\DateMetadata;
 
 use eZ\Publish\Core\Search\Solr\Query\Content\CriterionVisitor\DateMetadata;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/DateMetadata/PublishedBetween.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/DateMetadata/PublishedBetween.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Location\CriterionVisitor\DateMetadata;
 
 use eZ\Publish\Core\Search\Solr\Query\Content\CriterionVisitor\DateMetadata;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/DateMetadata/PublishedIn.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/DateMetadata/PublishedIn.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Location\CriterionVisitor\DateMetadata;
 
 use eZ\Publish\Core\Search\Solr\Query\Content\CriterionVisitor\DateMetadata;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/Field/FieldIn.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/Field/FieldIn.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Location\CriterionVisitor\Field;
 
 use eZ\Publish\Core\Search\Solr\Query\Content\CriterionVisitor\Field\FieldIn as ContentFieldIn;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/Field/FieldRange.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/Field/FieldRange.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Location\CriterionVisitor\Field;
 
 use eZ\Publish\Core\Search\Solr\Query\Content\CriterionVisitor\Field\FieldRange as ContentFieldRange;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/Field/MapLocationDistanceRange.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/Field/MapLocationDistanceRange.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Location\CriterionVisitor\Field;
 
 use eZ\Publish\Core\Search\Solr\Query\Content\CriterionVisitor\MapLocation\MapLocationDistanceRange as ContentMapLocationDistanceRange;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/FullText.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/FullText.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Location\CriterionVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\Content\CriterionVisitor\FullText as ContentFullText;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/LanguageCodeIn.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/LanguageCodeIn.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Location\CriterionVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\CriterionVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/Location/DepthBetween.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/Location/DepthBetween.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Location\CriterionVisitor\Location;
 
 use eZ\Publish\Core\Search\Solr\Query\CriterionVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/Location/DepthIn.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/Location/DepthIn.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Location\CriterionVisitor\Location;
 
 use eZ\Publish\Core\Search\Solr\Query\CriterionVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/Location/IsMainLocation.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/Location/IsMainLocation.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Location\CriterionVisitor\Location;
 
 use eZ\Publish\Core\Search\Solr\Query\CriterionVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/Location/PriorityBetween.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/Location/PriorityBetween.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Location\CriterionVisitor\Location;
 
 use eZ\Publish\Core\Search\Solr\Query\CriterionVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/Location/PriorityIn.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/Location/PriorityIn.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Location\CriterionVisitor\Location;
 
 use eZ\Publish\Core\Search\Solr\Query\CriterionVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/LocationIdIn.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/LocationIdIn.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Location\CriterionVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\CriterionVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/LocationRemoteIdIn.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/LocationRemoteIdIn.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Location\CriterionVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\CriterionVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/ObjectStateIdIn.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/ObjectStateIdIn.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Location\CriterionVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\CriterionVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/ParentLocationIdIn.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/ParentLocationIdIn.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Location\CriterionVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\CriterionVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/RemoteIdIn.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/RemoteIdIn.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Location\CriterionVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\CriterionVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/SectionIn.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/SectionIn.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Location\CriterionVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\CriterionVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/SubtreeIn.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/SubtreeIn.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Location\CriterionVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\CriterionVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/UserMetadataIn.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/UserMetadataIn.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Location\CriterionVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\CriterionVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/Visibility.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/Visibility.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Location\CriterionVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\CriterionVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Location/SortClauseVisitor/ContentId.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Location/SortClauseVisitor/ContentId.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Location\SortClauseVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\SortClauseVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Location/SortClauseVisitor/ContentName.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Location/SortClauseVisitor/ContentName.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Location\SortClauseVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\SortClauseVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Location/SortClauseVisitor/DateModified.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Location/SortClauseVisitor/DateModified.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Location\SortClauseVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\SortClauseVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Location/SortClauseVisitor/DatePublished.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Location/SortClauseVisitor/DatePublished.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Location\SortClauseVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\SortClauseVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Location/SortClauseVisitor/Field.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Location/SortClauseVisitor/Field.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Location\SortClauseVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\Content\SortClauseVisitor\Field as ContentField;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Location/SortClauseVisitor/Location/Depth.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Location/SortClauseVisitor/Location/Depth.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Location\SortClauseVisitor\Location;
 
 use eZ\Publish\Core\Search\Solr\Query\SortClauseVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Location/SortClauseVisitor/Location/Id.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Location/SortClauseVisitor/Location/Id.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Location\SortClauseVisitor\Location;
 
 use eZ\Publish\Core\Search\Solr\Query\SortClauseVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Location/SortClauseVisitor/Location/IsMainLocation.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Location/SortClauseVisitor/Location/IsMainLocation.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Location\SortClauseVisitor\Location;
 
 use eZ\Publish\Core\Search\Solr\Query\SortClauseVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Location/SortClauseVisitor/Location/Path.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Location/SortClauseVisitor/Location/Path.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Location\SortClauseVisitor\Location;
 
 use eZ\Publish\Core\Search\Solr\Query\SortClauseVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Location/SortClauseVisitor/Location/Priority.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Location/SortClauseVisitor/Location/Priority.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Location\SortClauseVisitor\Location;
 
 use eZ\Publish\Core\Search\Solr\Query\SortClauseVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Location/SortClauseVisitor/Location/Visibility.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Location/SortClauseVisitor/Location/Visibility.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Location\SortClauseVisitor\Location;
 
 use eZ\Publish\Core\Search\Solr\Query\SortClauseVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Location/SortClauseVisitor/MapLocationDistance.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Location/SortClauseVisitor/MapLocationDistance.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Location\SortClauseVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\Content\SortClauseVisitor\MapLocationDistance as ContentMapLocationDistance;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Location/SortClauseVisitor/SectionIdentifier.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Location/SortClauseVisitor/SectionIdentifier.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Location\SortClauseVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\SortClauseVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Location/SortClauseVisitor/SectionName.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Location/SortClauseVisitor/SectionName.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query\Location\SortClauseVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\SortClauseVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/QueryConverter.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/QueryConverter.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query;
 
 use eZ\Publish\API\Repository\Values\Content\Query;

--- a/lib/eZ/Publish/Core/Search/Solr/Query/SortClauseVisitor.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/SortClauseVisitor.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\Query;
 
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause;

--- a/lib/eZ/Publish/Core/Search/Solr/ResultExtractor.php
+++ b/lib/eZ/Publish/Core/Search/Solr/ResultExtractor.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr;
 
 use eZ\Publish\Core\Search\Solr\Query\FacetBuilderVisitor;

--- a/lib/eZ/Publish/Core/Search/Solr/ResultExtractor/LoadingResultExtractor.php
+++ b/lib/eZ/Publish/Core/Search/Solr/ResultExtractor/LoadingResultExtractor.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\Search\Solr\ResultExtractor;
 
 use eZ\Publish\Core\Search\Solr\ResultExtractor;

--- a/tests/bundle/EzPublishSolrSearchEngineBundle/DependencyInjection/EzPublishSolrSearchEngineExtensionTest.php
+++ b/tests/bundle/EzPublishSolrSearchEngineBundle/DependencyInjection/EzPublishSolrSearchEngineExtensionTest.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Bundle\EzPublishSolrSearchEngineBundle\Tests\DependencyInjection;
 
 use eZ\Bundle\EzPublishSolrSearchEngineBundle\DependencyInjection\EzPublishSolrSearchEngineExtension;

--- a/tests/lib/Container/Compiler/AggregateCriterionVisitorPassTest.php
+++ b/tests/lib/Container/Compiler/AggregateCriterionVisitorPassTest.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\SolrSearchEngine\Tests\Container\Compiler;
 
 use eZ\Publish\Core\Base\Container\Compiler\Search\Solr\AggregateCriterionVisitorPass;

--- a/tests/lib/Container/Compiler/AggregateFacetBuilderVisitorPassTest.php
+++ b/tests/lib/Container/Compiler/AggregateFacetBuilderVisitorPassTest.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\SolrSearchEngine\Tests\Container\Compiler;
 
 use eZ\Publish\Core\Base\Container\Compiler\Search\Solr\AggregateFacetBuilderVisitorPass;

--- a/tests/lib/Container/Compiler/AggregateFieldValueMapperPassTest.php
+++ b/tests/lib/Container/Compiler/AggregateFieldValueMapperPassTest.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\SolrSearchEngine\Tests\Container\Compiler;
 
 use eZ\Publish\Core\Base\Container\Compiler\Search\Solr\AggregateFieldValueMapperPass;

--- a/tests/lib/Container/Compiler/AggregateSortClauseVisitorPassTest.php
+++ b/tests/lib/Container/Compiler/AggregateSortClauseVisitorPassTest.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\SolrSearchEngine\Tests\Container\Compiler;
 
 use eZ\Publish\Core\Base\Container\Compiler\Search\Solr\AggregateSortClauseVisitorPass;

--- a/tests/lib/Search/Content/CriterionVisitor/FullTextTest.php
+++ b/tests/lib/Search/Content/CriterionVisitor/FullTextTest.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\SolrSearchEngine\Tests\Search\Content\CriterionVisitor;
 
 use eZ\SolrSearchEngine\Tests\Search\TestCase;

--- a/tests/lib/Search/Content/Gateway/EndpointResolver/NativeEndpointResolverTest.php
+++ b/tests/lib/Search/Content/Gateway/EndpointResolver/NativeEndpointResolverTest.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\SolrSearchEngine\Tests\Search\Content\Gateway\EndpointResolver;
 
 use eZ\Publish\Core\Search\Solr\Gateway\EndpointResolver\NativeEndpointResolver;

--- a/tests/lib/Search/TestCase.php
+++ b/tests/lib/Search/TestCase.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\SolrSearchEngine\Tests\Search;
 
 /**


### PR DESCRIPTION
This fixes a situation where Content document block does not overwrite the existing Content document that is not a block, and vice-versa. The block is a set of nested (block-joined) documents, in our case Content document with one or more nested Location documents.

The problem occurs when Content is first indexed without Locations, and Locations are later added.
In that case Content will first be indexed as a normal (not block-joined) single document, and when Locations are added it will be indexed again, this time as a document block containing Location and Content documents. In this case Solr will use `_root_` field to enforce uniqueness, which means we'll end up with two documents with the same ID. One standalone for Content without Locations (first indexed), and another one inside a document block (indexed later, with Locations).

Reverse situation is also a problem, that is when existing Locations are removed from Content.

The problem is also described here:

* http://grokbase.com/t/lucene/solr-user/14chqr73nv/converting-to-parent-child-block-indexing
* https://issues.apache.org/jira/browse/SOLR-5211

The problem is fixed by enforcing a document block in all cases. This is done by indexing a dummy nested document when Content does not have Locations.

The alternative is sending DELETE request before a document (block) is indexed, in all cases.