### PR TITLE
EZP-24704: Solr: Implement native result extractor

### DIFF
--- a/lib/eZ/Publish/Core/Search/Solr/DocumentMapper/NativeDocumentMapper.php
+++ b/lib/eZ/Publish/Core/Search/Solr/DocumentMapper/NativeDocumentMapper.php
@@ -169,9 +169,9 @@ class NativeDocumentMapper implements DocumentMapper
                 new FieldType\IdentifierField()
             ),
             new Field(
-                'version',
+                'version_no',
                 $content->versionInfo->versionNo,
-                new FieldType\IdentifierField()
+                new FieldType\IntegerField()
             ),
             new Field(
                 'status',
@@ -573,9 +573,9 @@ class NativeDocumentMapper implements DocumentMapper
             new FieldType\IdentifierField()
         );
         $fields[] = new Field(
-            'content_version',
+            'content_version_no',
             $content->versionInfo->versionNo,
-            new FieldType\IdentifierField()
+            new FieldType\IntegerField()
         );
         $fields[] = new Field(
             'content_status',

--- a/lib/eZ/Publish/Core/Search/Solr/ResultExtractor.php
+++ b/lib/eZ/Publish/Core/Search/Solr/ResultExtractor.php
@@ -23,7 +23,7 @@ abstract class ResultExtractor
     /**
      * Facet builder visitor.
      *
-     * @var \eZ\Publish\Core\Search\Elasticsearch\Content\FacetBuilderVisitor
+     * @var \eZ\Publish\Core\Search\Solr\Query\FacetBuilderVisitor
      */
     protected $facetBuilderVisitor;
 

--- a/lib/eZ/Publish/Core/Search/Solr/ResultExtractor/LoadingResultExtractor.php
+++ b/lib/eZ/Publish/Core/Search/Solr/ResultExtractor/LoadingResultExtractor.php
@@ -17,8 +17,8 @@ use eZ\Publish\Core\Search\Solr\Query\FacetBuilderVisitor;
 use RuntimeException;
 
 /**
- * The Loading Extractor extracts the value object from the Elasticsearch search hit data
- * by loading it from the database.
+ * The Loading Result Extractor extracts the value object from the Solr search hit data
+ * by loading it from the persistence.
  */
 class LoadingResultExtractor extends ResultExtractor
 {

--- a/lib/eZ/Publish/Core/Search/Solr/ResultExtractor/NativeResultExtractor.php
+++ b/lib/eZ/Publish/Core/Search/Solr/ResultExtractor/NativeResultExtractor.php
@@ -58,7 +58,7 @@ class NativeResultExtractor extends ResultExtractor
                 'name' => $hit->name_s,
                 'contentTypeId' => (int)$hit->type_id,
                 'sectionId' => (int)$hit->section_id,
-                'currentVersionNo' => (int)$hit->version_id,
+                'currentVersionNo' => $hit->version_no_i,
                 'isPublished' => true,
                 'ownerId' => (int)$hit->owner_id,
                 'modificationDate' => strtotime($hit->modified_dt),

--- a/lib/eZ/Publish/Core/Search/Solr/ResultExtractor/NativeResultExtractor.php
+++ b/lib/eZ/Publish/Core/Search/Solr/ResultExtractor/NativeResultExtractor.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace eZ\Publish\Core\Search\Solr\ResultExtractor;
+
+use eZ\Publish\Core\Search\Solr\ResultExtractor;
+use eZ\Publish\SPI\Persistence\Content\ContentInfo;
+use eZ\Publish\SPI\Persistence\Content\Location;
+use RuntimeException;
+
+/**
+ * The Native Result Extractor extracts the value object from the data
+ * returned by the Solr backend.
+ */
+class NativeResultExtractor extends ResultExtractor
+{
+    /**
+     * Extracts value object from $hit returned by Solr backend.
+     *
+     * @throws \RuntimeException If search $hit could not be handled
+     *
+     * @param mixed $hit
+     *
+     * @return \eZ\Publish\API\Repository\Values\ValueObject
+     */
+    public function extractHit($hit)
+    {
+        if ($hit->document_type_id === 'content') {
+            return $this->extractContentInfoFromHit($hit);
+        }
+
+        if ($hit->document_type_id === 'location') {
+            return $this->extractLocationFromHit($hit);
+        }
+
+        throw new RuntimeException(
+            "Could not extract: document of type '{$hit->document_type_id}' is not handled."
+        );
+    }
+
+    /**
+     * @param mixed $hit
+     *
+     * @return \eZ\Publish\SPI\Persistence\Content\ContentInfo
+     */
+    protected function extractContentInfoFromHit($hit)
+    {
+        $contentInfo = new ContentInfo(
+            array(
+                'id' => (int)$hit->content_id,
+                'name' => $hit->name_s,
+                'contentTypeId' => (int)$hit->type_id,
+                'sectionId' => (int)$hit->section_id,
+                'currentVersionNo' => (int)$hit->version_id,
+                'isPublished' => true,
+                'ownerId' => (int)$hit->owner_id,
+                'modificationDate' => strtotime($hit->modified_dt),
+                'publicationDate' => strtotime($hit->published_dt),
+                'alwaysAvailable' => $hit->always_available_b,
+                'remoteId' => $hit->remote_id_id,
+                'mainLanguageCode' => $hit->main_language_code_s,
+            )
+        );
+
+        if (isset($hit->main_location_id)) {
+            $contentInfo->mainLocationId = (int)$hit->main_location_id;
+        }
+
+        return $contentInfo;
+    }
+
+    /**
+     * @param mixed $hit
+     *
+     * @return \eZ\Publish\SPI\Persistence\Content\Location
+     */
+    protected function extractLocationFromHit($hit)
+    {
+        return new Location(
+            array(
+                'id' => (int)$hit->location_id,
+                'priority' => $hit->priority_i,
+                'hidden' => $hit->hidden_b,
+                'invisible' => $hit->invisible_b,
+                'remoteId' => $hit->remote_id_id,
+                'contentId' => (int)$hit->content_id_id,
+                'parentId' => (int)$hit->parent_id_id,
+                'pathString' => $hit->path_string_id,
+                'depth' => $hit->depth_i,
+                'sortField' => (int)$hit->sort_field_id,
+                'sortOrder' => (int)$hit->sort_order_id,
+            )
+        );
+    }
+}

--- a/lib/eZ/Publish/Core/settings/search_engines/solr.yml
+++ b/lib/eZ/Publish/Core/settings/search_engines/solr.yml
@@ -13,7 +13,7 @@ parameters:
     ezpublish.search.solr.gateway.endpoint_resolver.native.class: eZ\Publish\Core\Search\Solr\Gateway\EndpointResolver\NativeEndpointResolver
     ezpublish.search.solr.core_filter.native.class: eZ\Publish\Core\Search\Solr\CoreFilter\NativeCoreFilter
     ezpublish.search.solr.document_mapper.native.class: eZ\Publish\Core\Search\Solr\DocumentMapper\NativeDocumentMapper
-    ezpublish.search.solr.result_extractor.loading.class: eZ\Publish\Core\Search\Solr\ResultExtractor\LoadingResultExtractor
+    ezpublish.search.solr.result_extractor.native.class: eZ\Publish\Core\Search\Solr\ResultExtractor\NativeResultExtractor
     ezpublish.search.solr.query_converter.class: eZ\Publish\Core\Search\Solr\Query\Common\QueryConverter\NativeQueryConverter
     # Endpoint resolver arguments must be set in order to be overrideable
     ezpublish.search.solr.entry_endpoints: []
@@ -58,15 +58,13 @@ services:
     ezpublish.search.solr.document_mapper:
         alias: ezpublish.search.solr.document_mapper.native
 
-    ezpublish.search.solr.result_extractor.loading:
-        class: %ezpublish.search.solr.result_extractor.loading.class%
+    ezpublish.search.solr.result_extractor.native:
+        class: %ezpublish.search.solr.result_extractor.native.class%
         arguments:
-            - @ezpublish.spi.persistence.content_handler
-            - @ezpublish.spi.persistence.location_handler
             - @ezpublish.search.solr.query.content.facet_builder_visitor.aggregate
 
     ezpublish.search.solr.result_extractor:
-        alias: ezpublish.search.solr.result_extractor.loading
+        alias: ezpublish.search.solr.result_extractor.native
 
     ezpublish.search.solr.query_converter.content:
         class: %ezpublish.search.solr.query_converter.class%


### PR DESCRIPTION
> ##### This PR resolves https://jira.ez.no/browse/EZP-24704
> ##### Review together with https://github.com/ezsystems/ezpublish-kernel/pull/1372

This implements *native* result extractor, which extracts search result from data returned by Solr backend.

`NativeResultExtractor` replaces `LoadingResultExtractor`, which did the "extraction" by loading from persistence by ID returned from the Solr backend.

The motive is completely avoiding hitting of persistence when using `SearchService::findContentInfo()`.