### PR TITLE
Switch to eDisMax query parser

### DIFF
--- a/lib/eZ/Publish/Core/Search/Solr/Query/Common/QueryConverter/NativeQueryConverter.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Common/QueryConverter/NativeQueryConverter.php
@@ -62,7 +62,8 @@ class NativeQueryConverter extends QueryConverter
     public function convert(Query $query)
     {
         $params = array(
-            'q' => $this->criterionVisitor->visit($query->query),
+            'defType' => 'edismax',
+            'q.alt' => $this->criterionVisitor->visit($query->query),
             'fq' => $this->criterionVisitor->visit($query->filter),
             'sort' => $this->getSortClauses($query->sortClauses),
             'start' => $query->offset,


### PR DESCRIPTION
Switching to eDisMax query parser.

eDisMax will provide a base for more potential functionality in the future, for example boost query.