### PR TITLE
Renamed SearchHit::$contentTranslation to $matchedTranslation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "ezsystems/ezpublish-kernel": "~6.0@dev"
+        "ezsystems/ezpublish-kernel": "dev-rename-matched-translation"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.7",

--- a/lib/eZ/Publish/Core/Search/Solr/ResultExtractor.php
+++ b/lib/eZ/Publish/Core/Search/Solr/ResultExtractor.php
@@ -63,7 +63,7 @@ abstract class ResultExtractor
                 array(
                     'score' => $doc->score,
                     'index' => $this->getIndexIdentifier($doc),
-                    'contentTranslation' => $this->getMatchedLanguageCode($doc),
+                    'matchedTranslation' => $this->getMatchedLanguageCode($doc),
                     'valueObject' => $this->extractHit($doc),
                 )
             );


### PR DESCRIPTION
Review together with https://github.com/ezsystems/ezpublish-kernel/pull/1373

One of the remaining points from the workshop.

Initially the idea was for this to be plural (an array of strings), containing the array of matched language codes. Since we can't achieve that ATM the property is kept as string.