### PR TITLE
Implement commit() instead of setCommit()

### DIFF
--- a/lib/eZ/Publish/API/Repository/Tests/SetupFactory/LegacySolr.php
+++ b/lib/eZ/Publish/API/Repository/Tests/SetupFactory/LegacySolr.php
@@ -130,8 +130,8 @@ class LegacySolr extends Legacy
 
         /** @var \eZ\Publish\Core\Search\Solr\Handler $searchHandler */
         $searchHandler->purgeIndex();
-        $searchHandler->setCommit(true);
         $searchHandler->bulkIndexContent($contentObjects);
+        $searchHandler->commit();
     }
 
     protected function getTestConfigurationFile()

--- a/lib/eZ/Publish/Core/Search/Solr/Gateway.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Gateway.php
@@ -63,11 +63,13 @@ abstract class Gateway
     abstract public function purgeIndex();
 
     /**
-     * Set if index/delete actions should commit or if several actions is to be expected.
+     * Commits the data to the Solr index, making it available for search.
      *
-     * This should be set to false before group of actions and true before the last one
+     * This will perform Solr 'soft commit', which means there is no guarantee that data
+     * is actually written to the stable storage, it is only made available for search.
+     * Passing true will also write the data to the safe storage, ensuring durability.
      *
-     * @param bool $commit
+     * @param bool $flush
      */
-    abstract public function setCommit($commit);
+    abstract public function commit($flush = false);
 }

--- a/lib/eZ/Publish/Core/Search/Solr/Handler.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Handler.php
@@ -304,14 +304,16 @@ class Handler implements SearchHandlerInterface
     }
 
     /**
-     * Set if index/delete actions should commit or if several actions is to be expected.
+     * Commits the data to the Solr index, making it available for search.
      *
-     * This should be set to false before group of actions and true before the last one
+     * This will perform Solr 'soft commit', which means there is no guarantee that data
+     * is actually written to the stable storage, it is only made available for search.
+     * Passing true will also write the data to the safe storage, ensuring durability.
      *
-     * @param bool $commit
+     * @param bool $flush
      */
-    public function setCommit($commit)
+    public function commit($flush = false)
     {
-        $this->gateway->setCommit($commit);
+        $this->gateway->commit($flush);
     }
 }


### PR DESCRIPTION
Review together with https://github.com/ezsystems/ezpublish-kernel/pull/1374

This replaces internal search handler method `setCommit()` with `refresh()`, which performs empty soft commit request.

Since indexing is by definition asynchronous/delayed, exposing this in API does not make much sense, since we can't know what exactly will/won't be committed at any given moment.

On the other hand, the method makes sense on the search handler level, which also exposes methods `indexContent()` and `indexLocation()` (these are not async).