### PR TITLE
Simplify semantic configuration after nested Location documents

### DIFF
--- a/bundle/EzPublishSolrSearchEngineBundle/DependencyInjection/EzPublishSolrSearchEngineExtension.php
+++ b/bundle/EzPublishSolrSearchEngineBundle/DependencyInjection/EzPublishSolrSearchEngineExtension.php
@@ -155,10 +155,10 @@ class EzPublishSolrSearchEngineExtension extends Extension
 
         // Endpoint resolver
         $endpointResolverDefinition = new DefinitionDecorator(self::ENDPOINT_RESOLVER_ID);
-        $endpointResolverDefinition->replaceArgument(0, $connectionParams['entry_endpoints']['content']);
-        $endpointResolverDefinition->replaceArgument(1, $connectionParams['cluster']['content']['translations']);
-        $endpointResolverDefinition->replaceArgument(2, $connectionParams['cluster']['content']['default']);
-        $endpointResolverDefinition->replaceArgument(3, $connectionParams['cluster']['content']['main_translations']);
+        $endpointResolverDefinition->replaceArgument(0, $connectionParams['entry_endpoints']);
+        $endpointResolverDefinition->replaceArgument(1, $connectionParams['mapping']['translations']);
+        $endpointResolverDefinition->replaceArgument(2, $connectionParams['mapping']['default']);
+        $endpointResolverDefinition->replaceArgument(3, $connectionParams['mapping']['main_translations']);
         $endpointResolverId = "$alias.connection.$connectionName.endpoint_resolver_id";
         $container->setDefinition($endpointResolverId, $endpointResolverDefinition);
 

--- a/tests/bundle/EzPublishSolrSearchEngineBundle/DependencyInjection/EzPublishSolrSearchEngineExtensionTest.php
+++ b/tests/bundle/EzPublishSolrSearchEngineBundle/DependencyInjection/EzPublishSolrSearchEngineExtensionTest.php
@@ -184,7 +184,7 @@ class EzPublishSolrSearchEngineExtensionTest extends AbstractExtensionTestCase
                     'connections' => array(
                         'connection1' => array(
                             'entry_endpoints' => array(),
-                            'cluster' => array(),
+                            'mapping' => array(),
                         ),
                     ),
                 ),
@@ -193,12 +193,8 @@ class EzPublishSolrSearchEngineExtensionTest extends AbstractExtensionTestCase
                 array(
                     'connections' => array(
                         'connection1' => array(
-                            'entry_endpoints' => array(
-                                'content' => array(),
-                            ),
-                            'cluster' => array(
-                                'content' => array(),
-                            ),
+                            'entry_endpoints' => array(),
+                            'mapping' => array(),
                         ),
                     ),
                 ),
@@ -222,21 +218,17 @@ class EzPublishSolrSearchEngineExtensionTest extends AbstractExtensionTestCase
             'connections' => array(
                 'connection1' => array(
                     'entry_endpoints' => array(
-                        'content' => array(
-                            'endpoint1',
-                            'endpoint2',
-                        ),
+                        'endpoint1',
+                        'endpoint2',
                     ),
-                    'cluster' => array(
-                        'content' => array(
-                            'translations' => array(
-                                'cro-HR' => 'endpoint1',
-                                'eng-GB' => 'endpoint2',
-                                'gal-MW' => 'endpoint3',
-                            ),
-                            'default' => 'endpoint4',
-                            'main_translations' => 'endpoint5',
+                    'mapping' => array(
+                        'translations' => array(
+                            'cro-HR' => 'endpoint1',
+                            'eng-GB' => 'endpoint2',
+                            'gal-MW' => 'endpoint3',
                         ),
+                        'default' => 'endpoint4',
+                        'main_translations' => 'endpoint5',
                     ),
                 ),
             ),
@@ -289,15 +281,13 @@ class EzPublishSolrSearchEngineExtensionTest extends AbstractExtensionTestCase
         $configurationValues = array(
             'connections' => array(
                 'connection1' => array(
-                    'cluster' => array(
-                        'content' => array(
-                            'translations' => array(
-                                'cro-HR' => 'endpoint1',
-                                'eng-GB' => 'endpoint2',
-                            ),
-                            'default' => 'endpoint3',
-                            'main_translations' => 'endpoint4',
+                    'mapping' => array(
+                        'translations' => array(
+                            'cro-HR' => 'endpoint1',
+                            'eng-GB' => 'endpoint2',
                         ),
+                        'default' => 'endpoint3',
+                        'main_translations' => 'endpoint4',
                     ),
                 ),
             ),
@@ -351,15 +341,13 @@ class EzPublishSolrSearchEngineExtensionTest extends AbstractExtensionTestCase
         $configurationValues = array(
             'connections' => array(
                 'connection1' => array(
-                    'cluster' => array(
-                        'content' => array(
-                            'translations' => array(
-                                'cro-HR' => 'endpoint1',
-                                'eng-GB' => 'endpoint2',
-                            ),
-                            'default' => 'endpoint2',
-                            'main_translations' => 'endpoint2',
+                    'mapping' => array(
+                        'translations' => array(
+                            'cro-HR' => 'endpoint1',
+                            'eng-GB' => 'endpoint2',
                         ),
+                        'default' => 'endpoint2',
+                        'main_translations' => 'endpoint2',
                     ),
                 ),
             ),
@@ -406,61 +394,12 @@ class EzPublishSolrSearchEngineExtensionTest extends AbstractExtensionTestCase
         );
     }
 
-    public function testConnectionClusterDefaults()
+    public function testConnectionMappingDefaults()
     {
         $configurationValues = array(
             'connections' => array(
                 'connection1' => array(
-                    'cluster' => 'endpoint1',
-                ),
-            ),
-        );
-
-        $this->load($configurationValues);
-
-        $this->assertContainerBuilderHasParameter(
-            'ez_search_engine_solr.default_connection',
-            'connection1'
-        );
-
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
-            'ez_search_engine_solr.connection.connection1.endpoint_resolver_id',
-            0,
-            array(
-                'endpoint1',
-            )
-        );
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
-            'ez_search_engine_solr.connection.connection1.endpoint_resolver_id',
-            1,
-            array()
-        );
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
-            'ez_search_engine_solr.connection.connection1.endpoint_resolver_id',
-            2,
-            'endpoint1'
-        );
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
-            'ez_search_engine_solr.connection.connection1.endpoint_resolver_id',
-            3,
-            null
-        );
-        $this->assertContainerBuilderHasService(
-            'ez_search_engine_solr.connection.connection1.core_filter_id'
-        );
-        $this->assertContainerBuilderHasService(
-            'ez_search_engine_solr.connection.connection1.gateway_id'
-        );
-    }
-
-    public function testConnectionClustersDefault()
-    {
-        $configurationValues = array(
-            'connections' => array(
-                'connection1' => array(
-                    'cluster' => array(
-                        'content' => 'endpoint1',
-                    ),
+                    'mapping' => 'endpoint1',
                 ),
             ),
         );


### PR DESCRIPTION
This simplifies semantic configuration after https://github.com/ezsystems/ezplatform-solr-search-engine/pull/5

Indexing Locations as nested documents of Content removed the need for separate configuration for Location indexes. The configuration was removed, but the structure was not optimized.

Additionally `cluster` key is here renamed to `mapping`.

Previous full example:

```yaml
ez_search_engine_solr:
    endpoints:
        endpoint0:
            dsn: http://localhost:8983/solr
            core: core0
    default_connection: solr_test
    connections:
        solr_test:
            entry_endpoints:
                - endpoint0
            cluster:
                content:
                    translations:
                        eng-GB: endpoint1
                    default: endpoint0
                    main_translations: endpoint0
```

New full example:

```yaml
ez_search_engine_solr:
    endpoints:
        endpoint0:
            dsn: http://localhost:8983/solr
            core: core0
    default_connection: solr_test
    connections:
        solr_test:
            entry_endpoints:
                - endpoint0
            mapping:
                translations:
                    eng-GB: endpoint1
                default: endpoint0
                main_translations: endpoint0
```