### PR TITLE
Implement EZP-24802: Full text Location search

### DIFF
--- a/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/FullText.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Content/CriterionVisitor/FullText.php
@@ -83,8 +83,7 @@ class FullText extends CriterionVisitor
             }
         }
 
-        // @todo somethings fishy
-        return '(' . implode(
+        return '((' . implode(
             ') OR (',
             array_map(
                 function ($search) use ($criterion) {
@@ -96,6 +95,6 @@ class FullText extends CriterionVisitor
                 },
                 $queries
             )
-        ) . ')';
+        ) . '))';
     }
 }

--- a/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/FullText.php
+++ b/lib/eZ/Publish/Core/Search/Solr/Query/Location/CriterionVisitor/FullText.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * File containing the FullText criterion visitor class for Location Search.
+ * This file is part of the eZ Publish Kernel package.
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
@@ -11,10 +11,26 @@
 namespace eZ\Publish\Core\Search\Solr\Query\Location\CriterionVisitor;
 
 use eZ\Publish\Core\Search\Solr\Query\Content\CriterionVisitor\FullText as ContentFullText;
+use eZ\Publish\Core\Search\Solr\Query\CriterionVisitor;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 /**
  * Visits the FullText criterion.
  */
 class FullText extends ContentFullText
 {
+    /**
+     * Map field value to a proper Solr representation.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param \eZ\Publish\Core\Search\Solr\Query\CriterionVisitor $subVisitor
+     *
+     * @return string
+     */
+    public function visit(Criterion $criterion, CriterionVisitor $subVisitor = null)
+    {
+        $condition = $this->escapeQuote(parent::visit($criterion, $subVisitor));
+
+        return "{!child of='document_type_id:content' v='document_type_id:content AND {$condition}'}";
+    }
 }

--- a/lib/eZ/Publish/Core/settings/search_engines/solr/criterion_visitors.yml
+++ b/lib/eZ/Publish/Core/settings/search_engines/solr/criterion_visitors.yml
@@ -374,13 +374,12 @@ services:
         tags:
             - {name: ezpublish.search.solr.query.location.criterion_visitor}
 
-    # We don't support fulltext Location search out of the box
-    #ezpublish.search.solr.query.location.criterion_visitor.full_text:
-    #    class: %ezpublish.search.solr.query.location.criterion_visitor.full_text.class%
-    #    arguments:
-    #        - @ezpublish.search.common.field_name_resolver
-    #    tags:
-    #        - {name: ezpublish.search.solr.query.location.criterion_visitor}
+    ezpublish.search.solr.query.location.criterion_visitor.full_text:
+        class: %ezpublish.search.solr.query.location.criterion_visitor.full_text.class%
+        arguments:
+            - @ezpublish.search.common.field_name_resolver
+        tags:
+            - {name: ezpublish.search.solr.query.location.criterion_visitor}
 
     ezpublish.search.solr.query.location.criterion_visitor.custom_field_in:
         class: %ezpublish.search.solr.query.location.criterion_visitor.custom_field_in.class%

--- a/tests/lib/Search/Content/CriterionVisitor/FullTextTest.php
+++ b/tests/lib/Search/Content/CriterionVisitor/FullTextTest.php
@@ -52,7 +52,7 @@ class FullTextTest extends TestCase
         $criterion = new Criterion\FullText('Hello');
 
         $this->assertEquals(
-            '(text:Hello)',
+            '((text:Hello))',
             $visitor->visit($criterion)
         );
     }
@@ -65,7 +65,7 @@ class FullTextTest extends TestCase
         $criterion->fuzziness = .5;
 
         $this->assertEquals(
-            '(text:Hello~0.5)',
+            '((text:Hello~0.5))',
             $visitor->visit($criterion)
         );
     }
@@ -78,7 +78,7 @@ class FullTextTest extends TestCase
         $criterion->boost = array('title' => 2);
 
         $this->assertEquals(
-            '(text:Hello) OR (title_1_s:Hello^2) OR (title_2_s:Hello^2)',
+            '((text:Hello) OR (title_1_s:Hello^2) OR (title_2_s:Hello^2))',
             $visitor->visit($criterion)
         );
     }
@@ -93,7 +93,7 @@ class FullTextTest extends TestCase
         );
 
         $this->assertEquals(
-            '(text:Hello)',
+            '((text:Hello))',
             $visitor->visit($criterion)
         );
     }
@@ -107,7 +107,7 @@ class FullTextTest extends TestCase
         $criterion->boost = array('title' => 2);
 
         $this->assertEquals(
-            '(text:Hello~0.5) OR (title_1_s:Hello^2~0.5) OR (title_2_s:Hello^2~0.5)',
+            '((text:Hello~0.5) OR (title_1_s:Hello^2~0.5) OR (title_2_s:Hello^2~0.5))',
             $visitor->visit($criterion)
         );
     }


### PR DESCRIPTION
This PR resolves https://jira.ez.no/browse/EZP-24802

This implements full text Location search using child block join, possible since changing indexing of Locations to subdocuments of Content in https://jira.ez.no/browse/EZP-24649. The idea behind this was reusing parent document (Content) relevancy with full text Location search.

There is a bug in Solr version we currently support (`4.10`), causing skipping of scoring when using child block join: https://issues.apache.org/jira/browse/LUCENE-6588.
The issue is fixed since Solr `5.3` (latest).