### PR TITLE
Implement EZP-23247: missing field type Indexable definitions

### DIFF
--- a/lib/eZ/Publish/Core/Search/Solr/DocumentMapper/NativeDocumentMapper.php
+++ b/lib/eZ/Publish/Core/Search/Solr/DocumentMapper/NativeDocumentMapper.php
@@ -323,7 +323,7 @@ class NativeDocumentMapper implements DocumentMapper
             new FieldType\MultipleIdentifierField()
         );
 
-        $fieldSets = $this->mapContentFields($content, $contentType, true);
+        $fieldSets = $this->mapContentFields($content, $contentType);
         $documents = array();
 
         foreach ($fieldSets as $languageCode => $translationFields) {
@@ -428,15 +428,11 @@ class NativeDocumentMapper implements DocumentMapper
      *
      * @param \eZ\Publish\SPI\Persistence\Content $content
      * @param \eZ\Publish\SPI\Persistence\Content\Type $contentType
-     * @param bool $indexFulltext
      *
      * @return \eZ\Publish\SPI\Search\Field[][][]
      */
-    protected function mapContentFields(
-        Content $content,
-        ContentType $contentType,
-        $indexFulltext
-    ) {
+    protected function mapContentFields(Content $content, ContentType $contentType)
+    {
         $fieldSets = array();
 
         foreach ($content->fields as $field) {
@@ -462,14 +458,6 @@ class NativeDocumentMapper implements DocumentMapper
                         $indexField->value,
                         $indexField->type
                     );
-
-                    if ($indexFulltext && $indexField->type instanceof FieldType\StringField) {
-                        $fieldSets[$field->languageCode]['fulltext'][] = new Field(
-                            $name . '_fulltext',
-                            $indexField->value,
-                            new FieldType\TextField()
-                        );
-                    }
                 }
             }
         }

--- a/lib/eZ/Publish/Core/Search/Solr/FieldValueMapper/MultipleStringMapper.php
+++ b/lib/eZ/Publish/Core/Search/Solr/FieldValueMapper/MultipleStringMapper.php
@@ -11,7 +11,7 @@
 namespace eZ\Publish\Core\Search\Solr\FieldValueMapper;
 
 use eZ\Publish\SPI\Search\Field;
-use eZ\Publish\SPI\Search\FieldType\MultipleStringField;
+use eZ\Publish\SPI\Search\FieldType;
 
 /**
  * Maps raw document field values to something Solr can index.
@@ -27,7 +27,9 @@ class MultipleStringMapper extends StringMapper
      */
     public function canMap(Field $field)
     {
-        return $field->type instanceof MultipleStringField;
+        return
+            $field->type instanceof FieldType\MultipleStringField ||
+            $field->type instanceof FieldType\FullTextField;
     }
 
     /**

--- a/lib/eZ/Publish/Core/Search/Solr/FieldValueMapper/StringMapper.php
+++ b/lib/eZ/Publish/Core/Search/Solr/FieldValueMapper/StringMapper.php
@@ -13,7 +13,6 @@ namespace eZ\Publish\Core\Search\Solr\FieldValueMapper;
 use eZ\Publish\Core\Search\Solr\FieldValueMapper;
 use eZ\Publish\SPI\Search\Field;
 use eZ\Publish\SPI\Search\FieldType;
-use DOMDocument;
 
 /**
  * Maps raw document field values to something Solr can index.
@@ -56,6 +55,6 @@ class StringMapper extends FieldValueMapper
     protected function convert($value)
     {
         // Remove non-printables
-        return preg_replace('([\x00-\x09\x0B\x0C\x1E\x1F]+)', '', $value instanceof DOMDocument ? $value->saveXML() : $value);
+        return preg_replace('([\x00-\x09\x0B\x0C\x1E\x1F]+)', '', (string)$value);
     }
 }

--- a/lib/eZ/Publish/Core/Search/Solr/FieldValueMapper/StringMapper.php
+++ b/lib/eZ/Publish/Core/Search/Solr/FieldValueMapper/StringMapper.php
@@ -31,8 +31,7 @@ class StringMapper extends FieldValueMapper
     {
         return
             $field->type instanceof FieldType\StringField ||
-            $field->type instanceof FieldType\TextField ||
-            $field->type instanceof FieldType\HtmlField;
+            $field->type instanceof FieldType\TextField;
     }
 
     /**

--- a/lib/eZ/Publish/Core/Search/Solr/Resources/language-fieldtypes.xml
+++ b/lib/eZ/Publish/Core/Search/Solr/Resources/language-fieldtypes.xml
@@ -11,20 +11,3 @@
         <filter class="solr.LowerCaseFilterFactory"/>
       </analyzer>
     </fieldType>
-
-    <fieldType name="html" class="solr.TextField" positionIncrementGap="100">
-      <analyzer type="index">
-        <charFilter class="solr.HTMLStripCharFilterFactory" escapedTags="a, title" />
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" enablePositionIncrements="true" />
-        <filter class="solr.LowerCaseFilterFactory"/>
-      </analyzer>
-      <analyzer type="query">
-        <charFilter class="solr.HTMLStripCharFilterFactory" escapedTags="a, title" />
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" enablePositionIncrements="true" />
-        <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-      </analyzer>
-    </fieldType>
-    

--- a/lib/eZ/Publish/Core/Search/Solr/Resources/schema.xml
+++ b/lib/eZ/Publish/Core/Search/Solr/Resources/schema.xml
@@ -93,7 +93,6 @@ should not remove or drastically change the existing definitions.
     <dynamicField name="*_ms" type="string" indexed="true" stored="true" multiValued="true"/>
     <dynamicField name="*_l" type="long" indexed="true" stored="true"/>
     <dynamicField name="*_t" type="text" indexed="true" stored="true"/>
-    <dynamicField name="*_h" type="html" indexed="true" stored="false"/>
     <dynamicField name="*_b" type="boolean" indexed="true" stored="true"/>
     <dynamicField name="*_mb" type="boolean" indexed="true" stored="true" multiValued="true"/>
     <dynamicField name="*_f" type="float" indexed="true" stored="true"/>

--- a/lib/eZ/Publish/Core/Search/Solr/Resources/schema.xml
+++ b/lib/eZ/Publish/Core/Search/Solr/Resources/schema.xml
@@ -103,14 +103,12 @@ should not remove or drastically change the existing definitions.
     <dynamicField name="*_gl_1_coordinate" type="double" indexed="true" stored="true"/>
     <dynamicField name="*_c" type="currency" indexed="true" stored="true"/>
 
-    <field name="text" type="text" indexed="true" multiValued="true" stored="false"/>
-
     <!--
-      Index all text, html and string fields in full text index
+      Full text field is indexed through proxy fields matching '*_fulltext' pattern.
     -->
-    <copyField source="*_t" dest="text" />
-    <copyField source="*_s" dest="text" />
-    <copyField source="*_h" dest="text" />
+    <field name="text" type="text" indexed="true" multiValued="true" stored="false"/>
+    <dynamicField name="*_fulltext" type="text" indexed="false" multiValued="true" stored="false"/>
+    <copyField source="*_fulltext" dest="text" />
 
     <!--
       This field is required since Solr 4


### PR DESCRIPTION
> #### This PR resolves https://jira.ez.no/browse/EZP-23247
> #### Review with https://github.com/ezsystems/ezpublish-kernel/pull/1418

This implements handling of the new SPI search backend field type `FullText`.
Fields of this type are not stored, but instead are copied to the real full text field `text`.

This is used by the field type's `Indexable` definitions for indexing full text data.

#### Additionaly fixed

* removed handling of `DOMDocument` from string field value mapper (cleanup after merge of https://github.com/ezsystems/ezpublish-kernel/pull/262)
* referencing non-existent `HtmlField` SPI search backend field type