### PR TITLE
Fix EZP-24902: Document is not indexed for translation

### DIFF
--- a/lib/eZ/Publish/Core/Search/Solr/DocumentMapper/NativeDocumentMapper.php
+++ b/lib/eZ/Publish/Core/Search/Solr/DocumentMapper/NativeDocumentMapper.php
@@ -354,7 +354,7 @@ class NativeDocumentMapper implements DocumentMapper
                         'id' => $this->generateLocationDocumentId($location->id, $languageCode),
                         'fields' => array_merge(
                             $locationFields[$location->id],
-                            isset($translationFields['regular']) ? $translationFields['regular'] : array(),
+                            $translationFields['regular'],
                             $metaFields
                         ),
                     )
@@ -375,8 +375,8 @@ class NativeDocumentMapper implements DocumentMapper
                     'isMainTranslation' => $isMainTranslation,
                     'fields' => array_merge(
                         $fields,
-                        isset($translationFields['regular']) ? $translationFields['regular'] : array(),
-                        isset($translationFields['fulltext']) ? $translationFields['fulltext'] : array(),
+                        $translationFields['regular'],
+                        $translationFields['fulltext'],
                         $metaFields
                     ),
                     'documents' => $translationLocationDocuments,
@@ -449,7 +449,14 @@ class NativeDocumentMapper implements DocumentMapper
                         continue;
                     }
 
-                    $fieldSets[$field->languageCode]['regular'][] = new Field(
+                    if (!isset($fieldSets[$field->languageCode])) {
+                        $fieldSets[$field->languageCode] = array(
+                            'regular' => array(),
+                            'fulltext' => array(),
+                        );
+                    }
+
+                    $documentField = new Field(
                         $name = $this->fieldNameGenerator->getName(
                             $indexField->name,
                             $fieldDefinition->identifier,
@@ -458,6 +465,12 @@ class NativeDocumentMapper implements DocumentMapper
                         $indexField->value,
                         $indexField->type
                     );
+
+                    if ($documentField->type instanceof FieldType\FullTextField) {
+                        $fieldSets[$field->languageCode]['fulltext'][] = $documentField;
+                    } else {
+                        $fieldSets[$field->languageCode]['regular'][] = $documentField;
+                    }
                 }
             }
         }

--- a/lib/eZ/Publish/Core/Search/Solr/DocumentMapper/NativeDocumentMapper.php
+++ b/lib/eZ/Publish/Core/Search/Solr/DocumentMapper/NativeDocumentMapper.php
@@ -436,6 +436,13 @@ class NativeDocumentMapper implements DocumentMapper
         $fieldSets = array();
 
         foreach ($content->fields as $field) {
+            if (!isset($fieldSets[$field->languageCode])) {
+                $fieldSets[$field->languageCode] = array(
+                    'regular' => array(),
+                    'fulltext' => array(),
+                );
+            }
+
             foreach ($contentType->fieldDefinitions as $fieldDefinition) {
                 if ($fieldDefinition->id !== $field->fieldDefinitionId) {
                     continue;
@@ -447,13 +454,6 @@ class NativeDocumentMapper implements DocumentMapper
                 foreach ($indexFields as $indexField) {
                     if ($indexField->value === null) {
                         continue;
-                    }
-
-                    if (!isset($fieldSets[$field->languageCode])) {
-                        $fieldSets[$field->languageCode] = array(
-                            'regular' => array(),
-                            'fulltext' => array(),
-                        );
                     }
 
                     $documentField = new Field(


### PR DESCRIPTION
This PR resolves https://jira.ez.no/browse/EZP-24902
Review together with https://github.com/ezsystems/ezpublish-kernel/pull/1441

When mapping Content to documents per translation, translations are determined from the generated document fields. Since field is not mapped to the document if value of the field equals to `null`, it can happen that document is not added for the translation if all field values for the translation equal to `null`.

With this change a document will be indexed for translation even when it has no Content fields.

Additionally fixed indexing full-text fields to Location documents.