### PR TITLE
Wrong solr field name for location priority

### DIFF
--- a/lib/Query/Location/SortClauseVisitor/Location/Priority.php
+++ b/lib/Query/Location/SortClauseVisitor/Location/Priority.php
@@ -39,6 +39,6 @@ class Priority extends SortClauseVisitor
      */
     public function visit(SortClause $sortClause)
     {
-        return 'priority_id' . $this->getDirection($sortClause);
+        return 'priority_i' . $this->getDirection($sortClause);
     }
 }


### PR DESCRIPTION
Sort clauses content using `\eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location\Priority` are ignored by Solr because `priority_id` doesn't exist.