### PR TITLE
Fix EZP-25187: float/double indexing can fail due to locale

### DIFF
--- a/lib/FieldValueMapper/FloatMapper.php
+++ b/lib/FieldValueMapper/FloatMapper.php
@@ -40,6 +40,19 @@ class FloatMapper extends FieldValueMapper
      */
     public function map(Field $field)
     {
-        return (float)$field->value;
+        return $this->fixupFloat($field->value);
+    }
+
+    /**
+     * Convert to a proper Solr representation.
+     *
+     * @param mixed $value
+     *
+     * @return string
+     */
+    protected function fixupFloat($value)
+    {
+        // This will force the '.' as decimal separator and not depend on the locale
+        return sprintf('%F', (float)$value);
     }
 }

--- a/lib/Query/CriterionVisitor.php
+++ b/lib/Query/CriterionVisitor.php
@@ -108,6 +108,8 @@ abstract class CriterionVisitor
         switch (gettype($value)) {
             case 'boolean':
                 return ($value ? 'true' : 'false');
+            case 'double':
+                return sprintf('%F', $value);
 
             default:
                 return (string)$value;


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-25187

Different locales can represet floats differently (such as `123,45` for `de_DE.UTF-8`), which cause solr indexing to fail.
This uses the same, simple solution adopted for ezfind's indexboost (https://github.com/ezsystems/ezfind/commit/f46a315f2fa117e7).
