### PR TITLE
Fix EZP-25158: Missing FieldRelation Criterion visitor

### DIFF
--- a/lib/Query/Content/CriterionVisitor/Field/FieldRelation.php
+++ b/lib/Query/Content/CriterionVisitor/Field/FieldRelation.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * This file is part of the eZ Platform Solr Search Engine package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace EzSystems\EzPlatformSolrSearchEngine\Query\Content\CriterionVisitor\Field;
+
+use EzSystems\EzPlatformSolrSearchEngine\Query\CriterionVisitor;
+use EzSystems\EzPlatformSolrSearchEngine\Query\Content\CriterionVisitor\Field;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
+
+/**
+ * Visits the FieldRelation criterion.
+ */
+class FieldRelation extends Field
+{
+    /**
+     * Check if visitor is applicable to current criterion.
+     *
+     * @param Criterion $criterion
+     *
+     * @return bool
+     */
+    public function canVisit(Criterion $criterion)
+    {
+        return
+            $criterion instanceof Criterion\FieldRelation &&
+            (($criterion->operator ?: Operator::IN) === Operator::IN ||
+                $criterion->operator === Operator::CONTAINS);
+    }
+
+    /**
+     * Map field value to a proper Solr representation.
+     *
+     * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentException If no searchable fields are found for the given criterion target.
+     *
+     * @param Criterion $criterion
+     * @param CriterionVisitor $subVisitor
+     *
+     * @return string
+     */
+    public function visit(Criterion $criterion, CriterionVisitor $subVisitor = null)
+    {
+        $fieldNames = $this->getFieldNames($criterion, $criterion->target);
+
+        if (empty($fieldNames)) {
+            throw new InvalidArgumentException(
+                '$criterion->target',
+                "No searchable fields found for the given criterion target '{$criterion->target}'."
+            );
+        }
+
+        $criterion->value = (array)$criterion->value;
+
+        $queries = array();
+        foreach ($criterion->value as $value) {
+            $preparedValue = $this->escapeQuote($this->toString($value), true);
+
+            foreach ($fieldNames as $name) {
+                $queries[] = $name . ':"' . $preparedValue . '"';
+            }
+        }
+
+        switch ($criterion->operator) {
+            case Operator::CONTAINS:
+                $op = ' AND ';
+                break;
+            case Operator::IN:
+            default:
+                $op = ' OR ';
+        }
+
+        return '(' . implode($op, $queries) . ')';
+    }
+}

--- a/lib/Resources/config/container/solr/criterion_visitors.yml
+++ b/lib/Resources/config/container/solr/criterion_visitors.yml
@@ -28,6 +28,7 @@ parameters:
     ezpublish.search.solr.query.content.criterion_visitor.map_location_distance_in.class: EzSystems\EzPlatformSolrSearchEngine\Query\Content\CriterionVisitor\MapLocation\MapLocationDistanceIn
     ezpublish.search.solr.query.content.criterion_visitor.map_location_distance_range.class: EzSystems\EzPlatformSolrSearchEngine\Query\Content\CriterionVisitor\MapLocation\MapLocationDistanceRange
     ezpublish.search.solr.query.content.criterion_visitor.field_in.class: EzSystems\EzPlatformSolrSearchEngine\Query\Content\CriterionVisitor\Field\FieldIn
+    ezpublish.search.solr.query.content.criterion_visitor.field_relation.class: EzSystems\EzPlatformSolrSearchEngine\Query\Content\CriterionVisitor\Field\FieldRelation
     ezpublish.search.solr.query.content.criterion_visitor.field_range.class: EzSystems\EzPlatformSolrSearchEngine\Query\Content\CriterionVisitor\Field\FieldRange
     ezpublish.search.solr.query.content.criterion_visitor.visibility.class: EzSystems\EzPlatformSolrSearchEngine\Query\Content\CriterionVisitor\Visibility
     ezpublish.search.solr.query.content.criterion_visitor.custom_field_in.class: EzSystems\EzPlatformSolrSearchEngine\Query\Content\CriterionVisitor\CustomField\CustomFieldIn
@@ -220,6 +221,13 @@ services:
 
     ezpublish.search.solr.query.content.criterion_visitor.field_in:
         class: %ezpublish.search.solr.query.content.criterion_visitor.field_in.class%
+        arguments:
+            - @ezpublish.search.common.field_name_resolver
+        tags:
+            - {name: ezpublish.search.solr.query.content.criterion_visitor}
+
+    ezpublish.search.solr.query.content.criterion_visitor.field_relation:
+        class: %ezpublish.search.solr.query.content.criterion_visitor.field_relation.class%
         arguments:
             - @ezpublish.search.common.field_name_resolver
         tags:


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-25158

Attempting to use the `FieldRelation` Criterion will result in a "Intentionally not implemented" exception.

As the relation fields are already being indexed, the approach is to simply reuse/extend the Field criterion.