### PR TITLE
Fix EZP-25334: Missing PermissionSubtree Criterion Visitor

### DIFF
--- a/lib/Query/Location/CriterionVisitor/PermissionSubtree.php
+++ b/lib/Query/Location/CriterionVisitor/PermissionSubtree.php
@@ -33,6 +33,7 @@ class PermissionSubtree extends CriterionVisitor
     public function visit(Criterion $criterion, CriterionVisitor $subVisitor = null)
     {
         $subtrees = $criterion->value;
+
         return 'path_string_id:[' . implode('* ', $subtrees) . '*]';
     }
 }

--- a/lib/Query/Location/CriterionVisitor/PermissionSubtree.php
+++ b/lib/Query/Location/CriterionVisitor/PermissionSubtree.php
@@ -33,6 +33,6 @@ class PermissionSubtree extends CriterionVisitor
     public function visit(Criterion $criterion, CriterionVisitor $subVisitor = null)
     {
         $subtrees = $criterion->value;
-        return 'path_string_id:['.implode('* ', $subtrees).'*]';
+        return 'path_string_id:[' . implode('* ', $subtrees) . '*]';
     }
 }

--- a/lib/Query/Location/CriterionVisitor/PermissionSubtree.php
+++ b/lib/Query/Location/CriterionVisitor/PermissionSubtree.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * This file is part of the eZ Platform Solr Search Engine package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace EzSystems\EzPlatformSolrSearchEngine\Query\Location\CriterionVisitor;
+
+use EzSystems\EzPlatformSolrSearchEngine\Query\CriterionVisitor;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\Core\Repository\Values\Content\Query\Criterion as CoreCriterion;
+
+/**
+ * Visits the PermissionSubtree criterion.
+ */
+class PermissionSubtree extends CriterionVisitor
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function canVisit(Criterion $criterion)
+    {
+        return $criterion instanceof CoreCriterion\PermissionSubtree;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function visit(Criterion $criterion, CriterionVisitor $subVisitor = null)
+    {
+        $subtrees = $criterion->value;
+        return 'path_string_id:['.implode('* ', $subtrees).'*]';
+    }
+}

--- a/lib/Resources/config/container/solr/criterion_visitors.yml
+++ b/lib/Resources/config/container/solr/criterion_visitors.yml
@@ -50,6 +50,7 @@ parameters:
     ezpublish.search.solr.query.location.criterion_visitor.object_state_id_in.class: EzSystems\EzPlatformSolrSearchEngine\Query\Location\CriterionVisitor\ObjectStateIdIn
     ezpublish.search.solr.query.location.criterion_visitor.location_remote_id_in.class: EzSystems\EzPlatformSolrSearchEngine\Query\Location\CriterionVisitor\LocationRemoteIdIn
     ezpublish.search.solr.query.location.criterion_visitor.modified_in.class: EzSystems\EzPlatformSolrSearchEngine\Query\Location\CriterionVisitor\DateMetadata\ModifiedIn
+    ezpublish.search.solr.query.location.criterion_visitor.permission_subtree.class: EzSystems\EzPlatformSolrSearchEngine\Query\Location\CriterionVisitor\PermissionSubtree
     ezpublish.search.solr.query.location.criterion_visitor.published_in.class: EzSystems\EzPlatformSolrSearchEngine\Query\Location\CriterionVisitor\DateMetadata\PublishedIn
     ezpublish.search.solr.query.location.criterion_visitor.modified_between.class: EzSystems\EzPlatformSolrSearchEngine\Query\Location\CriterionVisitor\DateMetadata\ModifiedBetween
     ezpublish.search.solr.query.location.criterion_visitor.published_between.class: EzSystems\EzPlatformSolrSearchEngine\Query\Location\CriterionVisitor\DateMetadata\PublishedBetween
@@ -367,6 +368,11 @@ services:
 
     ezpublish.search.solr.query.location.criterion_visitor.is_main_location:
         class: %ezpublish.search.solr.query.location.criterion_visitor.is_main_location.class%
+        tags:
+            - {name: ezpublish.search.solr.query.location.criterion_visitor}
+
+    ezpublish.search.solr.query.location.criterion_visitor.permission_subtree:
+        class: %ezpublish.search.solr.query.location.criterion_visitor.permission_subtree.class%
         tags:
             - {name: ezpublish.search.solr.query.location.criterion_visitor}
 


### PR DESCRIPTION
PermissionVisitor was not implemented yet, this causes an uncaught exception when controlling user permissions by subtree.