### PR TITLE
v1.1 Bump and testing improvements 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+## Run on trusty environment as solr dies all the time on containers after travis move to gce
+sudo: required
+dist: trusty
+
 language: php
 
 matrix:
@@ -21,7 +25,7 @@ before_script:
     - travis_retry composer selfupdate
     # Avoid memory issues on composer install
     - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-    - travis_retry composer install --prefer-dist  --no-interaction
+    - travis_retry composer update --prefer-dist --prefer-stable --no-interaction
     - if [ "$SOLR_VERSION" != "" ] ; then ./bin/.travis/init_solr.sh ; fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: php
 
 matrix:
     include:
-        - php: 5.6
+        - php: 7.0
           env: TEST_CONFIG="phpunit.xml"
         - php: 5.4
           env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="4.10.4" CORES_SETUP="dedicated" SOLR_CONFS="lib/Resources/config/solr/schema.xml lib/Resources/config/solr/custom-fields-types.xml lib/Resources/config/solr/language-fieldtypes.xml" SOLR_CORES="core0 core1 core2 core3"
@@ -17,11 +17,11 @@ branches:
         - master
 
 before_script:
-    - composer selfupdate
     - phpenv config-rm xdebug.ini
-    # Avoid issues on composer install since we pull in both legacy and platform stack
+    - travis_retry composer selfupdate
+    # Avoid memory issues on composer install
     - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-    - composer install --prefer-dist
+    - travis_retry composer install --prefer-dist  --no-interaction
     - if [ "$SOLR_VERSION" != "" ] ; then ./bin/.travis/init_solr.sh ; fi
 
 script:

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (C) 1999-2015 eZ Systems AS. All rights reserved.
+Copyright (C) 1999-2016 eZ Systems AS. All rights reserved.
 This source code is provided under the following license:
 
 

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "ezsystems/ezplatform-solr-search-engine",
     "description": "Solr search engine implementation for eZ Platform",
     "license": "GPL-2.0",
+    "homepage": "https://github.com/ezsystems/ezplatform-solr-search-engine",
     "authors": [
         {
             "name": "eZ Systems dev team",
@@ -9,12 +10,12 @@
         }
     ],
     "require": {
-        "ezsystems/ezpublish-kernel": "~5.4.5@dev | ~6.0@dev"
+        "php": "^5.4.4|~7.0",
+        "ezsystems/ezpublish-kernel": "~5.4.6@dev|~6.0.1@dev|^6.1.1@dev"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.7",
-        "matthiasnoback/symfony-dependency-injection-test": "0.*",
-        "zendframework/zend-code": "~2.4.3"
+        "matthiasnoback/symfony-dependency-injection-test": "0.*"
     },
     "autoload": {
         "psr-4": {
@@ -26,7 +27,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0.x-dev"
+            "dev-master": "1.1.x-dev"
         }
     }
 }


### PR DESCRIPTION
To unblock #35:
- Bump requirements and version numbers
  - tag kernel v6.0.1 and v6.1.1 with #35 enhancement, 6.0.x for testing on php 5.4 
- Add testing on PHP 7.0
- Switch to Travis Trusty environment for:
 - Stable runs _(no more lost connection to solr issues)_
 - More power _for faster integration runs_
- Improve how composer packages are installed _(prefer stable)_