### PR TITLE
Implement indexing plugins

### DIFF
--- a/bundle/EzSystemsEzPlatformSolrSearchEngineBundle.php
+++ b/bundle/EzSystemsEzPlatformSolrSearchEngineBundle.php
@@ -17,6 +17,7 @@ use EzSystems\EzPlatformSolrSearchEngine\Container\Compiler\AggregateFacetBuilde
 use EzSystems\EzPlatformSolrSearchEngine\Container\Compiler\AggregateFieldValueMapperPass;
 use EzSystems\EzPlatformSolrSearchEngine\Container\Compiler\AggregateSortClauseVisitorPass;
 use EzSystems\EzPlatformSolrSearchEngine\Container\Compiler\EndpointRegistryPass;
+use EzSystems\EzPlatformSolrSearchEngine\Container\Compiler\DocumentFieldMapperPass;
 use eZ\Publish\Core\Base\Container\Compiler\Search\FieldRegistryPass;
 use eZ\Publish\Core\Base\Container\Compiler\Search\SignalSlotPass;
 
@@ -26,6 +27,12 @@ class EzSystemsEzPlatformSolrSearchEngineBundle extends Bundle
     {
         parent::build($container);
 
+        $container->addCompilerPass(new DocumentFieldMapperPass\Block());
+        $container->addCompilerPass(new DocumentFieldMapperPass\BlockTranslation());
+        $container->addCompilerPass(new DocumentFieldMapperPass\Content());
+        $container->addCompilerPass(new DocumentFieldMapperPass\ContentTranslation());
+        $container->addCompilerPass(new DocumentFieldMapperPass\Location());
+        $container->addCompilerPass(new DocumentFieldMapperPass\LocationTranslation());
         $container->addCompilerPass(new AggregateCriterionVisitorPass());
         $container->addCompilerPass(new AggregateFacetBuilderVisitorPass());
         $container->addCompilerPass(new AggregateFieldValueMapperPass());

--- a/lib/Container/Compiler/BaseDocumentFieldMapperPass.php
+++ b/lib/Container/Compiler/BaseDocumentFieldMapperPass.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * This file is part of the eZ Platform Solr Search Engine package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace EzSystems\EzPlatformSolrSearchEngine\Container\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Base compiler pass for aggregate document field mappers.
+ */
+abstract class BaseDocumentFieldMapperPass implements CompilerPassInterface
+{
+    /**
+     * Service ID of the aggregate plugin.
+     */
+    const AGGREGATE_MAPPER_SERVICE_ID = null;
+
+    /**
+     * Service tag of plugins registering to the aggregate one.
+     */
+    const AGGREGATE_MAPPER_SERVICE_TAG = null;
+
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition(static::AGGREGATE_MAPPER_SERVICE_ID)) {
+            return;
+        }
+
+        $aggregateMapperDefinition = $container->getDefinition(static::AGGREGATE_MAPPER_SERVICE_ID);
+        $taggedMapperServiceIds = $container->findTaggedServiceIds(static::AGGREGATE_MAPPER_SERVICE_TAG);
+
+        foreach ($taggedMapperServiceIds as $id => $attributes) {
+            $aggregateMapperDefinition->addMethodCall(
+                'addMapper',
+                [
+                    new Reference($id),
+                ]
+            );
+        }
+    }
+}

--- a/lib/Container/Compiler/DocumentFieldMapperPass/Block.php
+++ b/lib/Container/Compiler/DocumentFieldMapperPass/Block.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * This file is part of the eZ Platform Solr Search Engine package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace EzSystems\EzPlatformSolrSearchEngine\Container\Compiler\DocumentFieldMapperPass;
+
+use EzSystems\EzPlatformSolrSearchEngine\Container\Compiler\BaseDocumentFieldMapperPass;
+
+/**
+ * Compiler pass for aggregate document field mapper for the block documents.
+ */
+class Block extends BaseDocumentFieldMapperPass
+{
+    const AGGREGATE_MAPPER_SERVICE_ID = 'ezpublish.search.solr.document_mapper.plugin.block';
+    const AGGREGATE_MAPPER_SERVICE_TAG = self::AGGREGATE_MAPPER_SERVICE_ID;
+}

--- a/lib/Container/Compiler/DocumentFieldMapperPass/BlockTranslation.php
+++ b/lib/Container/Compiler/DocumentFieldMapperPass/BlockTranslation.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * This file is part of the eZ Platform Solr Search Engine package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace EzSystems\EzPlatformSolrSearchEngine\Container\Compiler\DocumentFieldMapperPass;
+
+use EzSystems\EzPlatformSolrSearchEngine\Container\Compiler\BaseDocumentFieldMapperPass;
+
+/**
+ * Compiler pass for aggregate document field mapper for the block documents
+ * in a specific translation.
+ */
+class BlockTranslation extends BaseDocumentFieldMapperPass
+{
+    const AGGREGATE_MAPPER_SERVICE_ID = 'ezpublish.search.solr.document_mapper.plugin.block_translation';
+    const AGGREGATE_MAPPER_SERVICE_TAG = self::AGGREGATE_MAPPER_SERVICE_ID;
+}

--- a/lib/Container/Compiler/DocumentFieldMapperPass/Content.php
+++ b/lib/Container/Compiler/DocumentFieldMapperPass/Content.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * This file is part of the eZ Platform Solr Search Engine package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace EzSystems\EzPlatformSolrSearchEngine\Container\Compiler\DocumentFieldMapperPass;
+
+use EzSystems\EzPlatformSolrSearchEngine\Container\Compiler\BaseDocumentFieldMapperPass;
+
+/**
+ * Compiler pass for aggregate document field mapper for the Content document.
+ */
+class Content extends BaseDocumentFieldMapperPass
+{
+    const AGGREGATE_MAPPER_SERVICE_ID = 'ezpublish.search.solr.document_mapper.plugin.content';
+    const AGGREGATE_MAPPER_SERVICE_TAG = self::AGGREGATE_MAPPER_SERVICE_ID;
+}

--- a/lib/Container/Compiler/DocumentFieldMapperPass/ContentTranslation.php
+++ b/lib/Container/Compiler/DocumentFieldMapperPass/ContentTranslation.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * This file is part of the eZ Platform Solr Search Engine package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace EzSystems\EzPlatformSolrSearchEngine\Container\Compiler\DocumentFieldMapperPass;
+
+use EzSystems\EzPlatformSolrSearchEngine\Container\Compiler\BaseDocumentFieldMapperPass;
+
+/**
+ * Compiler pass for aggregate document field mapper for the Content document
+ * in a specific translation.
+ */
+class ContentTranslation extends BaseDocumentFieldMapperPass
+{
+    const AGGREGATE_MAPPER_SERVICE_ID = 'ezpublish.search.solr.document_mapper.plugin.content_translation';
+    const AGGREGATE_MAPPER_SERVICE_TAG = self::AGGREGATE_MAPPER_SERVICE_ID;
+}

--- a/lib/Container/Compiler/DocumentFieldMapperPass/Location.php
+++ b/lib/Container/Compiler/DocumentFieldMapperPass/Location.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * This file is part of the eZ Platform Solr Search Engine package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace EzSystems\EzPlatformSolrSearchEngine\Container\Compiler\DocumentFieldMapperPass;
+
+use EzSystems\EzPlatformSolrSearchEngine\Container\Compiler\BaseDocumentFieldMapperPass;
+
+/**
+ * Compiler pass for aggregate document field mapper for the Location document.
+ */
+class Location extends BaseDocumentFieldMapperPass
+{
+    const AGGREGATE_MAPPER_SERVICE_ID = 'ezpublish.search.solr.document_mapper.plugin.location';
+    const AGGREGATE_MAPPER_SERVICE_TAG = self::AGGREGATE_MAPPER_SERVICE_ID;
+}

--- a/lib/Container/Compiler/DocumentFieldMapperPass/LocationTranslation.php
+++ b/lib/Container/Compiler/DocumentFieldMapperPass/LocationTranslation.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * This file is part of the eZ Platform Solr Search Engine package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace EzSystems\EzPlatformSolrSearchEngine\Container\Compiler\DocumentFieldMapperPass;
+
+use EzSystems\EzPlatformSolrSearchEngine\Container\Compiler\BaseDocumentFieldMapperPass;
+
+/**
+ * Compiler pass for aggregate document field mapper for the Location document of the Content
+ * in a specific translation.
+ */
+class LocationTranslation extends BaseDocumentFieldMapperPass
+{
+    const AGGREGATE_MAPPER_SERVICE_ID = 'ezpublish.search.solr.document_mapper.plugin.location_translation';
+    const AGGREGATE_MAPPER_SERVICE_TAG = self::AGGREGATE_MAPPER_SERVICE_ID;
+}

--- a/lib/DocumentMapper/FieldMapper.php
+++ b/lib/DocumentMapper/FieldMapper.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * This file is part of the eZ Platform Solr Search Engine package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace EzSystems\EzPlatformSolrSearchEngine\DocumentMapper;
+
+/**
+ * Base class for document field mappers.
+ */
+abstract class FieldMapper
+{
+}

--- a/lib/DocumentMapper/FieldMapper/Content.php
+++ b/lib/DocumentMapper/FieldMapper/Content.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * This file is part of the eZ Platform Solr Search Engine package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper;
+
+use EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper;
+use eZ\Publish\SPI\Persistence\Content as SPIContent;
+
+/**
+ * Base class for Content document field mapper.
+ *
+ * Content document field mapper maps Content to the search fields for Content document.
+ */
+abstract class Content extends FieldMapper
+{
+    /**
+     * Indicates if the mapper accepts the given $content for mapping.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content $content
+     *
+     * @return bool
+     */
+    abstract public function accept(SPIContent $content);
+
+    /**
+     * Maps given $content to an array of search fields.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content $content
+     *
+     * @return \eZ\Publish\SPI\Search\Field[]
+     */
+    abstract public function mapFields(SPIContent $content);
+}

--- a/lib/DocumentMapper/FieldMapper/Content/Aggregate.php
+++ b/lib/DocumentMapper/FieldMapper/Content/Aggregate.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * This file is part of the eZ Platform Solr Search Engine package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\Content;
+
+use EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\Content as ContentMapper;
+use eZ\Publish\SPI\Persistence\Content;
+
+/**
+ * Aggregate implementation of Content document field mapper.
+ */
+class Aggregate extends ContentMapper
+{
+    /**
+     * An array of aggregated field mappers, sorted by priority.
+     *
+     * @var \EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\Content[]
+     */
+    protected $mappers = [];
+
+    /**
+     * @param \EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\Content[] $mappers
+     *        An array of mappers, sorted by priority.
+     */
+    public function __construct(array $mappers = [])
+    {
+        foreach ($mappers as $mapper) {
+            $this->addMapper($mapper);
+        }
+    }
+
+    /**
+     * Adds given $mapper to the internal array as the next one in priority.
+     *
+     * @param \EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\Content $mapper
+     */
+    public function addMapper(ContentMapper $mapper)
+    {
+        $this->mappers[] = $mapper;
+    }
+
+    public function accept(Content $content)
+    {
+        return true;
+    }
+
+    public function mapFields(Content $content)
+    {
+        $fields = [[]];
+
+        foreach ($this->mappers as $mapper) {
+            if ($mapper->accept($content)) {
+                $fields[] = $mapper->mapFields($content);
+            }
+        }
+
+        return array_merge(...$fields);
+    }
+}

--- a/lib/DocumentMapper/FieldMapper/Content/Aggregate.php
+++ b/lib/DocumentMapper/FieldMapper/Content/Aggregate.php
@@ -53,14 +53,14 @@ class Aggregate extends ContentMapper
 
     public function mapFields(Content $content)
     {
-        $fields = [[]];
+        $fields = [];
 
         foreach ($this->mappers as $mapper) {
             if ($mapper->accept($content)) {
-                $fields[] = $mapper->mapFields($content);
+                $fields = array_merge($fields, $mapper->mapFields($content));
             }
         }
 
-        return array_merge(...$fields);
+        return $fields;
     }
 }

--- a/lib/DocumentMapper/FieldMapper/ContentTranslation.php
+++ b/lib/DocumentMapper/FieldMapper/ContentTranslation.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * This file is part of the eZ Platform Solr Search Engine package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper;
+
+use EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper;
+use eZ\Publish\SPI\Persistence\Content as SPIContent;
+
+/**
+ * Base class for Content translation document field mapper.
+ *
+ * Content translation document field mapper maps Content in a specific translation to the
+ * search fields for Content document.
+ */
+abstract class ContentTranslation extends FieldMapper
+{
+    /**
+     * Indicates if the mapper accepts given $content and $languageCode for mapping.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content $content
+     * @param string $languageCode
+     *
+     * @return bool
+     */
+    abstract public function accept(SPIContent $content, $languageCode);
+
+    /**
+     * Maps given $content for $languageCode to an array of search fields.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content $content
+     * @param string $languageCode
+     *
+     * @return \eZ\Publish\SPI\Search\Field[]
+     */
+    abstract public function mapFields(SPIContent $content, $languageCode);
+}

--- a/lib/DocumentMapper/FieldMapper/ContentTranslation/Aggregate.php
+++ b/lib/DocumentMapper/FieldMapper/ContentTranslation/Aggregate.php
@@ -53,14 +53,14 @@ class Aggregate extends ContentTranslation
 
     public function mapFields(Content $content, $languageCode)
     {
-        $fields = [[]];
+        $fields = [];
 
         foreach ($this->mappers as $mapper) {
             if ($mapper->accept($content, $languageCode)) {
-                $fields[] = $mapper->mapFields($content, $languageCode);
+                $fields = array_merge($fields, $mapper->mapFields($content, $languageCode));
             }
         }
 
-        return array_merge(...$fields);
+        return $fields;
     }
 }

--- a/lib/DocumentMapper/FieldMapper/ContentTranslation/Aggregate.php
+++ b/lib/DocumentMapper/FieldMapper/ContentTranslation/Aggregate.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * This file is part of the eZ Platform Solr Search Engine package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\ContentTranslation;
+
+use EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\ContentTranslation;
+use eZ\Publish\SPI\Persistence\Content;
+
+/**
+ * Aggregate implementation of Content translation document field mapper.
+ */
+class Aggregate extends ContentTranslation
+{
+    /**
+     * An array of aggregated field mappers, sorted by priority.
+     *
+     * @var \EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\ContentTranslation[]
+     */
+    protected $mappers = [];
+
+    /**
+     * @param \EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\ContentTranslation[] $mappers
+     *        An array of mappers, sorted by priority.
+     */
+    public function __construct(array $mappers = [])
+    {
+        foreach ($mappers as $mapper) {
+            $this->addMapper($mapper);
+        }
+    }
+
+    /**
+     * Adds given $mapper to the internal array as the next one in priority.
+     *
+     * @param \EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\ContentTranslation $mapper
+     */
+    public function addMapper(ContentTranslation $mapper)
+    {
+        $this->mappers[] = $mapper;
+    }
+
+    public function accept(Content $content, $languageCode)
+    {
+        return true;
+    }
+
+    public function mapFields(Content $content, $languageCode)
+    {
+        $fields = [[]];
+
+        foreach ($this->mappers as $mapper) {
+            if ($mapper->accept($content, $languageCode)) {
+                $fields[] = $mapper->mapFields($content, $languageCode);
+            }
+        }
+
+        return array_merge(...$fields);
+    }
+}

--- a/lib/DocumentMapper/FieldMapper/Location.php
+++ b/lib/DocumentMapper/FieldMapper/Location.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * This file is part of the eZ Platform Solr Search Engine package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper;
+
+use EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper;
+use eZ\Publish\SPI\Persistence\Content\Location as SPILocation;
+
+/**
+ * Base class for Location document field mappers.
+ *
+ * Location document field mapper maps Location to the search fields for Location document.
+ */
+abstract class Location extends FieldMapper
+{
+    /**
+     * Indicates if the mapper accepts given $location for mapping.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content\Location $location
+     *
+     * @return bool
+     */
+    abstract public function accept(SPILocation $location);
+
+    /**
+     * Maps given $location to an array of search fields.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content\Location $location
+     *
+     * @return \eZ\Publish\SPI\Search\Field[]
+     */
+    abstract public function mapFields(SPILocation $location);
+}

--- a/lib/DocumentMapper/FieldMapper/Location/Aggregate.php
+++ b/lib/DocumentMapper/FieldMapper/Location/Aggregate.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * This file is part of the eZ Platform Solr Search Engine package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\Location;
+
+use EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\Location as LocationMapper;
+use eZ\Publish\SPI\Persistence\Content\Location;
+
+/**
+ * Aggregate implementation of Location document field mapper.
+ */
+class Aggregate extends LocationMapper
+{
+    /**
+     * An array of aggregated field mappers, sorted by priority.
+     *
+     * @var \EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\Location[]
+     */
+    protected $mappers = [];
+
+    /**
+     * @param \EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\Location[] $mappers
+     *        An array of mappers, sorted by priority.
+     */
+    public function __construct(array $mappers = [])
+    {
+        foreach ($mappers as $mapper) {
+            $this->addMapper($mapper);
+        }
+    }
+
+    /**
+     * Adds given $mapper to the internal array as the next one in priority.
+     *
+     * @param \EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\Location $mapper
+     */
+    public function addMapper(LocationMapper $mapper)
+    {
+        $this->mappers[] = $mapper;
+    }
+
+    public function accept(Location $location)
+    {
+        return true;
+    }
+
+    public function mapFields(Location $location)
+    {
+        $fields = [[]];
+
+        foreach ($this->mappers as $mapper) {
+            if ($mapper->accept($location)) {
+                $fields[] = $mapper->mapFields($location);
+            }
+        }
+
+        return array_merge(...$fields);
+    }
+}

--- a/lib/DocumentMapper/FieldMapper/Location/Aggregate.php
+++ b/lib/DocumentMapper/FieldMapper/Location/Aggregate.php
@@ -53,14 +53,14 @@ class Aggregate extends LocationMapper
 
     public function mapFields(Location $location)
     {
-        $fields = [[]];
+        $fields = [];
 
         foreach ($this->mappers as $mapper) {
             if ($mapper->accept($location)) {
-                $fields[] = $mapper->mapFields($location);
+                $fields = array_merge($fields, $mapper->mapFields($location));
             }
         }
 
-        return array_merge(...$fields);
+        return $fields;
     }
 }

--- a/lib/DocumentMapper/FieldMapper/LocationTranslation.php
+++ b/lib/DocumentMapper/FieldMapper/LocationTranslation.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * This file is part of the eZ Platform Solr Search Engine package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper;
+
+use EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper;
+use eZ\Publish\SPI\Persistence\Content\Location as SPILocation;
+
+/**
+ * Base class for Location translation document field mappers.
+ *
+ * Location translation document field mapper maps Location of the Content in a specific
+ * translation to the search fields for Location document.
+ */
+abstract class LocationTranslation extends FieldMapper
+{
+    /**
+     * Indicates if the mapper accepts given $location and $languageCode for mapping.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content\Location $location
+     * @param string $languageCode
+     *
+     * @return bool
+     */
+    abstract public function accept(SPILocation $location, $languageCode);
+
+    /**
+     * Maps given $location for $languageCode to an array of search fields.
+     *
+     * Language code refers to the Content of the given Location.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content\Location $location
+     * @param string $languageCode
+     *
+     * @return \eZ\Publish\SPI\Search\Field[]
+     */
+    abstract public function mapFields(SPILocation $location, $languageCode);
+}

--- a/lib/DocumentMapper/FieldMapper/LocationTranslation/Aggregate.php
+++ b/lib/DocumentMapper/FieldMapper/LocationTranslation/Aggregate.php
@@ -53,14 +53,14 @@ class Aggregate extends LocationTranslation
 
     public function mapFields(Location $location, $languageCode)
     {
-        $fields = [[]];
+        $fields = [];
 
         foreach ($this->mappers as $mapper) {
             if ($mapper->accept($location, $languageCode)) {
-                $fields[] = $mapper->mapFields($location, $languageCode);
+                $fields = array_merge($fields, $mapper->mapFields($location, $languageCode));
             }
         }
 
-        return array_merge(...$fields);
+        return $fields;
     }
 }

--- a/lib/DocumentMapper/FieldMapper/LocationTranslation/Aggregate.php
+++ b/lib/DocumentMapper/FieldMapper/LocationTranslation/Aggregate.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * This file is part of the eZ Platform Solr Search Engine package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\LocationTranslation;
+
+use EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\LocationTranslation;
+use eZ\Publish\SPI\Persistence\Content\Location;
+
+/**
+ * Aggregate implementation of Location translation document field mapper.
+ */
+class Aggregate extends LocationTranslation
+{
+    /**
+     * An array of aggregated field mappers, sorted by priority.
+     *
+     * @var \EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\LocationTranslation[]
+     */
+    protected $mappers = [];
+
+    /**
+     * @param \EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\LocationTranslation[] $mappers
+     *        An array of mappers, sorted by priority.
+     */
+    public function __construct(array $mappers = [])
+    {
+        foreach ($mappers as $mapper) {
+            $this->addMapper($mapper);
+        }
+    }
+
+    /**
+     * Adds given $mapper to the internal array as the next one in priority.
+     *
+     * @param \EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\LocationTranslation $mapper
+     */
+    public function addMapper(LocationTranslation $mapper)
+    {
+        $this->mappers[] = $mapper;
+    }
+
+    public function accept(Location $content, $languageCode)
+    {
+        return true;
+    }
+
+    public function mapFields(Location $location, $languageCode)
+    {
+        $fields = [[]];
+
+        foreach ($this->mappers as $mapper) {
+            if ($mapper->accept($location, $languageCode)) {
+                $fields[] = $mapper->mapFields($location, $languageCode);
+            }
+        }
+
+        return array_merge(...$fields);
+    }
+}

--- a/lib/DocumentMapper/NativeDocumentMapper.php
+++ b/lib/DocumentMapper/NativeDocumentMapper.php
@@ -10,6 +10,10 @@
  */
 namespace EzSystems\EzPlatformSolrSearchEngine\DocumentMapper;
 
+use EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\Content as ContentFieldMapper;
+use EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\ContentTranslation as ContentTranslationFieldMapper;
+use EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\Location as LocationFieldMapper;
+use EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\LocationTranslation as LocationTranslationFieldMapper;
 use EzSystems\EzPlatformSolrSearchEngine\DocumentMapper;
 use eZ\Publish\SPI\Persistence\Content;
 use eZ\Publish\SPI\Persistence\Content\Type as ContentType;
@@ -31,6 +35,36 @@ use eZ\Publish\Core\Search\Common\FieldNameGenerator;
  */
 class NativeDocumentMapper implements DocumentMapper
 {
+    /**
+     * @var \EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\Content
+     */
+    private $blockFieldMapper;
+
+    /**
+     * @var \EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\ContentTranslation
+     */
+    private $blockTranslationFieldMapper;
+
+    /**
+     * @var \EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\Content
+     */
+    private $contentFieldMapper;
+
+    /**
+     * @var \EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\ContentTranslation
+     */
+    private $contentTranslationFieldMapper;
+
+    /**
+     * @var \EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\Location
+     */
+    private $locationFieldMapper;
+
+    /**
+     * @var \EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\LocationTranslation
+     */
+    private $locationTranslationFieldMapper;
+
     /**
      * Field registry.
      *
@@ -83,6 +117,12 @@ class NativeDocumentMapper implements DocumentMapper
     /**
      * Creates a new document mapper.
      *
+     * @param \EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\Content $blockFieldMapper
+     * @param \EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\ContentTranslation $blockTranslationFieldMapper
+     * @param \EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\Content $contentFieldMapper
+     * @param \EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\ContentTranslation $contentTranslationFieldMapper
+     * @param \EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\Location $locationFieldMapper
+     * @param \EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\LocationTranslation $locationTranslationFieldMapper
      * @param \eZ\Publish\Core\Search\Common\FieldRegistry $fieldRegistry
      * @param \eZ\Publish\SPI\Persistence\Content\Handler $contentHandler
      * @param \eZ\Publish\SPI\Persistence\Content\Location\Handler $locationHandler
@@ -92,6 +132,12 @@ class NativeDocumentMapper implements DocumentMapper
      * @param \eZ\Publish\Core\Search\Common\FieldNameGenerator $fieldNameGenerator
      */
     public function __construct(
+        ContentFieldMapper $blockFieldMapper,
+        ContentTranslationFieldMapper $blockTranslationFieldMapper,
+        ContentFieldMapper $contentFieldMapper,
+        ContentTranslationFieldMapper $contentTranslationFieldMapper,
+        LocationFieldMapper $locationFieldMapper,
+        LocationTranslationFieldMapper $locationTranslationFieldMapper,
         FieldRegistry $fieldRegistry,
         ContentHandler $contentHandler,
         LocationHandler $locationHandler,
@@ -100,6 +146,12 @@ class NativeDocumentMapper implements DocumentMapper
         SectionHandler $sectionHandler,
         FieldNameGenerator $fieldNameGenerator
     ) {
+        $this->blockFieldMapper = $blockFieldMapper;
+        $this->blockTranslationFieldMapper = $blockTranslationFieldMapper;
+        $this->contentFieldMapper = $contentFieldMapper;
+        $this->contentTranslationFieldMapper = $contentTranslationFieldMapper;
+        $this->locationFieldMapper = $locationFieldMapper;
+        $this->locationTranslationFieldMapper = $locationTranslationFieldMapper;
         $this->fieldRegistry = $fieldRegistry;
         $this->contentHandler = $contentHandler;
         $this->locationHandler = $locationHandler;
@@ -323,10 +375,22 @@ class NativeDocumentMapper implements DocumentMapper
             new FieldType\MultipleIdentifierField()
         );
 
+        $blockFields = $this->getBlockFields($content);
+        $contentFields = $this->getContentFields($content);
         $fieldSets = $this->mapContentFields($content, $contentType);
         $documents = array();
 
+        $locationFieldsMap = [];
+        foreach ($locations as $location) {
+            $locationFieldsMap[$location->id] = $this->getLocationFields($location);
+        }
+
         foreach ($fieldSets as $languageCode => $translationFields) {
+            $blockTranslationFields = $this->getBlockTranslationFields(
+                $content,
+                $languageCode
+            );
+
             $metaFields = array();
             $metaFields[] = new Field(
                 'meta_indexed_language_code',
@@ -349,13 +413,22 @@ class NativeDocumentMapper implements DocumentMapper
 
             $translationLocationDocuments = array();
             foreach ($locations as $location) {
+                $locationTranslationFields = $this->getLocationTranslationFields(
+                    $location,
+                    $languageCode
+                );
+
                 $translationLocationDocuments[] = new Document(
                     array(
                         'id' => $this->generateLocationDocumentId($location->id, $languageCode),
                         'fields' => array_merge(
                             $locationFields[$location->id],
                             $translationFields['regular'],
-                            $metaFields
+                            $metaFields,
+                            $blockFields,
+                            $locationFieldsMap[$location->id],
+                            $blockTranslationFields,
+                            $locationTranslationFields
                         ),
                     )
                 );
@@ -363,6 +436,10 @@ class NativeDocumentMapper implements DocumentMapper
 
             $isMainTranslation = ($content->versionInfo->contentInfo->mainLanguageCode === $languageCode);
             $alwaysAvailable = ($isMainTranslation && $content->versionInfo->contentInfo->alwaysAvailable);
+            $contentTranslationFields = $this->getContentTranslationFields(
+                $content,
+                $languageCode
+            );
 
             $documents[] = new Document(
                 array(
@@ -377,7 +454,11 @@ class NativeDocumentMapper implements DocumentMapper
                         $fields,
                         $translationFields['regular'],
                         $translationFields['fulltext'],
-                        $metaFields
+                        $metaFields,
+                        $blockFields,
+                        $contentFields,
+                        $blockTranslationFields,
+                        $contentTranslationFields
                     ),
                     'documents' => $translationLocationDocuments,
                 )
@@ -702,5 +783,122 @@ class NativeDocumentMapper implements DocumentMapper
         }
 
         return $objectStateIds;
+    }
+
+    /**
+     * Returns an array of fields for the given $content, to be added to the
+     * corresponding block documents.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content $content
+     *
+     * @return \eZ\Publish\SPI\Search\Field[]
+     */
+    private function getBlockFields(Content $content)
+    {
+        $fields = [];
+
+        if ($this->blockFieldMapper->accept($content)) {
+            $fields = $this->blockFieldMapper->mapFields($content);
+        }
+
+        return $fields;
+    }
+
+    /**
+     * Returns an array of fields for the given $content and $languageCode, to be added to the
+     * corresponding block documents.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content $content
+     * @param string $languageCode
+     *
+     * @return \eZ\Publish\SPI\Search\Field[]
+     */
+    private function getBlockTranslationFields(Content $content, $languageCode)
+    {
+        $fields = [];
+
+        if ($this->blockTranslationFieldMapper->accept($content, $languageCode)) {
+            $fields = $this->blockTranslationFieldMapper->mapFields($content, $languageCode);
+        }
+
+        return $fields;
+    }
+
+    /**
+     * Returns an array of fields for the given $content, to be added to the corresponding
+     * Content document.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content $content
+     *
+     * @return \eZ\Publish\SPI\Search\Field[]
+     */
+    private function getContentFields(Content $content)
+    {
+        $fields = [];
+
+        if ($this->contentFieldMapper->accept($content)) {
+            $fields = $this->contentFieldMapper->mapFields($content);
+        }
+
+        return $fields;
+    }
+
+    /**
+     * Returns an array of fields for the given $content and $languageCode, to be added to the
+     * corresponding Content document.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content $content
+     * @param string $languageCode
+     *
+     * @return \eZ\Publish\SPI\Search\Field[]
+     */
+    private function getContentTranslationFields(Content $content, $languageCode)
+    {
+        $fields = [];
+
+        if ($this->contentTranslationFieldMapper->accept($content, $languageCode)) {
+            $fields = $this->contentTranslationFieldMapper->mapFields($content, $languageCode);
+        }
+
+        return $fields;
+    }
+
+    /**
+     * Returns an array of fields for the given $location, to be added to the corresponding
+     * Location document.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content\Location $location
+     *
+     * @return \eZ\Publish\SPI\Search\Field[]
+     */
+    private function getLocationFields(Location $location)
+    {
+        $fields = [];
+
+        if ($this->locationFieldMapper->accept($location)) {
+            $fields = $this->locationFieldMapper->mapFields($location);
+        }
+
+        return $fields;
+    }
+
+    /**
+     * Returns an array of fields for the given $location and $languageCode, to be added to
+     * the corresponding Location document.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content\Location $location
+     * @param string $languageCode
+     *
+     * @return \eZ\Publish\SPI\Search\Field[]
+     */
+    private function getLocationTranslationFields(Location $location, $languageCode)
+    {
+        $fields = [];
+
+        if ($this->locationTranslationFieldMapper->accept($location, $languageCode)) {
+            $fields = $this->locationTranslationFieldMapper->mapFields($location, $languageCode);
+        }
+
+        return $fields;
     }
 }

--- a/lib/Resources/config/container/solr.yml
+++ b/lib/Resources/config/container/solr.yml
@@ -47,6 +47,12 @@ services:
     ezpublish.search.solr.document_mapper.native:
         class: %ezpublish.search.solr.document_mapper.native.class%
         arguments:
+            - @ezpublish.search.solr.document_field_mapper.block
+            - @ezpublish.search.solr.document_field_mapper.block_translation
+            - @ezpublish.search.solr.document_field_mapper.content
+            - @ezpublish.search.solr.document_field_mapper.content_translation
+            - @ezpublish.search.solr.document_field_mapper.location
+            - @ezpublish.search.solr.document_field_mapper.location_translation
             - @ezpublish.search.common.field_registry
             - @ezpublish.spi.persistence.content_handler
             - @ezpublish.spi.persistence.location_handler

--- a/lib/Resources/config/container/solr/services.yml
+++ b/lib/Resources/config/container/solr/services.yml
@@ -4,6 +4,12 @@ parameters:
     ezpublish.search.solr.query.common.sort_clause_visitor.aggregate.class: EzSystems\EzPlatformSolrSearchEngine\Query\Common\SortClauseVisitor\Aggregate
     ezpublish.search.solr.query.common.facet_builder_visitor.aggregate.class: EzSystems\EzPlatformSolrSearchEngine\Query\Common\FacetBuilderVisitor\Aggregate
     ezpublish.search.solr.field_value_mapper.aggregate.class: EzSystems\EzPlatformSolrSearchEngine\FieldValueMapper\Aggregate
+    ezpublish.search.solr.document_field_mapper.block.class: EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\Content\Aggregate
+    ezpublish.search.solr.document_field_mapper.block_translation.class: EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\ContentTranslation\Aggregate
+    ezpublish.search.solr.document_field_mapper.content.class: EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\Content\Aggregate
+    ezpublish.search.solr.document_field_mapper.content_translation.class: EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\ContentTranslation\Aggregate
+    ezpublish.search.solr.document_field_mapper.location.class: EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\Location\Aggregate
+    ezpublish.search.solr.document_field_mapper.location_translation.class: EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\LocationTranslation\Aggregate
 
 services:
     ezpublish.search.solr.gateway.client.http.stream:
@@ -43,3 +49,33 @@ services:
     # are registered to this one using compilation pass
     ezpublish.search.solr.query.location.facet_builder_visitor.aggregate:
         class: %ezpublish.search.solr.query.common.facet_builder_visitor.aggregate.class%
+
+    # Note: services tagged with 'ezpublish.search.solr.document_field_mapper.block'
+    # are registered to this one using compilation pass
+    ezpublish.search.solr.document_field_mapper.block:
+        class: '%ezpublish.search.solr.document_field_mapper.block.class%'
+
+    # Note: services tagged with 'ezpublish.search.solr.document_field_mapper.block_translation'
+    # are registered to this one using compilation pass
+    ezpublish.search.solr.document_field_mapper.block_translation:
+        class: '%ezpublish.search.solr.document_field_mapper.block_translation.class%'
+
+    # Note: services tagged with 'ezpublish.search.solr.document_field_mapper.content'
+    # are registered to this one using compilation pass
+    ezpublish.search.solr.document_field_mapper.content:
+        class: '%ezpublish.search.solr.document_field_mapper.content.class%'
+
+    # Note: services tagged with 'ezpublish.search.solr.document_field_mapper.content_translation'
+    # are registered to this one using compilation pass
+    ezpublish.search.solr.document_field_mapper.content_translation:
+        class: '%ezpublish.search.solr.document_field_mapper.content_translation.class%'
+
+    # Note: services tagged with 'ezpublish.search.solr.document_field_mapper.location'
+    # are registered to this one using compilation pass
+    ezpublish.search.solr.document_field_mapper.location:
+        class: '%ezpublish.search.solr.document_field_mapper.location.class%'
+
+    # Note: services tagged with 'ezpublish.search.solr.document_field_mapper.location_translation'
+    # are registered to this one using compilation pass
+    ezpublish.search.solr.document_field_mapper.location_translation:
+        class: '%ezpublish.search.solr.document_field_mapper.location_translation.class%'

--- a/lib/ResultExtractor.php
+++ b/lib/ResultExtractor.php
@@ -77,6 +77,8 @@ abstract class ResultExtractor
      * Returns language code of the Content's translation of the matched document.
      *
      * @param $hit
+     *
+     * @return string
      */
     protected function getMatchedLanguageCode($hit)
     {

--- a/tests/lib/SetupFactory/LegacySetupFactory.php
+++ b/tests/lib/SetupFactory/LegacySetupFactory.php
@@ -82,6 +82,12 @@ class LegacySetupFactory extends CoreLegacySetupFactory
             $solrTestLoader = new YamlFileLoader($containerBuilder, new FileLocator($testSettingsPath));
             $solrTestLoader->load($this->getTestConfigurationFile());
 
+            $containerBuilder->addCompilerPass(new Compiler\DocumentFieldMapperPass\Block());
+            $containerBuilder->addCompilerPass(new Compiler\DocumentFieldMapperPass\BlockTranslation());
+            $containerBuilder->addCompilerPass(new Compiler\DocumentFieldMapperPass\Content());
+            $containerBuilder->addCompilerPass(new Compiler\DocumentFieldMapperPass\ContentTranslation());
+            $containerBuilder->addCompilerPass(new Compiler\DocumentFieldMapperPass\Location());
+            $containerBuilder->addCompilerPass(new Compiler\DocumentFieldMapperPass\LocationTranslation());
             $containerBuilder->addCompilerPass(new Compiler\AggregateCriterionVisitorPass());
             $containerBuilder->addCompilerPass(new Compiler\AggregateFacetBuilderVisitorPass());
             $containerBuilder->addCompilerPass(new Compiler\AggregateFieldValueMapperPass());


### PR DESCRIPTION
This PR implements https://jira.ez.no/browse/EZP-24805

This implements document field mappers, aka indexing plugins feature.
Four types of base plugins are implemented:

1. `Content::mapFields(Content $content)`
2. `ContentTranslation::mapFields(Content $content, $languageCode)`
3. `Location::mapFields(Location $location)`
4. `LocationTranslation::mapFields(Location $location, $languageCode)`

For each of these an `Aggregate` plugin is implemented and used (6 places total):

1. `Content::mapFields(Content $content)`
  1. Block - indexes fields on the block document level -- meaning to each Content and Location document in the block
  2. Content - indexes fields to each Content document
2. `ContentTranslation::mapFields(Content $content, $languageCode)`
  1. BlockTranslation - indexes fields on the block level per translation
  2. ContentTranslation - indexes fields to Content document per translation
3. `Location::mapFields(Location $location)`
  1. Location - indexes field to each Location document
4. `LocationTranslation::mapFields(Location $location, $languageCode)`
  1. LocationTranslation - indexes field to Location document per translation

The same, but starting from extension points (service tags):

1. Block: `ezpublish.search.solr.document_field_mapper.block`
  - Accepts `Content::mapFields(Content $content)`
2. Block translation: `ezpublish.search.solr.document_field_mapper.block_translation`
  - Accepts `ContentTranslation::mapFields(Content $content, $languageCode)`
3. Content: `ezpublish.search.solr.document_field_mapper.content`
  - Accepts `Content::mapFields(Content $content)`
4. Content translation: `ezpublish.search.solr.document_field_mapper.content_translation`
  - Accepts `ContentTranslation::mapFields(Content $content, $languageCode)`
5. Location: `ezpublish.search.solr.document_field_mapper.location`
  - Accepts `Location::mapFields(Location $location)`
6. Location translation: `ezpublish.search.solr.document_field_mapper.location_translation`
  - Accepts `Content::mapFields(Location $location, $languageCode)`

Concrete plugins are registered to `Aggregate` plugin in a container compiler pass, using service tags.
At the moment no concrete plugins are implemented, followup to this would be refactoring `DocumentMapper` to use only plugins to map fields.

### TODOs
- [x] Get rid of argument unpacking (`...` operator) as it is not supported on PHP <5.6