### PR TITLE
EZP-25792: Deleted location don't affect subitems

### DIFF
--- a/lib/Gateway.php
+++ b/lib/Gateway.php
@@ -40,7 +40,13 @@ abstract class Gateway
      */
     abstract public function findLocations(Query $query, array $fieldFilters = array());
 
-    abstract public function findAllSomething(Query $query);
+    /**
+     * Returns all search hits for given query, that will be performed on all endpoints.
+     *
+     * @param Query $query
+     * @return mixed
+     */
+    abstract public function searchAllEndpoints(Query $query);
 
     /**
      * Indexes an array of documents.

--- a/lib/Gateway.php
+++ b/lib/Gateway.php
@@ -40,6 +40,8 @@ abstract class Gateway
      */
     abstract public function findLocations(Query $query, array $fieldFilters = array());
 
+    abstract public function findAllSomething(Query $query);
+
     /**
      * Indexes an array of documents.
      *

--- a/lib/Gateway/Native.php
+++ b/lib/Gateway/Native.php
@@ -151,9 +151,7 @@ class Native extends Gateway
             $parameters['shards'] = $searchTargets;
         }
 
-        $queryString = $this->generateQueryString($parameters);
-
-        return $this->search($queryString, $parameters);
+        return $this->search($parameters);
     }
 
     public function searchAllEndpoints(Query $query)
@@ -165,9 +163,7 @@ class Native extends Gateway
             $parameters['shards'] = $searchTargets;
         }
 
-        $queryString = $this->generateQueryString($parameters);
-
-        return $this->search($queryString, $parameters);
+        return $this->search($parameters);
     }
 
     /**
@@ -540,12 +536,14 @@ class Native extends Gateway
     /**
      * Perform request to client to search for records with query string.
      *
-     * @param string $queryString
      * @param array $parameters
+     *
      * @return mixed
      */
-    protected function search($queryString, array $parameters)
+    protected function search(array $parameters)
     {
+        $queryString = $this->generateQueryString($parameters);
+
         $response = $this->client->request(
             'GET',
             $this->endpointRegistry->getEndpoint(

--- a/lib/Gateway/Native.php
+++ b/lib/Gateway/Native.php
@@ -173,6 +173,37 @@ class Native extends Gateway
         return $result;
     }
 
+    public function findAllSomething(Query $query)
+    {
+        $parameters = $this->contentQueryConverter->convert($query);
+
+        $searchTargets = $this->endpointResolver->getEndpoints();
+        if (!empty($searchTargets)) {
+            $parameters['shards'] = $searchTargets;
+        }
+
+        $queryString = $this->generateQueryString($parameters);
+
+        $response = $this->client->request(
+            'GET',
+            $this->endpointRegistry->getEndpoint(
+                $this->endpointResolver->getEntryEndpoint()
+            ),
+            "/select?{$queryString}"
+        );
+
+        // @todo: Error handling?
+        $result = json_decode($response->body);
+
+        if (!isset($result->response)) {
+            throw new RuntimeException(
+                '->response not set: ' . var_export(array($result, $parameters), true)
+            );
+        }
+
+        return $result;
+    }
+
     /**
      * Generate URL-encoded query string.
      *

--- a/lib/Gateway/Native.php
+++ b/lib/Gateway/Native.php
@@ -153,55 +153,21 @@ class Native extends Gateway
 
         $queryString = $this->generateQueryString($parameters);
 
-        $response = $this->client->request(
-            'GET',
-            $this->endpointRegistry->getEndpoint(
-                $this->endpointResolver->getEntryEndpoint()
-            ),
-            "/select?{$queryString}"
-        );
-
-        // @todo: Error handling?
-        $result = json_decode($response->body);
-
-        if (!isset($result->response)) {
-            throw new RuntimeException(
-                '->response not set: ' . var_export(array($result, $parameters), true)
-            );
-        }
-
-        return $result;
+        return $this->search($queryString, $parameters);
     }
 
-    public function findAllSomething(Query $query)
+    public function searchAllEndpoints(Query $query)
     {
         $parameters = $this->contentQueryConverter->convert($query);
 
-        $searchTargets = $this->endpointResolver->getEndpoints();
+        $searchTargets = $this->getAllSearchTargets();
         if (!empty($searchTargets)) {
             $parameters['shards'] = $searchTargets;
         }
 
         $queryString = $this->generateQueryString($parameters);
 
-        $response = $this->client->request(
-            'GET',
-            $this->endpointRegistry->getEndpoint(
-                $this->endpointResolver->getEntryEndpoint()
-            ),
-            "/select?{$queryString}"
-        );
-
-        // @todo: Error handling?
-        $result = json_decode($response->body);
-
-        if (!isset($result->response)) {
-            throw new RuntimeException(
-                '->response not set: ' . var_export(array($result, $parameters), true)
-            );
-        }
-
-        return $result;
+        return $this->search($queryString, $parameters);
     }
 
     /**
@@ -216,11 +182,15 @@ class Native extends Gateway
      */
     protected function generateQueryString(array $parameters)
     {
-        return preg_replace(
+        $removedArrayCharacters = preg_replace(
             '/%5B[0-9]+%5D=/',
             '=',
             http_build_query($parameters)
         );
+
+        $removedDuplicatedEscapingForUrlPath = str_replace('%5C%5C%2F', '%5C%2F', $removedArrayCharacters);
+
+        return $removedDuplicatedEscapingForUrlPath;
     }
 
     /**
@@ -242,6 +212,24 @@ class Native extends Gateway
         }
 
         return implode(',', $shards);
+    }
+
+    /**
+     * Returns all search targets without language constraint.
+     *
+     * @return string
+     */
+    protected function getAllSearchTargets()
+    {
+        $shards = [];
+        $searchTargets = $this->endpointResolver->getEndpoints();
+        if (!empty($searchTargets)) {
+            foreach ($searchTargets as $endpointName) {
+                $shards[] = $this->endpointRegistry->getEndpoint($endpointName)->getIdentifier();
+            }
+        }
+
+        return  implode(',', $shards);
     }
 
     /**
@@ -547,5 +535,34 @@ class Native extends Gateway
             $xmlWriter->text($value);
             $xmlWriter->endElement();
         }
+    }
+
+    /**
+     * Perform request to client to search for records with query string.
+     *
+     * @param string $queryString
+     * @param array $parameters
+     * @return mixed
+     */
+    protected function search($queryString, array $parameters)
+    {
+        $response = $this->client->request(
+            'GET',
+            $this->endpointRegistry->getEndpoint(
+                $this->endpointResolver->getEntryEndpoint()
+            ),
+            "/select?{$queryString}"
+        );
+
+        // @todo: Error handling?
+        $result = json_decode($response->body);
+
+        if (!isset($result->response)) {
+            throw new RuntimeException(
+                '->response not set: ' . var_export(array($result, $parameters), true)
+            );
+        }
+
+        return $result;
     }
 }

--- a/lib/Handler.php
+++ b/lib/Handler.php
@@ -208,8 +208,6 @@ class Handler implements SearchHandlerInterface
      * @param string[] $fieldPaths
      * @param int $limit
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $filter
-     *
-     * @throws \Exception
      */
     public function suggest($prefix, $fieldPaths = array(), $limit = 10, Criterion $filter = null)
     {

--- a/lib/Query/Content/CriterionVisitor/CustomField/CustomFieldIn.php
+++ b/lib/Query/Content/CriterionVisitor/CustomField/CustomFieldIn.php
@@ -53,9 +53,18 @@ class CustomFieldIn extends CriterionVisitor
         foreach ($values as $value) {
             $preparedValue = $this->escapeQuote($this->toString($value), true);
 
-            $queries[] = $criterion->target . ':"' . $preparedValue . '"';
+            if ($this->isRegExp($preparedValue)) {
+                $queries[] = $criterion->target . ':' . $preparedValue;
+            } else {
+                $queries[] = $criterion->target . ':"' . $preparedValue . '"';
+            }
         }
 
         return '(' . implode(' OR ', $queries) . ')';
+    }
+
+    private function isRegExp($preparedValue)
+    {
+        return preg_match('#^/.*/$#', $preparedValue);
     }
 }


### PR DESCRIPTION
Issue: https://jira.ez.no/browse/EZP-25792

> Status: Ready for review
> Depends on https://github.com/ezsystems/ezpublish-kernel/pull/1658 *(integration tests)*

Explanation: 

The problem is that when we delete location we also want to delete all related sub location with related content, but if there is a content that have still another existing location that is out of the delete location subtree we just need to reindex this location instead of delete it.

Solution:

The solution is to find first which location need to be reindexed and with then need to be deleted with the content. As solr is handling location that are within content block we need to reindex or delete content index data.
