### PR TITLE
EZP-25756: Can't index data in solrBundle

### DIFF
--- a/lib/Handler.php
+++ b/lib/Handler.php
@@ -246,7 +246,11 @@ class Handler implements SearchHandlerInterface
         $documents = array();
 
         foreach ($contentObjects as $content) {
-            $documents[] = $this->mapper->mapContentBlock($content);
+            try {
+                $documents[] = $this->mapper->mapContentBlock($content);
+            } catch (NotFoundException $ex) {
+                // ignore content objects without assigned state id
+            }
         }
 
         if (!empty($documents)) {


### PR DESCRIPTION
**Related JIRA issue**: https://jira.ez.no/browse/EZP-25756

It fixes crashing of _ezplatform:solr_create_index_ command in 2 cases:
- [x] [Non-existent content object version](https://github.com/alongosz/ezplatform-solr-search-engine/blob/bc5b5db96e0e15e9f7e55fc54496ec4073b0ca3d/bundle/Command/SolrCreateIndexCommand.php#L90-L98) ([also logs a warning](https://github.com/alongosz/ezplatform-solr-search-engine/blob/bc5b5db96e0e15e9f7e55fc54496ec4073b0ca3d/bundle/Command/SolrCreateIndexCommand.php#L115))
- [x] Stateless content object ([here](https://github.com/alongosz/ezplatform-solr-search-engine/blob/bc5b5db96e0e15e9f7e55fc54496ec4073b0ca3d/lib/Handler.php#L249-L253) unable to log this unfortunately)
