### PR TITLE
EZP-25088: Signal slots configuration for Solr search engine

### DIFF
--- a/lib/Resources/config/container/solr.yml
+++ b/lib/Resources/config/container/solr.yml
@@ -4,6 +4,7 @@ imports:
     - {resource: solr/field_value_mappers.yml}
     - {resource: solr/services.yml}
     - {resource: solr/sort_clause_visitors.yml}
+    - {resource: solr/slots.yml}
 
 parameters:
     ezpublish.search.solr.connection.server: http://localhost:8983/solr/core0

--- a/lib/Resources/config/container/solr/slots.yml
+++ b/lib/Resources/config/container/solr/slots.yml
@@ -1,0 +1,130 @@
+parameters:
+    ezpublish.search.slot.class: eZ\Publish\Core\Search\Common\Slot
+    ezpublish.search.slot.publish_version.class: eZ\Publish\Core\Search\Common\Slot\PublishVersion
+    ezpublish.search.slot.copy_content.class: eZ\Publish\Core\Search\Common\Slot\CopyContent
+    ezpublish.search.slot.delete_content.class: eZ\Publish\Core\Search\Common\Slot\DeleteContent
+    ezpublish.search.slot.delete_version.class: eZ\Publish\Core\Search\Common\Slot\DeleteVersion
+    ezpublish.search.slot.create_location.class: eZ\Publish\Core\Search\Common\Slot\CreateLocation
+    ezpublish.search.slot.update_location.class: eZ\Publish\Core\Search\Common\Slot\UpdateLocation
+    ezpublish.search.slot.delete_location.class: eZ\Publish\Core\Search\Common\Slot\DeleteLocation
+    ezpublish.search.slot.create_user.class: eZ\Publish\Core\Search\Common\Slot\CreateUser
+    ezpublish.search.slot.create_user_group.class: eZ\Publish\Core\Search\Common\Slot\CreateUserGroup
+    ezpublish.search.slot.move_user_group.class: eZ\Publish\Core\Search\Common\Slot\MoveUserGroup
+    ezpublish.search.slot.copy_subtree.class: eZ\Publish\Core\Search\Common\Slot\CopySubtree
+    ezpublish.search.slot.move_subtree.class: eZ\Publish\Core\Search\Common\Slot\MoveSubtree
+    ezpublish.search.slot.trash.class: eZ\Publish\Core\Search\Common\Slot\Trash
+    ezpublish.search.slot.recover.class: eZ\Publish\Core\Search\Common\Slot\Recover
+    ezpublish.search.slot.hide_location.class: eZ\Publish\Core\Search\Common\Slot\HideLocation
+    ezpublish.search.slot.unhide_location.class: eZ\Publish\Core\Search\Common\Slot\UnhideLocation
+    ezpublish.search.slot.set_content_state.class: eZ\Publish\Core\Search\Common\Slot\SetContentState
+
+services:
+    ezpublish.search.slot:
+        class: %ezpublish.search.slot.class%
+        abstract: true
+        arguments:
+            - @ezpublish.api.inner_repository
+            - @ezpublish.api.persistence_handler
+            - @ezpublish.spi.search
+
+    ezpublish.search.slot.publish_version:
+        parent: ezpublish.search.slot
+        class: %ezpublish.search.slot.publish_version.class%
+        tags:
+            - {name: ezpublish.search.slot, signal: ContentService\PublishVersionSignal}
+
+    ezpublish.search.slot.copy_content:
+        parent: ezpublish.search.slot
+        class: %ezpublish.search.slot.copy_content.class%
+        tags:
+            - {name: ezpublish.search.slot, signal: ContentService\CopyContentSignal}
+
+    ezpublish.search.slot.delete_content:
+        parent: ezpublish.search.slot
+        class: %ezpublish.search.slot.delete_content.class%
+        tags:
+            - {name: ezpublish.search.slot, signal: ContentService\DeleteContentSignal}
+
+    ezpublish.search.slot.delete_version:
+        parent: ezpublish.search.slot
+        class: %ezpublish.search.slot.delete_version.class%
+        tags:
+            - {name: ezpublish.search.slot, signal: ContentService\DeleteVersionSignal}
+
+    ezpublish.search.slot.create_location:
+        parent: ezpublish.search.slot
+        class: %ezpublish.search.slot.create_location.class%
+        tags:
+            - {name: ezpublish.search.slot, signal: LocationService\CreateLocationSignal}
+
+    ezpublish.search.slot.update_location:
+        parent: ezpublish.search.slot
+        class: %ezpublish.search.slot.update_location.class%
+        tags:
+            - {name: ezpublish.search.slot, signal: LocationService\UpdateLocationSignal}
+
+    ezpublish.search.slot.delete_location:
+        parent: ezpublish.search.slot
+        class: %ezpublish.search.slot.delete_location.class%
+        tags:
+            - {name: ezpublish.search.slot, signal: LocationService\DeleteLocationSignal}
+
+    ezpublish.search.slot.create_user:
+        parent: ezpublish.search.slot
+        class: %ezpublish.search.slot.create_user.class%
+        tags:
+            - {name: ezpublish.search.slot, signal: UserService\CreateUserSignal}
+
+    ezpublish.search.slot.create_user_group:
+        parent: ezpublish.search.slot
+        class: %ezpublish.search.slot.create_user_group.class%
+        tags:
+            - {name: ezpublish.search.slot, signal: UserService\CreateUserGroupSignal}
+
+    ezpublish.search.slot.move_user_group:
+        parent: ezpublish.search.slot
+        class: %ezpublish.search.slot.move_user_group.class%
+        tags:
+            - {name: ezpublish.search.slot, signal: UserService\MoveUserGroupSignal}
+
+    ezpublish.search.slot.copy_subtree:
+        parent: ezpublish.search.slot
+        class: %ezpublish.search.slot.copy_subtree.class%
+        tags:
+            - {name: ezpublish.search.slot, signal: LocationService\CopySubtreeSignal}
+
+    ezpublish.search.slot.move_subtree:
+        parent: ezpublish.search.slot
+        class: %ezpublish.search.slot.move_subtree.class%
+        tags:
+            - {name: ezpublish.search.slot, signal: LocationService\MoveSubtreeSignal}
+
+    ezpublish.search.slot.trash:
+        parent: ezpublish.search.slot
+        class: %ezpublish.search.slot.trash.class%
+        tags:
+            - {name: ezpublish.search.slot, signal: TrashService\TrashSignal}
+
+    ezpublish.search.slot.recover:
+        parent: ezpublish.search.slot
+        class: %ezpublish.search.slot.recover.class%
+        tags:
+            - {name: ezpublish.search.slot, signal: TrashService\RecoverSignal}
+
+    ezpublish.search.slot.hide_location:
+        parent: ezpublish.search.slot
+        class: %ezpublish.search.slot.hide_location.class%
+        tags:
+            - {name: ezpublish.search.slot, signal: LocationService\HideLocationSignal}
+
+    ezpublish.search.slot.unhide_location:
+        parent: ezpublish.search.slot
+        class: %ezpublish.search.slot.unhide_location.class%
+        tags:
+            - {name: ezpublish.search.slot, signal: LocationService\UnhideLocationSignal}
+
+    ezpublish.search.slot.set_content_state:
+        parent: ezpublish.search.slot
+        class: %ezpublish.search.slot.set_content_state.class%
+        tags:
+            - {name: ezpublish.search.slot, signal: ObjectStateService\SetContentStateSignal}


### PR DESCRIPTION
Another part of [EZP-25088](https://jira.ez.no/browse/EZP-25088)-related changes.

[Kernel PR #1704](https://github.com/ezsystems/ezpublish-kernel/pull/1704) moves search engines signal slot configuration to each search engine.
This PR implements it for Solr.