### PR TITLE
EZP-25088: Align with signal slot dispatcher changes introduced by the Kernel PR #1704

### DIFF
--- a/bundle/EzSystemsEzPlatformSolrSearchEngineBundle.php
+++ b/bundle/EzSystemsEzPlatformSolrSearchEngineBundle.php
@@ -18,7 +18,7 @@ use EzSystems\EzPlatformSolrSearchEngine\Container\Compiler\AggregateSortClauseV
 use EzSystems\EzPlatformSolrSearchEngine\Container\Compiler\EndpointRegistryPass;
 use eZ\Publish\Core\Base\Container\Compiler\Search\AggregateFieldValueMapperPass;
 use eZ\Publish\Core\Base\Container\Compiler\Search\FieldRegistryPass;
-use eZ\Publish\Core\Base\Container\Compiler\Search\SignalSlotPass;
+use eZ\Publish\Core\Base\Container\Compiler\Search\SearchEngineSignalSlotPass;
 
 class EzSystemsEzPlatformSolrSearchEngineBundle extends Bundle
 {
@@ -33,7 +33,7 @@ class EzSystemsEzPlatformSolrSearchEngineBundle extends Bundle
 
         $container->addCompilerPass(new AggregateFieldValueMapperPass());
         $container->addCompilerPass(new FieldRegistryPass());
-        $container->addCompilerPass(new SignalSlotPass());
+        $container->addCompilerPass(new SearchEngineSignalSlotPass('solr'));
     }
 
     public function getContainerExtension()

--- a/lib/Resources/config/container/solr/slots.yml
+++ b/lib/Resources/config/container/solr/slots.yml
@@ -1,130 +1,130 @@
 parameters:
-    ezpublish.search.slot.class: eZ\Publish\Core\Search\Common\Slot
-    ezpublish.search.slot.publish_version.class: eZ\Publish\Core\Search\Common\Slot\PublishVersion
-    ezpublish.search.slot.copy_content.class: eZ\Publish\Core\Search\Common\Slot\CopyContent
-    ezpublish.search.slot.delete_content.class: eZ\Publish\Core\Search\Common\Slot\DeleteContent
-    ezpublish.search.slot.delete_version.class: eZ\Publish\Core\Search\Common\Slot\DeleteVersion
-    ezpublish.search.slot.create_location.class: eZ\Publish\Core\Search\Common\Slot\CreateLocation
-    ezpublish.search.slot.update_location.class: eZ\Publish\Core\Search\Common\Slot\UpdateLocation
-    ezpublish.search.slot.delete_location.class: eZ\Publish\Core\Search\Common\Slot\DeleteLocation
-    ezpublish.search.slot.create_user.class: eZ\Publish\Core\Search\Common\Slot\CreateUser
-    ezpublish.search.slot.create_user_group.class: eZ\Publish\Core\Search\Common\Slot\CreateUserGroup
-    ezpublish.search.slot.move_user_group.class: eZ\Publish\Core\Search\Common\Slot\MoveUserGroup
-    ezpublish.search.slot.copy_subtree.class: eZ\Publish\Core\Search\Common\Slot\CopySubtree
-    ezpublish.search.slot.move_subtree.class: eZ\Publish\Core\Search\Common\Slot\MoveSubtree
-    ezpublish.search.slot.trash.class: eZ\Publish\Core\Search\Common\Slot\Trash
-    ezpublish.search.slot.recover.class: eZ\Publish\Core\Search\Common\Slot\Recover
-    ezpublish.search.slot.hide_location.class: eZ\Publish\Core\Search\Common\Slot\HideLocation
-    ezpublish.search.slot.unhide_location.class: eZ\Publish\Core\Search\Common\Slot\UnhideLocation
-    ezpublish.search.slot.set_content_state.class: eZ\Publish\Core\Search\Common\Slot\SetContentState
+    ezpublish.search.solr.slot.class: eZ\Publish\Core\Search\Common\Slot
+    ezpublish.search.solr.slot.publish_version.class: eZ\Publish\Core\Search\Common\Slot\PublishVersion
+    ezpublish.search.solr.slot.copy_content.class: eZ\Publish\Core\Search\Common\Slot\CopyContent
+    ezpublish.search.solr.slot.delete_content.class: eZ\Publish\Core\Search\Common\Slot\DeleteContent
+    ezpublish.search.solr.slot.delete_version.class: eZ\Publish\Core\Search\Common\Slot\DeleteVersion
+    ezpublish.search.solr.slot.create_location.class: eZ\Publish\Core\Search\Common\Slot\CreateLocation
+    ezpublish.search.solr.slot.update_location.class: eZ\Publish\Core\Search\Common\Slot\UpdateLocation
+    ezpublish.search.solr.slot.delete_location.class: eZ\Publish\Core\Search\Common\Slot\DeleteLocation
+    ezpublish.search.solr.slot.create_user.class: eZ\Publish\Core\Search\Common\Slot\CreateUser
+    ezpublish.search.solr.slot.create_user_group.class: eZ\Publish\Core\Search\Common\Slot\CreateUserGroup
+    ezpublish.search.solr.slot.move_user_group.class: eZ\Publish\Core\Search\Common\Slot\MoveUserGroup
+    ezpublish.search.solr.slot.copy_subtree.class: eZ\Publish\Core\Search\Common\Slot\CopySubtree
+    ezpublish.search.solr.slot.move_subtree.class: eZ\Publish\Core\Search\Common\Slot\MoveSubtree
+    ezpublish.search.solr.slot.trash.class: eZ\Publish\Core\Search\Common\Slot\Trash
+    ezpublish.search.solr.slot.recover.class: eZ\Publish\Core\Search\Common\Slot\Recover
+    ezpublish.search.solr.slot.hide_location.class: eZ\Publish\Core\Search\Common\Slot\HideLocation
+    ezpublish.search.solr.slot.unhide_location.class: eZ\Publish\Core\Search\Common\Slot\UnhideLocation
+    ezpublish.search.solr.slot.set_content_state.class: eZ\Publish\Core\Search\Common\Slot\SetContentState
 
 services:
-    ezpublish.search.slot:
-        class: %ezpublish.search.slot.class%
+    ezpublish.search.solr.slot:
+        class: %ezpublish.search.solr.slot.class%
         abstract: true
         arguments:
             - @ezpublish.api.inner_repository
             - @ezpublish.api.persistence_handler
             - @ezpublish.spi.search
 
-    ezpublish.search.slot.publish_version:
-        parent: ezpublish.search.slot
-        class: %ezpublish.search.slot.publish_version.class%
+    ezpublish.search.solr.slot.publish_version:
+        parent: ezpublish.search.solr.slot
+        class: %ezpublish.search.solr.slot.publish_version.class%
         tags:
-            - {name: ezpublish.search.slot, signal: ContentService\PublishVersionSignal}
+            - {name: ezpublish.search.solr.slot, signal: ContentService\PublishVersionSignal}
 
-    ezpublish.search.slot.copy_content:
-        parent: ezpublish.search.slot
-        class: %ezpublish.search.slot.copy_content.class%
+    ezpublish.search.solr.slot.copy_content:
+        parent: ezpublish.search.solr.slot
+        class: %ezpublish.search.solr.slot.copy_content.class%
         tags:
-            - {name: ezpublish.search.slot, signal: ContentService\CopyContentSignal}
+            - {name: ezpublish.search.solr.slot, signal: ContentService\CopyContentSignal}
 
-    ezpublish.search.slot.delete_content:
-        parent: ezpublish.search.slot
-        class: %ezpublish.search.slot.delete_content.class%
+    ezpublish.search.solr.slot.delete_content:
+        parent: ezpublish.search.solr.slot
+        class: %ezpublish.search.solr.slot.delete_content.class%
         tags:
-            - {name: ezpublish.search.slot, signal: ContentService\DeleteContentSignal}
+            - {name: ezpublish.search.solr.slot, signal: ContentService\DeleteContentSignal}
 
-    ezpublish.search.slot.delete_version:
-        parent: ezpublish.search.slot
-        class: %ezpublish.search.slot.delete_version.class%
+    ezpublish.search.solr.slot.delete_version:
+        parent: ezpublish.search.solr.slot
+        class: %ezpublish.search.solr.slot.delete_version.class%
         tags:
-            - {name: ezpublish.search.slot, signal: ContentService\DeleteVersionSignal}
+            - {name: ezpublish.search.solr.slot, signal: ContentService\DeleteVersionSignal}
 
-    ezpublish.search.slot.create_location:
-        parent: ezpublish.search.slot
-        class: %ezpublish.search.slot.create_location.class%
+    ezpublish.search.solr.slot.create_location:
+        parent: ezpublish.search.solr.slot
+        class: %ezpublish.search.solr.slot.create_location.class%
         tags:
-            - {name: ezpublish.search.slot, signal: LocationService\CreateLocationSignal}
+            - {name: ezpublish.search.solr.slot, signal: LocationService\CreateLocationSignal}
 
-    ezpublish.search.slot.update_location:
-        parent: ezpublish.search.slot
-        class: %ezpublish.search.slot.update_location.class%
+    ezpublish.search.solr.slot.update_location:
+        parent: ezpublish.search.solr.slot
+        class: %ezpublish.search.solr.slot.update_location.class%
         tags:
-            - {name: ezpublish.search.slot, signal: LocationService\UpdateLocationSignal}
+            - {name: ezpublish.search.solr.slot, signal: LocationService\UpdateLocationSignal}
 
-    ezpublish.search.slot.delete_location:
-        parent: ezpublish.search.slot
-        class: %ezpublish.search.slot.delete_location.class%
+    ezpublish.search.solr.slot.delete_location:
+        parent: ezpublish.search.solr.slot
+        class: %ezpublish.search.solr.slot.delete_location.class%
         tags:
-            - {name: ezpublish.search.slot, signal: LocationService\DeleteLocationSignal}
+            - {name: ezpublish.search.solr.slot, signal: LocationService\DeleteLocationSignal}
 
-    ezpublish.search.slot.create_user:
-        parent: ezpublish.search.slot
-        class: %ezpublish.search.slot.create_user.class%
+    ezpublish.search.solr.slot.create_user:
+        parent: ezpublish.search.solr.slot
+        class: %ezpublish.search.solr.slot.create_user.class%
         tags:
-            - {name: ezpublish.search.slot, signal: UserService\CreateUserSignal}
+            - {name: ezpublish.search.solr.slot, signal: UserService\CreateUserSignal}
 
-    ezpublish.search.slot.create_user_group:
-        parent: ezpublish.search.slot
-        class: %ezpublish.search.slot.create_user_group.class%
+    ezpublish.search.solr.slot.create_user_group:
+        parent: ezpublish.search.solr.slot
+        class: %ezpublish.search.solr.slot.create_user_group.class%
         tags:
-            - {name: ezpublish.search.slot, signal: UserService\CreateUserGroupSignal}
+            - {name: ezpublish.search.solr.slot, signal: UserService\CreateUserGroupSignal}
 
-    ezpublish.search.slot.move_user_group:
-        parent: ezpublish.search.slot
-        class: %ezpublish.search.slot.move_user_group.class%
+    ezpublish.search.solr.slot.move_user_group:
+        parent: ezpublish.search.solr.slot
+        class: %ezpublish.search.solr.slot.move_user_group.class%
         tags:
-            - {name: ezpublish.search.slot, signal: UserService\MoveUserGroupSignal}
+            - {name: ezpublish.search.solr.slot, signal: UserService\MoveUserGroupSignal}
 
-    ezpublish.search.slot.copy_subtree:
-        parent: ezpublish.search.slot
-        class: %ezpublish.search.slot.copy_subtree.class%
+    ezpublish.search.solr.slot.copy_subtree:
+        parent: ezpublish.search.solr.slot
+        class: %ezpublish.search.solr.slot.copy_subtree.class%
         tags:
-            - {name: ezpublish.search.slot, signal: LocationService\CopySubtreeSignal}
+            - {name: ezpublish.search.solr.slot, signal: LocationService\CopySubtreeSignal}
 
-    ezpublish.search.slot.move_subtree:
-        parent: ezpublish.search.slot
-        class: %ezpublish.search.slot.move_subtree.class%
+    ezpublish.search.solr.slot.move_subtree:
+        parent: ezpublish.search.solr.slot
+        class: %ezpublish.search.solr.slot.move_subtree.class%
         tags:
-            - {name: ezpublish.search.slot, signal: LocationService\MoveSubtreeSignal}
+            - {name: ezpublish.search.solr.slot, signal: LocationService\MoveSubtreeSignal}
 
-    ezpublish.search.slot.trash:
-        parent: ezpublish.search.slot
-        class: %ezpublish.search.slot.trash.class%
+    ezpublish.search.solr.slot.trash:
+        parent: ezpublish.search.solr.slot
+        class: %ezpublish.search.solr.slot.trash.class%
         tags:
-            - {name: ezpublish.search.slot, signal: TrashService\TrashSignal}
+            - {name: ezpublish.search.solr.slot, signal: TrashService\TrashSignal}
 
-    ezpublish.search.slot.recover:
-        parent: ezpublish.search.slot
-        class: %ezpublish.search.slot.recover.class%
+    ezpublish.search.solr.slot.recover:
+        parent: ezpublish.search.solr.slot
+        class: %ezpublish.search.solr.slot.recover.class%
         tags:
-            - {name: ezpublish.search.slot, signal: TrashService\RecoverSignal}
+            - {name: ezpublish.search.solr.slot, signal: TrashService\RecoverSignal}
 
-    ezpublish.search.slot.hide_location:
-        parent: ezpublish.search.slot
-        class: %ezpublish.search.slot.hide_location.class%
+    ezpublish.search.solr.slot.hide_location:
+        parent: ezpublish.search.solr.slot
+        class: %ezpublish.search.solr.slot.hide_location.class%
         tags:
-            - {name: ezpublish.search.slot, signal: LocationService\HideLocationSignal}
+            - {name: ezpublish.search.solr.slot, signal: LocationService\HideLocationSignal}
 
-    ezpublish.search.slot.unhide_location:
-        parent: ezpublish.search.slot
-        class: %ezpublish.search.slot.unhide_location.class%
+    ezpublish.search.solr.slot.unhide_location:
+        parent: ezpublish.search.solr.slot
+        class: %ezpublish.search.solr.slot.unhide_location.class%
         tags:
-            - {name: ezpublish.search.slot, signal: LocationService\UnhideLocationSignal}
+            - {name: ezpublish.search.solr.slot, signal: LocationService\UnhideLocationSignal}
 
-    ezpublish.search.slot.set_content_state:
-        parent: ezpublish.search.slot
-        class: %ezpublish.search.slot.set_content_state.class%
+    ezpublish.search.solr.slot.set_content_state:
+        parent: ezpublish.search.solr.slot
+        class: %ezpublish.search.solr.slot.set_content_state.class%
         tags:
-            - {name: ezpublish.search.slot, signal: ObjectStateService\SetContentStateSignal}
+            - {name: ezpublish.search.solr.slot, signal: ObjectStateService\SetContentStateSignal}

--- a/tests/lib/Resources/config/common.yml
+++ b/tests/lib/Resources/config/common.yml
@@ -1,0 +1,9 @@
+parameters:
+    ezpublish.signalslot.signal_dispatcher.factory.class: eZ\Publish\Core\Base\Container\ApiLoader\SignalSlot\SignalDispatcherFactory
+
+services:
+    ezpublish.signalslot.signal_dispatcher.factory:
+        class: %ezpublish.signalslot.signal_dispatcher.factory.class%
+        arguments:
+            - "%ezpublish.signalslot.signal_dispatcher.class%"
+            - "solr"

--- a/tests/lib/Resources/config/multicore_dedicated.yml
+++ b/tests/lib/Resources/config/multicore_dedicated.yml
@@ -1,3 +1,6 @@
+imports:
+    - {resource: common.yml}
+
 parameters:
     # Redefining default field type classes with the implementation that defines the type
     # as searchable. Needed in order to test searching wiht Solr engine.

--- a/tests/lib/Resources/config/multicore_shared.yml
+++ b/tests/lib/Resources/config/multicore_shared.yml
@@ -1,3 +1,6 @@
+imports:
+    - {resource: common.yml}
+
 parameters:
     # Redefining default field type classes with the implementation that defines the type
     # as searchable. Needed in order to test searching wiht Solr engine.

--- a/tests/lib/Resources/config/single_core.yml
+++ b/tests/lib/Resources/config/single_core.yml
@@ -1,3 +1,6 @@
+imports:
+    - {resource: common.yml}
+
 parameters:
     # Redefining default field type classes with the implementation that defines the type
     # as searchable. Needed in order to test searching wiht Solr engine.

--- a/tests/lib/SetupFactory/LegacySetupFactory.php
+++ b/tests/lib/SetupFactory/LegacySetupFactory.php
@@ -88,7 +88,7 @@ class LegacySetupFactory extends CoreLegacySetupFactory
             $containerBuilder->addCompilerPass(new Compiler\EndpointRegistryPass());
             $containerBuilder->addCompilerPass(new BaseCompiler\Search\AggregateFieldValueMapperPass());
             $containerBuilder->addCompilerPass(new BaseCompiler\Search\FieldRegistryPass());
-            $containerBuilder->addCompilerPass(new BaseCompiler\Search\SignalSlotPass());
+            $containerBuilder->addCompilerPass(new BaseCompiler\Search\SearchEngineSignalSlotPass('solr'));
 
             $this->externalBuildContainer($containerBuilder);
 


### PR DESCRIPTION
This PR aligns with changes introduced in the [Kernel PR #1704](https://github.com/ezsystems/ezpublish-kernel/pull/1704), related to the JIRA issue [EZP-25088](https://jira.ez.no/browse/EZP-25088).

**Goal**: properly separate Solr search engine signal slots. Separating configuration is not enough as service names are overridden in case all search engine bundles are loaded in `AppKernel`

**Changes**:
- [x] Use new `eZ\Publish\Core\Base\Container\Compiler\Search\SearchEngineSignalSlotPass` with proper search engine alias instead of `eZ\Publish\Core\Base\Container\Compiler\Search\SignalSlotPass`
- [x] Rename signal slots to be specific to Solr search engine
- [x] Use `SignalDispatcherFactory` to attach proper search engine slots to signals.
- [x] Fix tests setup.