### PR TITLE
[WIP] EZP-26098: Implemented \eZ\Publish\SPI\Search\Indexing interface on Search Engine Handler

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,9 +9,15 @@
             "email": "dev-team@ez.no"
         }
     ],
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/alongosz/ezpublish-kernel"
+        }
+    ],
     "require": {
         "php": "~5.5|~7.0",
-        "ezsystems/ezpublish-kernel": "^6.5@dev"
+        "ezsystems/ezpublish-kernel": "dev-ezp-26098-create-search-index-in-handler"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.7",


### PR DESCRIPTION
Status: **WIP**.
Related to JIRA issue [EZP-26098](https://jira.ez.no/browse/EZP-26098).

This PR aligns with changes proposed in the [Kernel PR #1740](https://github.com/ezsystems/ezpublish-kernel/pull/1740).

It adds to Search Engine Handler full responsibility of (re)creating Solr search engine index.

**TODO**:
- [x] Implement ` \eZ\Publish\SPI\Search\Indexing` interface on Search Engine Handler.
- [ ] Wait for [Kernel PR #1740](https://github.com/ezsystems/ezpublish-kernel/pull/1740) to be merged (if we decide to go with this approach).