### PR TITLE
EZP-26123: Extract facets of all types

### DIFF
--- a/lib/ResultExtractor.php
+++ b/lib/ResultExtractor.php
@@ -50,11 +50,13 @@ abstract class ResultExtractor
         );
 
         if (isset($data->facet_counts)) {
-            foreach ($data->facet_counts->facet_fields as $field => $facet) {
-                $result->facets[] = $this->facetBuilderVisitor->map(
-                    $field,
-                    $facet
-                );
+            foreach ($data->facet_counts as $facetCounts) {
+                foreach ($facetCounts as $field => $facet) {
+                    $result->facets[] = $this->facetBuilderVisitor->map(
+                        $field,
+                        (array)$facet
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
This is https://github.com/ezsystems/ezplatform-solr-search-engine/pull/52 reopened against `1.0`branch
This PR resolves https://jira.ez.no/browse/EZP-26123

This change allows mapping any type of facets as they come in facet_counts:  "facet_queries", "facet_fields", "facet_dates", "facet_ranges"  "facet_intervals"
This would be implementor's responsibility to map it properly, as the data structure is different.

For now, this is tested with visitors processing facet_fields and facet_intervals, if it gets positive feedback I can test if it's fine for other cases. 