### PR TITLE
EZP-26128: Backport to 1.0 deprecation warning fixes

### DIFF
--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -6,8 +6,8 @@ services:
     ezpublish.solr.engine_factory:
         class: %ezpublish.solr.engine_factory.class%
         arguments:
-            - @ezpublish.api.repository_configuration_provider
+            - "@ezpublish.api.repository_configuration_provider"
             - %ez_search_engine_solr.default_connection%
             - %ezpublish.spi.search.solr.class%
         calls:
-            - [setContainer, [@service_container]]
+            - [setContainer, ["@service_container"]]

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -4,10 +4,10 @@ parameters:
 
 services:
     ezpublish.solr.engine_factory:
-        class: %ezpublish.solr.engine_factory.class%
+        class: "%ezpublish.solr.engine_factory.class%"
         arguments:
             - "@ezpublish.api.repository_configuration_provider"
-            - %ez_search_engine_solr.default_connection%
-            - %ezpublish.spi.search.solr.class%
+            - "%ez_search_engine_solr.default_connection%"
+            - "%ezpublish.spi.search.solr.class%"
         calls:
             - [setContainer, ["@service_container"]]

--- a/lib/Resources/config/container/solr.yml
+++ b/lib/Resources/config/container/solr.yml
@@ -23,21 +23,21 @@ parameters:
 
 services:
     ezpublish.search.solr.gateway.endpoint_registry:
-        class: %ezpublish.search.solr.gateway.endpoint_registry.class%
+        class: "%ezpublish.search.solr.gateway.endpoint_registry.class%"
 
     ezpublish.search.solr.gateway.endpoint_resolver.native:
-        class: %ezpublish.search.solr.gateway.endpoint_resolver.native.class%
+        class: "%ezpublish.search.solr.gateway.endpoint_resolver.native.class%"
         arguments:
-            - %ezpublish.search.solr.entry_endpoints%
-            - %ezpublish.search.solr.cluster_endpoints%
-            - %ezpublish.search.solr.default_endpoint%
-            - %ezpublish.search.solr.main_translations_endpoint%
+            - "%ezpublish.search.solr.entry_endpoints%"
+            - "%ezpublish.search.solr.cluster_endpoints%"
+            - "%ezpublish.search.solr.default_endpoint%"
+            - "%ezpublish.search.solr.main_translations_endpoint%"
 
     ezpublish.search.solr.gateway.endpoint_resolver:
         alias: ezpublish.search.solr.gateway.endpoint_resolver.native
 
     ezpublish.search.solr.core_filter.native:
-        class: %ezpublish.search.solr.core_filter.native.class%
+        class: "%ezpublish.search.solr.core_filter.native.class%"
         arguments:
             - "@ezpublish.search.solr.gateway.endpoint_resolver.native"
 
@@ -45,7 +45,7 @@ services:
         alias: ezpublish.search.solr.core_filter.native
 
     ezpublish.search.solr.document_mapper.native:
-        class: %ezpublish.search.solr.document_mapper.native.class%
+        class: "%ezpublish.search.solr.document_mapper.native.class%"
         arguments:
             - "@ezpublish.search.common.field_registry"
             - "@ezpublish.spi.persistence.content_handler"
@@ -59,7 +59,7 @@ services:
         alias: ezpublish.search.solr.document_mapper.native
 
     ezpublish.search.solr.result_extractor.native:
-        class: %ezpublish.search.solr.result_extractor.native.class%
+        class: "%ezpublish.search.solr.result_extractor.native.class%"
         arguments:
             - "@ezpublish.search.solr.query.content.facet_builder_visitor.aggregate"
 
@@ -67,21 +67,21 @@ services:
         alias: ezpublish.search.solr.result_extractor.native
 
     ezpublish.search.solr.query_converter.content:
-        class: %ezpublish.search.solr.query_converter.class%
+        class: "%ezpublish.search.solr.query_converter.class%"
         arguments:
             - "@ezpublish.search.solr.query.content.criterion_visitor.aggregate"
             - "@ezpublish.search.solr.query.content.sort_clause_visitor.aggregate"
             - "@ezpublish.search.solr.query.content.facet_builder_visitor.aggregate"
 
     ezpublish.search.solr.query_converter.location:
-        class: %ezpublish.search.solr.query_converter.class%
+        class: "%ezpublish.search.solr.query_converter.class%"
         arguments:
             - "@ezpublish.search.solr.query.location.criterion_visitor.aggregate"
             - "@ezpublish.search.solr.query.location.sort_clause_visitor.aggregate"
             - "@ezpublish.search.solr.query.location.facet_builder_visitor.aggregate"
 
     ezpublish.search.solr.gateway.native:
-        class: %ezpublish.search.solr.gateway.native.class%
+        class: "%ezpublish.search.solr.gateway.native.class%"
         arguments:
             - "@ezpublish.search.solr.gateway.client.http.stream"
             - "@ezpublish.search.solr.gateway.endpoint_resolver"
@@ -95,7 +95,7 @@ services:
         alias: ezpublish.search.solr.gateway.native
 
     ezpublish.spi.search.solr:
-        class: %ezpublish.spi.search.solr.class%
+        class: "%ezpublish.spi.search.solr.class%"
         arguments:
             - "@ezpublish.search.solr.gateway"
             - "@ezpublish.spi.persistence.content_handler"

--- a/lib/Resources/config/container/solr.yml
+++ b/lib/Resources/config/container/solr.yml
@@ -39,7 +39,7 @@ services:
     ezpublish.search.solr.core_filter.native:
         class: %ezpublish.search.solr.core_filter.native.class%
         arguments:
-            - @ezpublish.search.solr.gateway.endpoint_resolver.native
+            - "@ezpublish.search.solr.gateway.endpoint_resolver.native"
 
     ezpublish.search.solr.core_filter:
         alias: ezpublish.search.solr.core_filter.native
@@ -47,13 +47,13 @@ services:
     ezpublish.search.solr.document_mapper.native:
         class: %ezpublish.search.solr.document_mapper.native.class%
         arguments:
-            - @ezpublish.search.common.field_registry
-            - @ezpublish.spi.persistence.content_handler
-            - @ezpublish.spi.persistence.location_handler
-            - @ezpublish.spi.persistence.content_type_handler
-            - @ezpublish.spi.persistence.object_state_handler
-            - @ezpublish.spi.persistence.section_handler
-            - @ezpublish.search.common.field_name_generator
+            - "@ezpublish.search.common.field_registry"
+            - "@ezpublish.spi.persistence.content_handler"
+            - "@ezpublish.spi.persistence.location_handler"
+            - "@ezpublish.spi.persistence.content_type_handler"
+            - "@ezpublish.spi.persistence.object_state_handler"
+            - "@ezpublish.spi.persistence.section_handler"
+            - "@ezpublish.search.common.field_name_generator"
 
     ezpublish.search.solr.document_mapper:
         alias: ezpublish.search.solr.document_mapper.native
@@ -61,7 +61,7 @@ services:
     ezpublish.search.solr.result_extractor.native:
         class: %ezpublish.search.solr.result_extractor.native.class%
         arguments:
-            - @ezpublish.search.solr.query.content.facet_builder_visitor.aggregate
+            - "@ezpublish.search.solr.query.content.facet_builder_visitor.aggregate"
 
     ezpublish.search.solr.result_extractor:
         alias: ezpublish.search.solr.result_extractor.native
@@ -69,27 +69,27 @@ services:
     ezpublish.search.solr.query_converter.content:
         class: %ezpublish.search.solr.query_converter.class%
         arguments:
-            - @ezpublish.search.solr.query.content.criterion_visitor.aggregate
-            - @ezpublish.search.solr.query.content.sort_clause_visitor.aggregate
-            - @ezpublish.search.solr.query.content.facet_builder_visitor.aggregate
+            - "@ezpublish.search.solr.query.content.criterion_visitor.aggregate"
+            - "@ezpublish.search.solr.query.content.sort_clause_visitor.aggregate"
+            - "@ezpublish.search.solr.query.content.facet_builder_visitor.aggregate"
 
     ezpublish.search.solr.query_converter.location:
         class: %ezpublish.search.solr.query_converter.class%
         arguments:
-            - @ezpublish.search.solr.query.location.criterion_visitor.aggregate
-            - @ezpublish.search.solr.query.location.sort_clause_visitor.aggregate
-            - @ezpublish.search.solr.query.location.facet_builder_visitor.aggregate
+            - "@ezpublish.search.solr.query.location.criterion_visitor.aggregate"
+            - "@ezpublish.search.solr.query.location.sort_clause_visitor.aggregate"
+            - "@ezpublish.search.solr.query.location.facet_builder_visitor.aggregate"
 
     ezpublish.search.solr.gateway.native:
         class: %ezpublish.search.solr.gateway.native.class%
         arguments:
-            - @ezpublish.search.solr.gateway.client.http.stream
-            - @ezpublish.search.solr.gateway.endpoint_resolver
-            - @ezpublish.search.solr.gateway.endpoint_registry
-            - @ezpublish.search.solr.query_converter.content
-            - @ezpublish.search.solr.query_converter.location
-            - @ezpublish.search.solr.field_value_mapper.aggregate
-            - @ezpublish.search.common.field_name_generator
+            - "@ezpublish.search.solr.gateway.client.http.stream"
+            - "@ezpublish.search.solr.gateway.endpoint_resolver"
+            - "@ezpublish.search.solr.gateway.endpoint_registry"
+            - "@ezpublish.search.solr.query_converter.content"
+            - "@ezpublish.search.solr.query_converter.location"
+            - "@ezpublish.search.solr.field_value_mapper.aggregate"
+            - "@ezpublish.search.common.field_name_generator"
 
     ezpublish.search.solr.gateway:
         alias: ezpublish.search.solr.gateway.native
@@ -97,11 +97,11 @@ services:
     ezpublish.spi.search.solr:
         class: %ezpublish.spi.search.solr.class%
         arguments:
-            - @ezpublish.search.solr.gateway
-            - @ezpublish.spi.persistence.content_handler
-            - @ezpublish.search.solr.document_mapper
-            - @ezpublish.search.solr.result_extractor
-            - @ezpublish.search.solr.core_filter
+            - "@ezpublish.search.solr.gateway"
+            - "@ezpublish.spi.persistence.content_handler"
+            - "@ezpublish.search.solr.document_mapper"
+            - "@ezpublish.search.solr.result_extractor"
+            - "@ezpublish.search.solr.core_filter"
         tags:
             - {name: ezpublish.searchEngine, alias: solr}
         lazy: true

--- a/lib/Resources/config/container/solr/criterion_visitors.yml
+++ b/lib/Resources/config/container/solr/criterion_visitors.yml
@@ -125,7 +125,7 @@ services:
     ezpublish.search.solr.query.content.criterion_visitor.content_type_identifier_in:
         class: %ezpublish.search.solr.query.content.criterion_visitor.content_type_identifier_in.class%
         arguments:
-            - @ezpublish.spi.persistence.content_type_handler
+            - "@ezpublish.spi.persistence.content_type_handler"
         tags:
             - {name: ezpublish.search.solr.query.content.criterion_visitor}
 
@@ -192,7 +192,7 @@ services:
     ezpublish.search.solr.query.content.criterion_visitor.full_text:
         class: %ezpublish.search.solr.query.content.criterion_visitor.full_text.class%
         arguments:
-            - @ezpublish.search.common.field_name_resolver
+            - "@ezpublish.search.common.field_name_resolver"
         tags:
             - {name: ezpublish.search.solr.query.content.criterion_visitor}
 
@@ -204,7 +204,7 @@ services:
     ezpublish.search.solr.query.content.criterion_visitor.map_location_distance_in:
         class: %ezpublish.search.solr.query.content.criterion_visitor.map_location_distance_in.class%
         arguments:
-            - @ezpublish.search.common.field_name_resolver
+            - "@ezpublish.search.common.field_name_resolver"
             - 'ezgmaplocation'
             - 'value_location'
         tags:
@@ -213,7 +213,7 @@ services:
     ezpublish.search.solr.query.content.criterion_visitor.map_location_distance_range:
         class: %ezpublish.search.solr.query.content.criterion_visitor.map_location_distance_range.class%
         arguments:
-            - @ezpublish.search.common.field_name_resolver
+            - "@ezpublish.search.common.field_name_resolver"
             - 'ezgmaplocation'
             - 'value_location'
         tags:
@@ -222,24 +222,24 @@ services:
     ezpublish.search.solr.query.content.criterion_visitor.field_in:
         class: %ezpublish.search.solr.query.content.criterion_visitor.field_in.class%
         arguments:
-            - @ezpublish.search.common.field_name_resolver
-            - @ezpublish.search.solr.field_value_mapper.aggregate
+            - "@ezpublish.search.common.field_name_resolver"
+            - "@ezpublish.search.solr.field_value_mapper.aggregate"
         tags:
             - {name: ezpublish.search.solr.query.content.criterion_visitor}
 
     ezpublish.search.solr.query.content.criterion_visitor.field_relation:
         class: %ezpublish.search.solr.query.content.criterion_visitor.field_relation.class%
         arguments:
-            - @ezpublish.search.common.field_name_resolver
-            - @ezpublish.search.solr.field_value_mapper.aggregate
+            - "@ezpublish.search.common.field_name_resolver"
+            - "@ezpublish.search.solr.field_value_mapper.aggregate"
         tags:
             - {name: ezpublish.search.solr.query.content.criterion_visitor}
 
     ezpublish.search.solr.query.content.criterion_visitor.field_range:
         class: %ezpublish.search.solr.query.content.criterion_visitor.field_range.class%
         arguments:
-            - @ezpublish.search.common.field_name_resolver
-            - @ezpublish.search.solr.field_value_mapper.aggregate
+            - "@ezpublish.search.common.field_name_resolver"
+            - "@ezpublish.search.solr.field_value_mapper.aggregate"
         tags:
             - {name: ezpublish.search.solr.query.content.criterion_visitor}
 
@@ -282,7 +282,7 @@ services:
     ezpublish.search.solr.query.location.criterion_visitor.content_type_identifier_in:
         class: %ezpublish.search.solr.query.location.criterion_visitor.content_type_identifier_in.class%
         arguments:
-            - @ezpublish.spi.persistence.content_type_handler
+            - "@ezpublish.spi.persistence.content_type_handler"
         tags:
             - {name: ezpublish.search.solr.query.location.criterion_visitor}
 
@@ -386,23 +386,23 @@ services:
     ezpublish.search.solr.query.location.criterion_visitor.field_in:
         class: %ezpublish.search.solr.query.location.criterion_visitor.field_in.class%
         arguments:
-            - @ezpublish.search.common.field_name_resolver
-            - @ezpublish.search.solr.field_value_mapper.aggregate
+            - "@ezpublish.search.common.field_name_resolver"
+            - "@ezpublish.search.solr.field_value_mapper.aggregate"
         tags:
             - {name: ezpublish.search.solr.query.location.criterion_visitor}
 
     ezpublish.search.solr.query.location.criterion_visitor.field_range:
         class: %ezpublish.search.solr.query.location.criterion_visitor.field_range.class%
         arguments:
-            - @ezpublish.search.common.field_name_resolver
-            - @ezpublish.search.solr.field_value_mapper.aggregate
+            - "@ezpublish.search.common.field_name_resolver"
+            - "@ezpublish.search.solr.field_value_mapper.aggregate"
         tags:
             - {name: ezpublish.search.solr.query.location.criterion_visitor}
 
     ezpublish.search.solr.query.location.criterion_visitor.full_text:
         class: %ezpublish.search.solr.query.location.criterion_visitor.full_text.class%
         arguments:
-            - @ezpublish.search.common.field_name_resolver
+            - "@ezpublish.search.common.field_name_resolver"
         tags:
             - {name: ezpublish.search.solr.query.location.criterion_visitor}
 
@@ -419,7 +419,7 @@ services:
     ezpublish.search.solr.query.location.criterion_visitor.map_location_distance_range:
         class: %ezpublish.search.solr.query.location.criterion_visitor.map_location_distance_range.class%
         arguments:
-            - @ezpublish.search.common.field_name_resolver
+            - "@ezpublish.search.common.field_name_resolver"
             - 'ezgmaplocation'
             - 'value_location'
         tags:

--- a/lib/Resources/config/container/solr/criterion_visitors.yml
+++ b/lib/Resources/config/container/solr/criterion_visitors.yml
@@ -72,137 +72,137 @@ parameters:
 services:
     # Common for Content and Location search
     ezpublish.search.solr.query.common.criterion_visitor.match_all:
-        class: %ezpublish.search.solr.query.common.criterion_visitor.match_all.class%
+        class: "%ezpublish.search.solr.query.common.criterion_visitor.match_all.class%"
         tags:
             - {name: ezpublish.search.solr.query.content.criterion_visitor}
             - {name: ezpublish.search.solr.query.location.criterion_visitor}
 
     ezpublish.search.solr.query.common.criterion_visitor.match_none:
-        class: %ezpublish.search.solr.query.common.criterion_visitor.match_none.class%
+        class: "%ezpublish.search.solr.query.common.criterion_visitor.match_none.class%"
         tags:
             - {name: ezpublish.search.solr.query.content.criterion_visitor}
             - {name: ezpublish.search.solr.query.location.criterion_visitor}
 
     ezpublish.search.solr.query.common.criterion_visitor.logical_and:
-        class: %ezpublish.search.solr.query.common.criterion_visitor.logical_and.class%
+        class: "%ezpublish.search.solr.query.common.criterion_visitor.logical_and.class%"
         tags:
             - {name: ezpublish.search.solr.query.content.criterion_visitor}
             - {name: ezpublish.search.solr.query.location.criterion_visitor}
 
     ezpublish.search.solr.query.common.criterion_visitor.logical_or:
-        class: %ezpublish.search.solr.query.common.criterion_visitor.logical_or.class%
+        class: "%ezpublish.search.solr.query.common.criterion_visitor.logical_or.class%"
         tags:
             - {name: ezpublish.search.solr.query.content.criterion_visitor}
             - {name: ezpublish.search.solr.query.location.criterion_visitor}
 
     ezpublish.search.solr.query.common.criterion_visitor.logical_not:
-        class: %ezpublish.search.solr.query.common.criterion_visitor.logical_not.class%
+        class: "%ezpublish.search.solr.query.common.criterion_visitor.logical_not.class%"
         tags:
             - {name: ezpublish.search.solr.query.content.criterion_visitor}
             - {name: ezpublish.search.solr.query.location.criterion_visitor}
 
     # Content search
     ezpublish.search.solr.query.content.criterion_visitor.ancestor:
-        class: %ezpublish.search.solr.query.content.criterion_visitor.ancestor.class%
+        class: "%ezpublish.search.solr.query.content.criterion_visitor.ancestor.class%"
         tags:
             - {name: ezpublish.search.solr.query.content.criterion_visitor}
 
     ezpublish.search.solr.query.content.criterion_visitor.content_id_in:
-        class: %ezpublish.search.solr.query.content.criterion_visitor.content_id_in.class%
+        class: "%ezpublish.search.solr.query.content.criterion_visitor.content_id_in.class%"
         tags:
             - {name: ezpublish.search.solr.query.content.criterion_visitor}
 
     ezpublish.search.solr.query.content.criterion_visitor.subtree_in:
-        class: %ezpublish.search.solr.query.content.criterion_visitor.subtree_in.class%
+        class: "%ezpublish.search.solr.query.content.criterion_visitor.subtree_in.class%"
         tags:
             - {name: ezpublish.search.solr.query.content.criterion_visitor}
 
     ezpublish.search.solr.query.content.criterion_visitor.content_type_id_in:
-        class: %ezpublish.search.solr.query.content.criterion_visitor.content_type_id_in.class%
+        class: "%ezpublish.search.solr.query.content.criterion_visitor.content_type_id_in.class%"
         tags:
             - {name: ezpublish.search.solr.query.content.criterion_visitor}
 
     ezpublish.search.solr.query.content.criterion_visitor.content_type_identifier_in:
-        class: %ezpublish.search.solr.query.content.criterion_visitor.content_type_identifier_in.class%
+        class: "%ezpublish.search.solr.query.content.criterion_visitor.content_type_identifier_in.class%"
         arguments:
             - "@ezpublish.spi.persistence.content_type_handler"
         tags:
             - {name: ezpublish.search.solr.query.content.criterion_visitor}
 
     ezpublish.search.solr.query.content.criterion_visitor.content_type_group_id_in:
-        class: %ezpublish.search.solr.query.content.criterion_visitor.content_type_group_id_in.class%
+        class: "%ezpublish.search.solr.query.content.criterion_visitor.content_type_group_id_in.class%"
         tags:
             - {name: ezpublish.search.solr.query.content.criterion_visitor}
 
     ezpublish.search.solr.query.content.criterion_visitor.location_id_in:
-        class: %ezpublish.search.solr.query.content.criterion_visitor.location_id_in.class%
+        class: "%ezpublish.search.solr.query.content.criterion_visitor.location_id_in.class%"
         tags:
             - {name: ezpublish.search.solr.query.content.criterion_visitor}
 
     ezpublish.search.solr.query.content.criterion_visitor.parent_location_id_in:
-        class: %ezpublish.search.solr.query.content.criterion_visitor.parent_location_id_in.class%
+        class: "%ezpublish.search.solr.query.content.criterion_visitor.parent_location_id_in.class%"
         tags:
             - {name: ezpublish.search.solr.query.content.criterion_visitor}
 
     ezpublish.search.solr.query.content.criterion_visitor.section_in:
-        class: %ezpublish.search.solr.query.content.criterion_visitor.section_in.class%
+        class: "%ezpublish.search.solr.query.content.criterion_visitor.section_in.class%"
         tags:
             - {name: ezpublish.search.solr.query.content.criterion_visitor}
 
     ezpublish.search.solr.query.content.criterion_visitor.remote_id_in:
-        class: %ezpublish.search.solr.query.content.criterion_visitor.remote_id_in.class%
+        class: "%ezpublish.search.solr.query.content.criterion_visitor.remote_id_in.class%"
         tags:
             - {name: ezpublish.search.solr.query.content.criterion_visitor}
 
     ezpublish.search.solr.query.content.criterion_visitor.language_code_in:
-        class: %ezpublish.search.solr.query.content.criterion_visitor.language_code_in.class%
+        class: "%ezpublish.search.solr.query.content.criterion_visitor.language_code_in.class%"
         tags:
             - {name: ezpublish.search.solr.query.content.criterion_visitor}
 
     ezpublish.search.solr.query.content.criterion_visitor.object_state_id_in:
-        class: %ezpublish.search.solr.query.content.criterion_visitor.object_state_id_in.class%
+        class: "%ezpublish.search.solr.query.content.criterion_visitor.object_state_id_in.class%"
         tags:
             - {name: ezpublish.search.solr.query.content.criterion_visitor}
 
     ezpublish.search.solr.query.content.criterion_visitor.location_remote_id_in:
-        class: %ezpublish.search.solr.query.content.criterion_visitor.location_remote_id_in.class%
+        class: "%ezpublish.search.solr.query.content.criterion_visitor.location_remote_id_in.class%"
         tags:
             - {name: ezpublish.search.solr.query.content.criterion_visitor}
 
     ezpublish.search.solr.query.content.criterion_visitor.modified_in:
-        class: %ezpublish.search.solr.query.content.criterion_visitor.modified_in.class%
+        class: "%ezpublish.search.solr.query.content.criterion_visitor.modified_in.class%"
         tags:
             - {name: ezpublish.search.solr.query.content.criterion_visitor}
 
     ezpublish.search.solr.query.content.criterion_visitor.published_in:
-        class: %ezpublish.search.solr.query.content.criterion_visitor.published_in.class%
+        class: "%ezpublish.search.solr.query.content.criterion_visitor.published_in.class%"
         tags:
             - {name: ezpublish.search.solr.query.content.criterion_visitor}
 
     ezpublish.search.solr.query.content.criterion_visitor.modified_between:
-        class: %ezpublish.search.solr.query.content.criterion_visitor.modified_between.class%
+        class: "%ezpublish.search.solr.query.content.criterion_visitor.modified_between.class%"
         tags:
             - {name: ezpublish.search.solr.query.content.criterion_visitor}
 
     ezpublish.search.solr.query.content.criterion_visitor.published_between:
-        class: %ezpublish.search.solr.query.content.criterion_visitor.published_between.class%
+        class: "%ezpublish.search.solr.query.content.criterion_visitor.published_between.class%"
         tags:
             - {name: ezpublish.search.solr.query.content.criterion_visitor}
 
     ezpublish.search.solr.query.content.criterion_visitor.full_text:
-        class: %ezpublish.search.solr.query.content.criterion_visitor.full_text.class%
+        class: "%ezpublish.search.solr.query.content.criterion_visitor.full_text.class%"
         arguments:
             - "@ezpublish.search.common.field_name_resolver"
         tags:
             - {name: ezpublish.search.solr.query.content.criterion_visitor}
 
     ezpublish.search.solr.query.content.criterion_visitor.user_metadata_in:
-        class: %ezpublish.search.solr.query.content.criterion_visitor.user_metadata_in.class%
+        class: "%ezpublish.search.solr.query.content.criterion_visitor.user_metadata_in.class%"
         tags:
             - {name: ezpublish.search.solr.query.content.criterion_visitor}
 
     ezpublish.search.solr.query.content.criterion_visitor.map_location_distance_in:
-        class: %ezpublish.search.solr.query.content.criterion_visitor.map_location_distance_in.class%
+        class: "%ezpublish.search.solr.query.content.criterion_visitor.map_location_distance_in.class%"
         arguments:
             - "@ezpublish.search.common.field_name_resolver"
             - 'ezgmaplocation'
@@ -211,7 +211,7 @@ services:
             - {name: ezpublish.search.solr.query.content.criterion_visitor}
 
     ezpublish.search.solr.query.content.criterion_visitor.map_location_distance_range:
-        class: %ezpublish.search.solr.query.content.criterion_visitor.map_location_distance_range.class%
+        class: "%ezpublish.search.solr.query.content.criterion_visitor.map_location_distance_range.class%"
         arguments:
             - "@ezpublish.search.common.field_name_resolver"
             - 'ezgmaplocation'
@@ -220,7 +220,7 @@ services:
             - {name: ezpublish.search.solr.query.content.criterion_visitor}
 
     ezpublish.search.solr.query.content.criterion_visitor.field_in:
-        class: %ezpublish.search.solr.query.content.criterion_visitor.field_in.class%
+        class: "%ezpublish.search.solr.query.content.criterion_visitor.field_in.class%"
         arguments:
             - "@ezpublish.search.common.field_name_resolver"
             - "@ezpublish.search.solr.field_value_mapper.aggregate"
@@ -228,7 +228,7 @@ services:
             - {name: ezpublish.search.solr.query.content.criterion_visitor}
 
     ezpublish.search.solr.query.content.criterion_visitor.field_relation:
-        class: %ezpublish.search.solr.query.content.criterion_visitor.field_relation.class%
+        class: "%ezpublish.search.solr.query.content.criterion_visitor.field_relation.class%"
         arguments:
             - "@ezpublish.search.common.field_name_resolver"
             - "@ezpublish.search.solr.field_value_mapper.aggregate"
@@ -236,7 +236,7 @@ services:
             - {name: ezpublish.search.solr.query.content.criterion_visitor}
 
     ezpublish.search.solr.query.content.criterion_visitor.field_range:
-        class: %ezpublish.search.solr.query.content.criterion_visitor.field_range.class%
+        class: "%ezpublish.search.solr.query.content.criterion_visitor.field_range.class%"
         arguments:
             - "@ezpublish.search.common.field_name_resolver"
             - "@ezpublish.search.solr.field_value_mapper.aggregate"
@@ -244,147 +244,147 @@ services:
             - {name: ezpublish.search.solr.query.content.criterion_visitor}
 
     ezpublish.search.solr.query.content.criterion_visitor.visibility:
-        class: %ezpublish.search.solr.query.content.criterion_visitor.visibility.class%
+        class: "%ezpublish.search.solr.query.content.criterion_visitor.visibility.class%"
         tags:
             - {name: ezpublish.search.solr.query.content.criterion_visitor}
 
     ezpublish.search.solr.query.content.criterion_visitor.custom_field_in:
-        class: %ezpublish.search.solr.query.content.criterion_visitor.custom_field_in.class%
+        class: "%ezpublish.search.solr.query.content.criterion_visitor.custom_field_in.class%"
         tags:
             - {name: ezpublish.search.solr.query.content.criterion_visitor}
 
     ezpublish.search.solr.query.content.criterion_visitor.custom_field_range:
-        class: %ezpublish.search.solr.query.content.criterion_visitor.custom_field_range.class%
+        class: "%ezpublish.search.solr.query.content.criterion_visitor.custom_field_range.class%"
         tags:
             - {name: ezpublish.search.solr.query.content.criterion_visitor}
 
     # Location search
     ezpublish.search.solr.query.location.criterion_visitor.ancestor:
-        class: %ezpublish.search.solr.query.location.criterion_visitor.ancestor.class%
+        class: "%ezpublish.search.solr.query.location.criterion_visitor.ancestor.class%"
         tags:
             - {name: ezpublish.search.solr.query.location.criterion_visitor}
 
     ezpublish.search.solr.query.location.criterion_visitor.content_id_in:
-        class: %ezpublish.search.solr.query.location.criterion_visitor.content_id_in.class%
+        class: "%ezpublish.search.solr.query.location.criterion_visitor.content_id_in.class%"
         tags:
             - {name: ezpublish.search.solr.query.location.criterion_visitor}
 
     ezpublish.search.solr.query.location.criterion_visitor.subtree_in:
-        class: %ezpublish.search.solr.query.location.criterion_visitor.subtree_in.class%
+        class: "%ezpublish.search.solr.query.location.criterion_visitor.subtree_in.class%"
         tags:
             - {name: ezpublish.search.solr.query.location.criterion_visitor}
 
     ezpublish.search.solr.query.location.criterion_visitor.content_type_id_in:
-        class: %ezpublish.search.solr.query.location.criterion_visitor.content_type_id_in.class%
+        class: "%ezpublish.search.solr.query.location.criterion_visitor.content_type_id_in.class%"
         tags:
             - {name: ezpublish.search.solr.query.location.criterion_visitor}
 
     ezpublish.search.solr.query.location.criterion_visitor.content_type_identifier_in:
-        class: %ezpublish.search.solr.query.location.criterion_visitor.content_type_identifier_in.class%
+        class: "%ezpublish.search.solr.query.location.criterion_visitor.content_type_identifier_in.class%"
         arguments:
             - "@ezpublish.spi.persistence.content_type_handler"
         tags:
             - {name: ezpublish.search.solr.query.location.criterion_visitor}
 
     ezpublish.search.solr.query.location.criterion_visitor.content_type_group_id_in:
-        class: %ezpublish.search.solr.query.location.criterion_visitor.content_type_group_id_in.class%
+        class: "%ezpublish.search.solr.query.location.criterion_visitor.content_type_group_id_in.class%"
         tags:
             - {name: ezpublish.search.solr.query.location.criterion_visitor}
 
     ezpublish.search.solr.query.location.criterion_visitor.location_id_in:
-        class: %ezpublish.search.solr.query.location.criterion_visitor.location_id_in.class%
+        class: "%ezpublish.search.solr.query.location.criterion_visitor.location_id_in.class%"
         tags:
             - {name: ezpublish.search.solr.query.location.criterion_visitor}
 
     ezpublish.search.solr.query.location.criterion_visitor.parent_location_id_in:
-        class: %ezpublish.search.solr.query.location.criterion_visitor.parent_location_id_in.class%
+        class: "%ezpublish.search.solr.query.location.criterion_visitor.parent_location_id_in.class%"
         tags:
             - {name: ezpublish.search.solr.query.location.criterion_visitor}
 
     ezpublish.search.solr.query.location.criterion_visitor.section_in:
-        class: %ezpublish.search.solr.query.location.criterion_visitor.section_in.class%
+        class: "%ezpublish.search.solr.query.location.criterion_visitor.section_in.class%"
         tags:
             - {name: ezpublish.search.solr.query.location.criterion_visitor}
         tags:
             - {name: ezpublish.search.solr.query.content.criterion_visitor}
 
     ezpublish.search.solr.query.location.criterion_visitor.remote_id_in:
-        class: %ezpublish.search.solr.query.location.criterion_visitor.remote_id_in.class%
+        class: "%ezpublish.search.solr.query.location.criterion_visitor.remote_id_in.class%"
         tags:
             - {name: ezpublish.search.solr.query.location.criterion_visitor}
 
     ezpublish.search.solr.query.location.criterion_visitor.language_code_in:
-        class: %ezpublish.search.solr.query.location.criterion_visitor.language_code_in.class%
+        class: "%ezpublish.search.solr.query.location.criterion_visitor.language_code_in.class%"
         tags:
             - {name: ezpublish.search.solr.query.location.criterion_visitor}
 
     ezpublish.search.solr.query.location.criterion_visitor.object_state_id_in:
-        class: %ezpublish.search.solr.query.location.criterion_visitor.object_state_id_in.class%
+        class: "%ezpublish.search.solr.query.location.criterion_visitor.object_state_id_in.class%"
         tags:
             - {name: ezpublish.search.solr.query.location.criterion_visitor}
 
     ezpublish.search.solr.query.location.criterion_visitor.location_remote_id_in:
-        class: %ezpublish.search.solr.query.location.criterion_visitor.location_remote_id_in.class%
+        class: "%ezpublish.search.solr.query.location.criterion_visitor.location_remote_id_in.class%"
         tags:
             - {name: ezpublish.search.solr.query.location.criterion_visitor}
 
     ezpublish.search.solr.query.location.criterion_visitor.modified_in:
-        class: %ezpublish.search.solr.query.location.criterion_visitor.modified_in.class%
+        class: "%ezpublish.search.solr.query.location.criterion_visitor.modified_in.class%"
         tags:
             - {name: ezpublish.search.solr.query.location.criterion_visitor}
 
     ezpublish.search.solr.query.location.criterion_visitor.published_in:
-        class: %ezpublish.search.solr.query.location.criterion_visitor.published_in.class%
+        class: "%ezpublish.search.solr.query.location.criterion_visitor.published_in.class%"
         tags:
             - {name: ezpublish.search.solr.query.location.criterion_visitor}
 
     ezpublish.search.solr.query.location.criterion_visitor.modified_between:
-        class: %ezpublish.search.solr.query.location.criterion_visitor.modified_between.class%
+        class: "%ezpublish.search.solr.query.location.criterion_visitor.modified_between.class%"
         tags:
             - {name: ezpublish.search.solr.query.location.criterion_visitor}
 
     ezpublish.search.solr.query.location.criterion_visitor.published_between:
-        class: %ezpublish.search.solr.query.location.criterion_visitor.published_between.class%
+        class: "%ezpublish.search.solr.query.location.criterion_visitor.published_between.class%"
         tags:
             - {name: ezpublish.search.solr.query.location.criterion_visitor}
 
     ezpublish.search.solr.query.location.criterion_visitor.user_metadata_in:
-        class: %ezpublish.search.solr.query.location.criterion_visitor.user_metadata_in.class%
+        class: "%ezpublish.search.solr.query.location.criterion_visitor.user_metadata_in.class%"
         tags:
             - {name: ezpublish.search.solr.query.location.criterion_visitor}
 
     ezpublish.search.solr.query.location.criterion_visitor.visibility:
-        class: %ezpublish.search.solr.query.location.criterion_visitor.visibility.class%
+        class: "%ezpublish.search.solr.query.location.criterion_visitor.visibility.class%"
         tags:
             - {name: ezpublish.search.solr.query.location.criterion_visitor}
 
     ezpublish.search.solr.query.location.criterion_visitor.depth_in:
-        class: %ezpublish.search.solr.query.location.criterion_visitor.depth_in.class%
+        class: "%ezpublish.search.solr.query.location.criterion_visitor.depth_in.class%"
         tags:
             - {name: ezpublish.search.solr.query.location.criterion_visitor}
 
     ezpublish.search.solr.query.location.criterion_visitor.depth_between:
-        class: %ezpublish.search.solr.query.location.criterion_visitor.depth_between.class%
+        class: "%ezpublish.search.solr.query.location.criterion_visitor.depth_between.class%"
         tags:
             - {name: ezpublish.search.solr.query.location.criterion_visitor}
 
     ezpublish.search.solr.query.location.criterion_visitor.is_main_location:
-        class: %ezpublish.search.solr.query.location.criterion_visitor.is_main_location.class%
+        class: "%ezpublish.search.solr.query.location.criterion_visitor.is_main_location.class%"
         tags:
             - {name: ezpublish.search.solr.query.location.criterion_visitor}
 
     ezpublish.search.solr.query.location.criterion_visitor.priority_in:
-        class: %ezpublish.search.solr.query.location.criterion_visitor.priority_in.class%
+        class: "%ezpublish.search.solr.query.location.criterion_visitor.priority_in.class%"
         tags:
             - {name: ezpublish.search.solr.query.location.criterion_visitor}
 
     ezpublish.search.solr.query.location.criterion_visitor.priority_between:
-        class: %ezpublish.search.solr.query.location.criterion_visitor.priority_between.class%
+        class: "%ezpublish.search.solr.query.location.criterion_visitor.priority_between.class%"
         tags:
             - {name: ezpublish.search.solr.query.location.criterion_visitor}
 
     ezpublish.search.solr.query.location.criterion_visitor.field_in:
-        class: %ezpublish.search.solr.query.location.criterion_visitor.field_in.class%
+        class: "%ezpublish.search.solr.query.location.criterion_visitor.field_in.class%"
         arguments:
             - "@ezpublish.search.common.field_name_resolver"
             - "@ezpublish.search.solr.field_value_mapper.aggregate"
@@ -392,7 +392,7 @@ services:
             - {name: ezpublish.search.solr.query.location.criterion_visitor}
 
     ezpublish.search.solr.query.location.criterion_visitor.field_range:
-        class: %ezpublish.search.solr.query.location.criterion_visitor.field_range.class%
+        class: "%ezpublish.search.solr.query.location.criterion_visitor.field_range.class%"
         arguments:
             - "@ezpublish.search.common.field_name_resolver"
             - "@ezpublish.search.solr.field_value_mapper.aggregate"
@@ -400,24 +400,24 @@ services:
             - {name: ezpublish.search.solr.query.location.criterion_visitor}
 
     ezpublish.search.solr.query.location.criterion_visitor.full_text:
-        class: %ezpublish.search.solr.query.location.criterion_visitor.full_text.class%
+        class: "%ezpublish.search.solr.query.location.criterion_visitor.full_text.class%"
         arguments:
             - "@ezpublish.search.common.field_name_resolver"
         tags:
             - {name: ezpublish.search.solr.query.location.criterion_visitor}
 
     ezpublish.search.solr.query.location.criterion_visitor.custom_field_in:
-        class: %ezpublish.search.solr.query.location.criterion_visitor.custom_field_in.class%
+        class: "%ezpublish.search.solr.query.location.criterion_visitor.custom_field_in.class%"
         tags:
             - {name: ezpublish.search.solr.query.location.criterion_visitor}
 
     ezpublish.search.solr.query.location.criterion_visitor.custom_field_range:
-        class: %ezpublish.search.solr.query.location.criterion_visitor.custom_field_range.class%
+        class: "%ezpublish.search.solr.query.location.criterion_visitor.custom_field_range.class%"
         tags:
             - {name: ezpublish.search.solr.query.location.criterion_visitor}
 
     ezpublish.search.solr.query.location.criterion_visitor.map_location_distance_range:
-        class: %ezpublish.search.solr.query.location.criterion_visitor.map_location_distance_range.class%
+        class: "%ezpublish.search.solr.query.location.criterion_visitor.map_location_distance_range.class%"
         arguments:
             - "@ezpublish.search.common.field_name_resolver"
             - 'ezgmaplocation'

--- a/lib/Resources/config/container/solr/facet_builder_visitors.yml
+++ b/lib/Resources/config/container/solr/facet_builder_visitors.yml
@@ -5,16 +5,16 @@ parameters:
 
 services:
     ezpublish.search.solr.query.content.facet_builder_visitor.content_type:
-        class: %ezpublish.search.solr.query.content.facet_builder_visitor.content_type.class%
+        class: "%ezpublish.search.solr.query.content.facet_builder_visitor.content_type.class%"
         tags:
             - {name: ezpublish.search.solr.query.content.facet_builder_visitor}
 
     ezpublish.search.solr.query.content.facet_builder_visitor.section:
-        class: %ezpublish.search.solr.query.content.facet_builder_visitor.section.class%
+        class: "%ezpublish.search.solr.query.content.facet_builder_visitor.section.class%"
         tags:
             - {name: ezpublish.search.solr.query.content.facet_builder_visitor}
 
     ezpublish.search.solr.query.content.facet_builder_visitor.user:
-        class: %ezpublish.search.solr.query.content.facet_builder_visitor.user.class%
+        class: "%ezpublish.search.solr.query.content.facet_builder_visitor.user.class%"
         tags:
             - {name: ezpublish.search.solr.query.content.facet_builder_visitor}

--- a/lib/Resources/config/container/solr/field_value_mappers.yml
+++ b/lib/Resources/config/container/solr/field_value_mappers.yml
@@ -14,61 +14,61 @@ parameters:
 
 services:
     ezpublish.search.solr.field_value_mapper.identifier:
-        class: %ezpublish.search.solr.field_value_mapper.identifier.class%
+        class: "%ezpublish.search.solr.field_value_mapper.identifier.class%"
         tags:
             - {name: ezpublish.search.solr.field_value_mapper}
 
     ezpublish.search.solr.field_value_mapper.multiple_identifier:
-        class: %ezpublish.search.solr.field_value_mapper.multiple_identifier.class%
+        class: "%ezpublish.search.solr.field_value_mapper.multiple_identifier.class%"
         tags:
             - {name: ezpublish.search.solr.field_value_mapper}
 
     ezpublish.search.solr.field_value_mapper.string:
-        class: %ezpublish.search.solr.field_value_mapper.string.class%
+        class: "%ezpublish.search.solr.field_value_mapper.string.class%"
         tags:
             - {name: ezpublish.search.solr.field_value_mapper}
 
     ezpublish.search.solr.field_value_mapper.multiple_string:
-        class: %ezpublish.search.solr.field_value_mapper.multiple_string.class%
+        class: "%ezpublish.search.solr.field_value_mapper.multiple_string.class%"
         tags:
             - {name: ezpublish.search.solr.field_value_mapper}
 
     ezpublish.search.solr.field_value_mapper.integer:
-        class: %ezpublish.search.solr.field_value_mapper.integer.class%
+        class: "%ezpublish.search.solr.field_value_mapper.integer.class%"
         tags:
             - {name: ezpublish.search.solr.field_value_mapper}
 
     ezpublish.search.solr.field_value_mapper.multiple_integer:
-        class: %ezpublish.search.solr.field_value_mapper.multiple_integer.class%
+        class: "%ezpublish.search.solr.field_value_mapper.multiple_integer.class%"
         tags:
             - {name: ezpublish.search.solr.field_value_mapper}
 
     ezpublish.search.solr.field_value_mapper.float:
-        class: %ezpublish.search.solr.field_value_mapper.float.class%
+        class: "%ezpublish.search.solr.field_value_mapper.float.class%"
         tags:
             - {name: ezpublish.search.solr.field_value_mapper}
 
     ezpublish.search.solr.field_value_mapper.date:
-        class: %ezpublish.search.solr.field_value_mapper.date.class%
+        class: "%ezpublish.search.solr.field_value_mapper.date.class%"
         tags:
             - {name: ezpublish.search.solr.field_value_mapper}
 
     ezpublish.search.solr.field_value_mapper.price:
-        class: %ezpublish.search.solr.field_value_mapper.price.class%
+        class: "%ezpublish.search.solr.field_value_mapper.price.class%"
         tags:
             - {name: ezpublish.search.solr.field_value_mapper}
 
     ezpublish.search.solr.field_value_mapper.boolean:
-        class: %ezpublish.search.solr.field_value_mapper.boolean.class%
+        class: "%ezpublish.search.solr.field_value_mapper.boolean.class%"
         tags:
             - {name: ezpublish.search.solr.field_value_mapper}
 
     ezpublish.search.solr.field_value_mapper.multiple_boolean:
-        class: %ezpublish.search.solr.field_value_mapper.multiple_boolean.class%
+        class: "%ezpublish.search.solr.field_value_mapper.multiple_boolean.class%"
         tags:
             - {name: ezpublish.search.solr.field_value_mapper}
 
     ezpublish.search.solr.field_value_mapper.geo_location:
-        class: %ezpublish.search.solr.field_value_mapper.geo_location.class%
+        class: "%ezpublish.search.solr.field_value_mapper.geo_location.class%"
         tags:
             - {name: ezpublish.search.solr.field_value_mapper}

--- a/lib/Resources/config/container/solr/services.yml
+++ b/lib/Resources/config/container/solr/services.yml
@@ -7,39 +7,39 @@ parameters:
 
 services:
     ezpublish.search.solr.gateway.client.http.stream:
-        class: %ezpublish.search.solr.gateway.client.http.stream.class%
+        class: "%ezpublish.search.solr.gateway.client.http.stream.class%"
 
     # Note: services tagged with 'ezpublish.search.solr.query.content.criterion_visitor'
     # are registered to this one using compilation pass
     ezpublish.search.solr.query.content.criterion_visitor.aggregate:
-        class: %ezpublish.search.solr.query.common.criterion_visitor.aggregate.class%
+        class: "%ezpublish.search.solr.query.common.criterion_visitor.aggregate.class%"
 
     # Note: services tagged with 'ezpublish.search.solr.query.content.sort_clause_visitor'
     # are registered to this one using compilation pass
     ezpublish.search.solr.query.content.sort_clause_visitor.aggregate:
-        class: %ezpublish.search.solr.query.common.sort_clause_visitor.aggregate.class%
+        class: "%ezpublish.search.solr.query.common.sort_clause_visitor.aggregate.class%"
 
     # Note: services tagged with 'ezpublish.search.solr.query.content.facet_builder_visitor'
     # are registered to this one using compilation pass
     ezpublish.search.solr.query.content.facet_builder_visitor.aggregate:
-        class: %ezpublish.search.solr.query.common.facet_builder_visitor.aggregate.class%
+        class: "%ezpublish.search.solr.query.common.facet_builder_visitor.aggregate.class%"
 
     # Note: services tagged with 'ezpublish.search.solr.field_value_mapper'
     # are registered to this one using compilation pass
     ezpublish.search.solr.field_value_mapper.aggregate:
-        class: %ezpublish.search.solr.field_value_mapper.aggregate.class%
+        class: "%ezpublish.search.solr.field_value_mapper.aggregate.class%"
 
     # Note: services tagged with 'ezpublish.search.solr.query.location.criterion_visitor'
     # are registered to this one using compilation pass
     ezpublish.search.solr.query.location.criterion_visitor.aggregate:
-        class: %ezpublish.search.solr.query.common.criterion_visitor.aggregate.class%
+        class: "%ezpublish.search.solr.query.common.criterion_visitor.aggregate.class%"
 
     # Note: services tagged with 'ezpublish.search.solr.query.location.sort_clause_visitor'
     # are registered to this one using compilation pass
     ezpublish.search.solr.query.location.sort_clause_visitor.aggregate:
-        class: %ezpublish.search.solr.query.common.sort_clause_visitor.aggregate.class%
+        class: "%ezpublish.search.solr.query.common.sort_clause_visitor.aggregate.class%"
 
     # Note: services tagged with 'ezpublish.search.solr.query.location.facet_builder_visitor'
     # are registered to this one using compilation pass
     ezpublish.search.solr.query.location.facet_builder_visitor.aggregate:
-        class: %ezpublish.search.solr.query.common.facet_builder_visitor.aggregate.class%
+        class: "%ezpublish.search.solr.query.common.facet_builder_visitor.aggregate.class%"

--- a/lib/Resources/config/container/solr/sort_clause_visitors.yml
+++ b/lib/Resources/config/container/solr/sort_clause_visitors.yml
@@ -27,44 +27,44 @@ parameters:
 services:
     # Content search
     ezpublish.search.solr.query.content.sort_clause_visitor.content_id:
-        class: %ezpublish.search.solr.query.content.sort_clause_visitor.content_id.class%
+        class: "%ezpublish.search.solr.query.content.sort_clause_visitor.content_id.class%"
         tags:
             - {name: ezpublish.search.solr.query.content.sort_clause_visitor}
 
     ezpublish.search.solr.query.content.sort_clause_visitor.content_name:
-        class: %ezpublish.search.solr.query.content.sort_clause_visitor.content_name.class%
+        class: "%ezpublish.search.solr.query.content.sort_clause_visitor.content_name.class%"
         tags:
             - {name: ezpublish.search.solr.query.content.sort_clause_visitor}
 
     ezpublish.search.solr.query.content.sort_clause_visitor.field:
-        class: %ezpublish.search.solr.query.content.sort_clause_visitor.field.class%
+        class: "%ezpublish.search.solr.query.content.sort_clause_visitor.field.class%"
         arguments:
             - "@ezpublish.search.common.field_name_resolver"
         tags:
             - {name: ezpublish.search.solr.query.content.sort_clause_visitor}
 
     ezpublish.search.solr.query.content.sort_clause_visitor.section_identifier:
-        class: %ezpublish.search.solr.query.content.sort_clause_visitor.section_identifier.class%
+        class: "%ezpublish.search.solr.query.content.sort_clause_visitor.section_identifier.class%"
         tags:
             - {name: ezpublish.search.solr.query.content.sort_clause_visitor}
 
     ezpublish.search.solr.query.content.sort_clause_visitor.section_name:
-        class: %ezpublish.search.solr.query.content.sort_clause_visitor.section_name.class%
+        class: "%ezpublish.search.solr.query.content.sort_clause_visitor.section_name.class%"
         tags:
             - {name: ezpublish.search.solr.query.content.sort_clause_visitor}
 
     ezpublish.search.solr.query.content.sort_clause_visitor.date_published:
-        class: %ezpublish.search.solr.query.content.sort_clause_visitor.date_published.class%
+        class: "%ezpublish.search.solr.query.content.sort_clause_visitor.date_published.class%"
         tags:
             - {name: ezpublish.search.solr.query.content.sort_clause_visitor}
 
     ezpublish.search.solr.query.content.sort_clause_visitor.date_modified:
-        class: %ezpublish.search.solr.query.content.sort_clause_visitor.date_modified.class%
+        class: "%ezpublish.search.solr.query.content.sort_clause_visitor.date_modified.class%"
         tags:
             - {name: ezpublish.search.solr.query.content.sort_clause_visitor}
 
     ezpublish.search.solr.query.content.sort_clause_visitor.map_location_distance:
-        class: %ezpublish.search.solr.query.content.sort_clause_visitor.map_location_distance.class%
+        class: "%ezpublish.search.solr.query.content.sort_clause_visitor.map_location_distance.class%"
         arguments:
             - "@ezpublish.search.common.field_name_resolver"
             - 'value_location'
@@ -73,74 +73,74 @@ services:
 
     # Location search
     ezpublish.search.solr.query.location.sort_clause_visitor.content_id:
-        class: %ezpublish.search.solr.query.location.sort_clause_visitor.content_id.class%
+        class: "%ezpublish.search.solr.query.location.sort_clause_visitor.content_id.class%"
         tags:
             - {name: ezpublish.search.solr.query.location.sort_clause_visitor}
 
     ezpublish.search.solr.query.location.sort_clause_visitor.content_name:
-        class: %ezpublish.search.solr.query.location.sort_clause_visitor.content_name.class%
+        class: "%ezpublish.search.solr.query.location.sort_clause_visitor.content_name.class%"
         tags:
             - {name: ezpublish.search.solr.query.location.sort_clause_visitor}
 
     ezpublish.search.solr.query.location.sort_clause_visitor.date_published:
-        class: %ezpublish.search.solr.query.location.sort_clause_visitor.date_published.class%
+        class: "%ezpublish.search.solr.query.location.sort_clause_visitor.date_published.class%"
         tags:
             - {name: ezpublish.search.solr.query.location.sort_clause_visitor}
 
     ezpublish.search.solr.query.location.sort_clause_visitor.date_modified:
-        class: %ezpublish.search.solr.query.location.sort_clause_visitor.date_modified.class%
+        class: "%ezpublish.search.solr.query.location.sort_clause_visitor.date_modified.class%"
         tags:
             - {name: ezpublish.search.solr.query.location.sort_clause_visitor}
 
     ezpublish.search.solr.query.location.sort_clause_visitor.field:
-        class: %ezpublish.search.solr.query.location.sort_clause_visitor.field.class%
+        class: "%ezpublish.search.solr.query.location.sort_clause_visitor.field.class%"
         arguments:
             - "@ezpublish.search.common.field_name_resolver"
         tags:
             - {name: ezpublish.search.solr.query.location.sort_clause_visitor}
 
     ezpublish.search.solr.query.location.sort_clause_visitor.section_identifier:
-        class: %ezpublish.search.solr.query.location.sort_clause_visitor.section_identifier.class%
+        class: "%ezpublish.search.solr.query.location.sort_clause_visitor.section_identifier.class%"
         tags:
             - {name: ezpublish.search.solr.query.location.sort_clause_visitor}
 
     ezpublish.search.solr.query.location.sort_clause_visitor.section_name:
-        class: %ezpublish.search.solr.query.location.sort_clause_visitor.section_name.class%
+        class: "%ezpublish.search.solr.query.location.sort_clause_visitor.section_name.class%"
         tags:
             - {name: ezpublish.search.solr.query.location.sort_clause_visitor}
 
     ezpublish.search.solr.query.location.sort_clause_visitor.depth:
-        class: %ezpublish.search.solr.query.location.sort_clause_visitor.depth.class%
+        class: "%ezpublish.search.solr.query.location.sort_clause_visitor.depth.class%"
         tags:
             - {name: ezpublish.search.solr.query.location.sort_clause_visitor}
 
     ezpublish.search.solr.query.location.sort_clause_visitor.id:
-        class: %ezpublish.search.solr.query.location.sort_clause_visitor.id.class%
+        class: "%ezpublish.search.solr.query.location.sort_clause_visitor.id.class%"
         tags:
             - {name: ezpublish.search.solr.query.location.sort_clause_visitor}
 
     ezpublish.search.solr.query.location.sort_clause_visitor.is_main_location:
-        class: %ezpublish.search.solr.query.location.sort_clause_visitor.is_main_location.class%
+        class: "%ezpublish.search.solr.query.location.sort_clause_visitor.is_main_location.class%"
         tags:
             - {name: ezpublish.search.solr.query.location.sort_clause_visitor}
 
     ezpublish.search.solr.query.location.sort_clause_visitor.path:
-        class: %ezpublish.search.solr.query.location.sort_clause_visitor.path.class%
+        class: "%ezpublish.search.solr.query.location.sort_clause_visitor.path.class%"
         tags:
             - {name: ezpublish.search.solr.query.location.sort_clause_visitor}
 
     ezpublish.search.solr.query.location.sort_clause_visitor.priority:
-        class: %ezpublish.search.solr.query.location.sort_clause_visitor.priority.class%
+        class: "%ezpublish.search.solr.query.location.sort_clause_visitor.priority.class%"
         tags:
             - {name: ezpublish.search.solr.query.location.sort_clause_visitor}
 
     ezpublish.search.solr.query.location.sort_clause_visitor.visibility:
-        class: %ezpublish.search.solr.query.location.sort_clause_visitor.visibility.class%
+        class: "%ezpublish.search.solr.query.location.sort_clause_visitor.visibility.class%"
         tags:
             - {name: ezpublish.search.solr.query.location.sort_clause_visitor}
 
     ezpublish.search.solr.query.location.sort_clause_visitor.map_location_distance:
-        class: %ezpublish.search.solr.query.location.sort_clause_visitor.map_location_distance.class%
+        class: "%ezpublish.search.solr.query.location.sort_clause_visitor.map_location_distance.class%"
         arguments:
             - "@ezpublish.search.common.field_name_resolver"
             - 'value_location'

--- a/lib/Resources/config/container/solr/sort_clause_visitors.yml
+++ b/lib/Resources/config/container/solr/sort_clause_visitors.yml
@@ -39,7 +39,7 @@ services:
     ezpublish.search.solr.query.content.sort_clause_visitor.field:
         class: %ezpublish.search.solr.query.content.sort_clause_visitor.field.class%
         arguments:
-            - @ezpublish.search.common.field_name_resolver
+            - "@ezpublish.search.common.field_name_resolver"
         tags:
             - {name: ezpublish.search.solr.query.content.sort_clause_visitor}
 
@@ -66,7 +66,7 @@ services:
     ezpublish.search.solr.query.content.sort_clause_visitor.map_location_distance:
         class: %ezpublish.search.solr.query.content.sort_clause_visitor.map_location_distance.class%
         arguments:
-            - @ezpublish.search.common.field_name_resolver
+            - "@ezpublish.search.common.field_name_resolver"
             - 'value_location'
         tags:
             - {name: ezpublish.search.solr.query.content.sort_clause_visitor}
@@ -95,7 +95,7 @@ services:
     ezpublish.search.solr.query.location.sort_clause_visitor.field:
         class: %ezpublish.search.solr.query.location.sort_clause_visitor.field.class%
         arguments:
-            - @ezpublish.search.common.field_name_resolver
+            - "@ezpublish.search.common.field_name_resolver"
         tags:
             - {name: ezpublish.search.solr.query.location.sort_clause_visitor}
 
@@ -142,7 +142,7 @@ services:
     ezpublish.search.solr.query.location.sort_clause_visitor.map_location_distance:
         class: %ezpublish.search.solr.query.location.sort_clause_visitor.map_location_distance.class%
         arguments:
-            - @ezpublish.search.common.field_name_resolver
+            - "@ezpublish.search.common.field_name_resolver"
             - 'value_location'
         tags:
             - {name: ezpublish.search.solr.query.location.sort_clause_visitor}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,6 +5,9 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          syntaxCheck="true">
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
     <testsuites>
         <testsuite name="Solr search engine tests">
             <directory suffix="Test.php">./tests/</directory>

--- a/tests/lib/Resources/config/multicore_dedicated.yml
+++ b/tests/lib/Resources/config/multicore_dedicated.yml
@@ -27,13 +27,13 @@ parameters:
 
 services:
     ezpublish.cache_pool.spi.cache.decorator:
-        class: %ezpublish.cache_pool.spi.cache.decorator.class%
+        class: "%ezpublish.cache_pool.spi.cache.decorator.class%"
 
     ezpublish.spi.search_engine:
         alias: ezpublish.spi.search.solr
 
     ezpublish.search.solr.endpoint.endpoint0:
-        class: %ezpublish.solr.endpoint.class%
+        class: "%ezpublish.solr.endpoint.class%"
         arguments:
             -
                 scheme: http
@@ -45,7 +45,7 @@ services:
             - {name: ezpublish.search.solr.endpoint, alias: endpoint0}
 
     ezpublish.search.solr.endpoint.endpoint1:
-        class: %ezpublish.solr.endpoint.class%
+        class: "%ezpublish.solr.endpoint.class%"
         arguments:
             -
                 scheme: http
@@ -57,7 +57,7 @@ services:
             - {name: ezpublish.search.solr.endpoint, alias: endpoint1}
 
     ezpublish.search.solr.endpoint.endpoint2:
-        class: %ezpublish.solr.endpoint.class%
+        class: "%ezpublish.solr.endpoint.class%"
         arguments:
             -
                 scheme: http
@@ -69,7 +69,7 @@ services:
             - {name: ezpublish.search.solr.endpoint, alias: endpoint2}
 
     ezpublish.search.solr.endpoint.endpoint3:
-        class: %ezpublish.solr.endpoint.class%
+        class: "%ezpublish.solr.endpoint.class%"
         arguments:
             -
                 scheme: http

--- a/tests/lib/Resources/config/multicore_shared.yml
+++ b/tests/lib/Resources/config/multicore_shared.yml
@@ -24,13 +24,13 @@ parameters:
 
 services:
     ezpublish.cache_pool.spi.cache.decorator:
-        class: %ezpublish.cache_pool.spi.cache.decorator.class%
+        class: "%ezpublish.cache_pool.spi.cache.decorator.class%"
 
     ezpublish.spi.search_engine:
         alias: ezpublish.spi.search.solr
 
     ezpublish.search.solr.endpoint.endpoint0:
-        class: %ezpublish.solr.endpoint.class%
+        class: "%ezpublish.solr.endpoint.class%"
         arguments:
             -
                 scheme: http
@@ -42,7 +42,7 @@ services:
             - {name: ezpublish.search.solr.endpoint, alias: endpoint0}
 
     ezpublish.search.solr.endpoint.endpoint1:
-        class: %ezpublish.solr.endpoint.class%
+        class: "%ezpublish.solr.endpoint.class%"
         arguments:
             -
                 scheme: http
@@ -54,7 +54,7 @@ services:
             - {name: ezpublish.search.solr.endpoint, alias: endpoint1}
 
     ezpublish.search.solr.endpoint.endpoint2:
-        class: %ezpublish.solr.endpoint.class%
+        class: "%ezpublish.solr.endpoint.class%"
         arguments:
             -
                 scheme: http
@@ -66,7 +66,7 @@ services:
             - {name: ezpublish.search.solr.endpoint, alias: endpoint2}
 
     ezpublish.search.solr.endpoint.endpoint3:
-        class: %ezpublish.solr.endpoint.class%
+        class: "%ezpublish.solr.endpoint.class%"
         arguments:
             -
                 scheme: http

--- a/tests/lib/Resources/config/single_core.yml
+++ b/tests/lib/Resources/config/single_core.yml
@@ -23,13 +23,13 @@ parameters:
 
 services:
     ezpublish.cache_pool.spi.cache.decorator:
-        class: %ezpublish.cache_pool.spi.cache.decorator.class%
+        class: "%ezpublish.cache_pool.spi.cache.decorator.class%"
 
     ezpublish.spi.search_engine:
         alias: ezpublish.spi.search.solr
 
     ezpublish.search.solr.endpoint.endpoint0:
-        class: %ezpublish.solr.endpoint.class%
+        class: "%ezpublish.solr.endpoint.class%"
         arguments:
             -
                 scheme: http


### PR DESCRIPTION
This is a backport of #58 to 1.0 branch, resolving JIRA Story: [EZP-26128](https://jira.ez.no/browse/EZP-26128).

- [x] Make sure tests are run with full error reporting (afcfc5a).
- [x] Quote service references in Yaml files (b76c3db).
- [x] Quote parameter references in Yaml files (c0457cb).