### PR TITLE
[WIP] EZP-26098: Implement \eZ\Publish\SPI\Search\Indexing\ContentIndexing interface on Search Engine Handler

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,9 +9,15 @@
             "email": "dev-team@ez.no"
         }
     ],
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/alongosz/ezpublish-kernel"
+        }
+    ],
     "require": {
         "php": "~5.5|~7.0",
-        "ezsystems/ezpublish-kernel": "^6.5@dev"
+        "ezsystems/ezpublish-kernel": "dev-ezp-26098-generic-search-engine-indexing-command"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.7",

--- a/lib/Handler.php
+++ b/lib/Handler.php
@@ -5,8 +5,6 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- *
- * @version //autogentag//
  */
 namespace EzSystems\EzPlatformSolrSearchEngine;
 
@@ -19,6 +17,7 @@ use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\LocationQuery;
 use eZ\Publish\Core\Base\Exceptions\NotFoundException;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
+use eZ\Publish\SPI\Search\Indexing\ContentIndexing;
 
 /**
  * The Content Search handler retrieves sets of of Content objects, based on a
@@ -41,7 +40,7 @@ use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
  * content objects based on criteria, which could not be converted in to
  * database statements.
  */
-class Handler implements SearchHandlerInterface
+class Handler implements SearchHandlerInterface, ContentIndexing
 {
     /**
      * Content locator gateway.
@@ -318,6 +317,14 @@ class Handler implements SearchHandlerInterface
     public function commit($flush = false)
     {
         $this->gateway->commit($flush);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function commitIndex()
+    {
+        $this->gateway->commit(true);
     }
 
     /**


### PR DESCRIPTION
Status: **WIP**.
Related to JIRA issue [EZP-26098](https://jira.ez.no/browse/EZP-26098).

This PR aligns with changes proposed in the [Kernel PR #1738](https://github.com/ezsystems/ezpublish-kernel/pull/1738), implementing `\eZ\Publish\SPI\Search\Indexing\ContentIndexing` interface on the Solr Search Engine Handler. Please note that `LocationIndexing` should not be implemented as in case of Solr Locations are nested in a document representing content.

An alternative approach has been presented in the [Kernel PR #1740](https://github.com/ezsystems/ezpublish-kernel/pull/1740) and Solr PR #55.

**TODO**:
- [x] Implement ` \eZ\Publish\SPI\Search\Indexing\ContentIndexing` interface on Search Engine Handler.
- [ ] Wait for [Kernel PR #1738](https://github.com/ezsystems/ezpublish-kernel/pull/1738) to be merged (if we decide to go with this approach).