### PR TITLE
EZP-26219: Add missing Search Engine slots

### DIFF
--- a/lib/Resources/config/container/solr/slots.yml
+++ b/lib/Resources/config/container/solr/slots.yml
@@ -20,6 +20,7 @@ parameters:
     ezpublish.search.solr.slot.unhide_location.class: eZ\Publish\Core\Search\Common\Slot\UnhideLocation
     ezpublish.search.solr.slot.set_content_state.class: eZ\Publish\Core\Search\Common\Slot\SetContentState
     ezpublish.search.solr.slot.swap_location.class: eZ\Publish\Core\Search\Common\Slot\SwapLocation
+    ezpublish.search.solr.slot.update_content_metadata.class: eZ\Publish\Core\Search\Common\Slot\UpdateContentMetadata
 
 services:
     ezpublish.search.solr.slot:
@@ -149,3 +150,9 @@ services:
         class: "%ezpublish.search.solr.slot.swap_location.class%"
         tags:
             - {name: ezpublish.search.solr.slot, signal: LocationService\SwapLocationSignal}
+
+    ezpublish.search.solr.slot.update_content_metadata:
+        parent: ezpublish.search.solr.slot
+        class: "%ezpublish.search.solr.slot.update_content_metadata.class%"
+        tags:
+            - {name: ezpublish.search.solr.slot, signal: ContentService\UpdateContentMetadataSignal}

--- a/lib/Resources/config/container/solr/slots.yml
+++ b/lib/Resources/config/container/solr/slots.yml
@@ -21,6 +21,7 @@ parameters:
     ezpublish.search.solr.slot.set_content_state.class: eZ\Publish\Core\Search\Common\Slot\SetContentState
     ezpublish.search.solr.slot.swap_location.class: eZ\Publish\Core\Search\Common\Slot\SwapLocation
     ezpublish.search.solr.slot.update_content_metadata.class: eZ\Publish\Core\Search\Common\Slot\UpdateContentMetadata
+    ezpublish.search.solr.slot.assign_section.class: eZ\Publish\Core\Search\Common\Slot\AssignSection
 
 services:
     ezpublish.search.solr.slot:
@@ -156,3 +157,9 @@ services:
         class: "%ezpublish.search.solr.slot.update_content_metadata.class%"
         tags:
             - {name: ezpublish.search.solr.slot, signal: ContentService\UpdateContentMetadataSignal}
+
+    ezpublish.search.solr.slot.assign_section:
+        parent: ezpublish.search.solr.slot
+        class: "%ezpublish.search.solr.slot.assign_section.class%"
+        tags:
+            - {name: ezpublish.search.solr.slot, signal: SectionService\AssignSectionSignal}

--- a/lib/Resources/config/container/solr/slots.yml
+++ b/lib/Resources/config/container/solr/slots.yml
@@ -19,6 +19,7 @@ parameters:
     ezpublish.search.solr.slot.hide_location.class: eZ\Publish\Core\Search\Common\Slot\HideLocation
     ezpublish.search.solr.slot.unhide_location.class: eZ\Publish\Core\Search\Common\Slot\UnhideLocation
     ezpublish.search.solr.slot.set_content_state.class: eZ\Publish\Core\Search\Common\Slot\SetContentState
+    ezpublish.search.solr.slot.swap_location.class: eZ\Publish\Core\Search\Common\Slot\SwapLocation
 
 services:
     ezpublish.search.solr.slot:
@@ -142,3 +143,9 @@ services:
         class: "%ezpublish.search.solr.slot.set_content_state.class%"
         tags:
             - {name: ezpublish.search.solr.slot, signal: ObjectStateService\SetContentStateSignal}
+
+    ezpublish.search.solr.slot.swap_location:
+        parent: ezpublish.search.solr.slot
+        class: "%ezpublish.search.solr.slot.swap_location.class%"
+        tags:
+            - {name: ezpublish.search.solr.slot, signal: LocationService\SwapLocationSignal}


### PR DESCRIPTION
Status: **Ready for a review**
This PR aligns with Search Engine Slots introduced in the [Kernel PR #1776](https://github.com/ezsystems/ezpublish-kernel/pull/1776)

**TODO**:
- [x] Add `SwapLocation` Slot to Solr `slots.yml` configuration (21bcf25).
- [x] Add `UpdateContentMetadata` Slot to Solr `slots.yml` configuration (50da479).
- [x] Add `AssignSectionSignal` Slot to Solr `slots.yml` configuration (d1c3aef).
- [x] Wait for ~~the [Kernel PR #1776](https://github.com/ezsystems/ezpublish-kernel/pull/1776) to be merged~~ the new Slots to be merged into Kernel `dev-master`.