### PR TITLE
Fix EZP-26307: incorrect bulk_count results in index loop

### DIFF
--- a/bundle/Command/SolrCreateIndexCommand.php
+++ b/bundle/Command/SolrCreateIndexCommand.php
@@ -41,6 +41,9 @@ EOT
         $this->logger = $this->getContainer()->get('logger');
 
         $bulkCount = $input->getArgument('bulk_count');
+        if (!is_numeric($bulkCount) || (int)$bulkCount < 1) {
+            throw new RuntimeException("'bulk_count' argument should be > 0, got '{$bulkCount}'");
+        }
 
         /** @var \eZ\Publish\SPI\Search\Handler $searchHandler */
         $searchHandler = $this->getContainer()->get('ezpublish.spi.search');
@@ -85,7 +88,7 @@ EOT
         do {
             $contentObjects = array();
 
-            for ($k = 0; $k <= $bulkCount; ++$k) {
+            for ($k = 0; $k < $bulkCount; ++$k) {
                 if (!$row = $stmt->fetch(PDO::FETCH_ASSOC)) {
                     break;
                 }


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-26307

Problem: 
`bulk_count` parameter is cast to int without validation (converted to 0), while the loop would effectively index `$bulkCount+1` contents per run.
This would result in an infinite loop.

Fix by validating the parameter and indexing the correct number of contents.