### PR TITLE
EZP-26098: Implement Search Indexer Service

### DIFF
--- a/lib/Indexer.php
+++ b/lib/Indexer.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * This file is part of the eZ Platform Solr Search Engine package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformSolrSearchEngine;
+
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+use eZ\Publish\Core\Search\Common\Indexer as SearchIndexer;
+use EzSystems\EzPlatformSolrSearchEngine\Handler as SearchHandler;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Output\OutputInterface;
+use PDO;
+use RuntimeException;
+
+class Indexer extends SearchIndexer
+{
+    /**
+     * @var \EzSystems\EzPlatformSolrSearchEngine\Handler
+     */
+    protected $searchHandler;
+
+    /**
+     * Create search engine index.
+     *
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     * @param int $iterationCount
+     * @param bool $commit
+     */
+    public function createSearchIndex(OutputInterface $output, $iterationCount, $commit)
+    {
+        $output->writeln('Creating Solr Search Engine Index...');
+
+        if (!$this->searchHandler instanceof SearchHandler) {
+            throw new RuntimeException(sprintf('Expected to find an instance of %s, but found %s', SearchHandler::class, get_class($this->searchHandler)));
+        }
+
+        $stmt = $this->getContentDbFieldsStmt(['count(id)']);
+        $totalCount = intval($stmt->fetchColumn());
+        $stmt = $this->getContentDbFieldsStmt(['id', 'current_version']);
+
+        $this->searchHandler->purgeIndex();
+
+        $progress = new ProgressBar($output);
+        $progress->start($totalCount);
+
+        $i = 0;
+        do {
+            $contentObjects = [];
+            for ($k = 0; $k <= $iterationCount; ++$k) {
+                if (!$row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+                    break;
+                }
+                try {
+                    $contentObjects[] = $this->persistenceHandler->contentHandler()->load(
+                        $row['id'],
+                        $row['current_version']
+                    );
+                } catch (NotFoundException $e) {
+                    $this->logWarning($progress, "Could not load current version of Content with id ${row['id']}, so skipped for indexing. Full exception: " . $e->getMessage());
+                }
+            }
+
+            $documents = [];
+            foreach ($contentObjects as $content) {
+                try {
+                    $documents[] = $this->searchHandler->generateDocument($content);
+                } catch (NotFoundException $e) {
+                    // Ignore content objects that have some sort of missing data on it
+                    $this->logWarning($progress, 'Content with id ' . $content->versionInfo->id . ' has missing data, so skipped for indexing. Full exception: ' . $e->getMessage());
+                }
+            }
+            if (!empty($documents)) {
+                $this->searchHandler->bulkIndexDocuments($documents);
+            }
+
+            if ($commit) {
+                $this->searchHandler->commit();
+            }
+
+            $progress->advance($k);
+        } while (($i += $iterationCount) < $totalCount);
+        $progress->finish();
+        $output->writeln('');
+
+        $output->writeln('Finished creating Solr Search Engine Index');
+    }
+}

--- a/lib/Resources/config/container/solr.yml
+++ b/lib/Resources/config/container/solr.yml
@@ -8,6 +8,7 @@ imports:
 parameters:
     ezpublish.search.solr.connection.server: http://localhost:8983/solr/core0
     ezpublish.spi.search.solr.class: EzSystems\EzPlatformSolrSearchEngine\Handler
+    ezpublish.spi.search.solr.indexer.class: EzSystems\EzPlatformSolrSearchEngine\Indexer
     ezpublish.search.solr.gateway.native.class: EzSystems\EzPlatformSolrSearchEngine\Gateway\Native
     ezpublish.search.solr.gateway.endpoint_registry.class: EzSystems\EzPlatformSolrSearchEngine\Gateway\EndpointRegistry
     ezpublish.search.solr.gateway.endpoint_resolver.native.class: EzSystems\EzPlatformSolrSearchEngine\Gateway\EndpointResolver\NativeEndpointResolver
@@ -109,4 +110,15 @@ services:
             - "@ezpublish.search.solr.core_filter"
         tags:
             - {name: ezpublish.searchEngine, alias: solr}
+        lazy: true
+
+    ezpublish.spi.search.solr.indexer:
+        class: "%ezpublish.spi.search.solr.indexer.class%"
+        arguments:
+            - "@logger"
+            - "@ezpublish.api.storage_engine"
+            - "@ezpublish.api.storage_engine.legacy.dbhandler"
+            - "@ezpublish.spi.search.solr"
+        tags:
+            - {name: ezpublish.searchEngineIndexer, alias: solr}
         lazy: true

--- a/tests/lib/Resources/config/common.yml
+++ b/tests/lib/Resources/config/common.yml
@@ -7,3 +7,5 @@ services:
         arguments:
             - "%ezpublish.signalslot.signal_dispatcher.class%"
             - "solr"
+    logger:
+        class: Psr\Log\NullLogger


### PR DESCRIPTION
> Related to: [EZP-26098](https://jira.ez.no/browse/EZP-26098).

This PR aligns with the most recent approach presented in the [Kernel PR #1738](https://github.com/ezsystems/ezpublish-kernel/pull/1738) implementing Search Engine Indexer Service for Solr, based on current version of `\EzSystems\EzPlatformSolrSearchEngineBundle\Command\SolrCreateIndexCommand`.

**TODO**:
- [x] Implement Search Engine Indexer Service for Solr (7ddf875).
- [x] Wait for [Kernel PR #1738](https://github.com/ezsystems/ezpublish-kernel/pull/1738) to be merged.
