### PR TITLE
EZP-26668: Index fields though field mapper plugins

### DIFF
--- a/lib/DocumentMapper/NativeDocumentMapper.php
+++ b/lib/DocumentMapper/NativeDocumentMapper.php
@@ -550,68 +550,7 @@ class NativeDocumentMapper implements DocumentMapper
 
     protected function mapLocationFields(Location $location, Content $content, Section $section)
     {
-        $fields = array(
-            new Field(
-                'location',
-                $location->id,
-                new FieldType\IdentifierField()
-            ),
-            new Field(
-                'document_type',
-                self::DOCUMENT_TYPE_IDENTIFIER_LOCATION,
-                new FieldType\IdentifierField()
-            ),
-            new Field(
-                'priority',
-                $location->priority,
-                new FieldType\IntegerField()
-            ),
-            new Field(
-                'hidden',
-                $location->hidden,
-                new FieldType\BooleanField()
-            ),
-            new Field(
-                'invisible',
-                $location->invisible,
-                new FieldType\BooleanField()
-            ),
-            new Field(
-                'remote_id',
-                $location->remoteId,
-                new FieldType\IdentifierField()
-            ),
-            new Field(
-                'parent_id',
-                $location->parentId,
-                new FieldType\IdentifierField()
-            ),
-            new Field(
-                'path_string',
-                $location->pathString,
-                new FieldType\IdentifierField()
-            ),
-            new Field(
-                'depth',
-                $location->depth,
-                new FieldType\IntegerField()
-            ),
-            new Field(
-                'sort_field',
-                $location->sortField,
-                new FieldType\IdentifierField()
-            ),
-            new Field(
-                'sort_order',
-                $location->sortOrder,
-                new FieldType\IdentifierField()
-            ),
-            new Field(
-                'is_main_location',
-                ($location->id == $content->versionInfo->contentInfo->mainLocationId),
-                new FieldType\BooleanField()
-            ),
-        );
+        $fields = [];
 
         // UserGroups and Users are Content, but permissions cascade is achieved through
         // Locations hierarchy. We index all ancestor Location Content ids of all

--- a/lib/DocumentMapper/NativeDocumentMapper.php
+++ b/lib/DocumentMapper/NativeDocumentMapper.php
@@ -185,106 +185,7 @@ class NativeDocumentMapper implements DocumentMapper
             }
         }
 
-        // UserGroups and Users are Content, but permissions cascade is achieved through
-        // Locations hierarchy. We index all ancestor Location Content ids of all
-        // Locations of an owner.
-        $ancestorLocationsContentIds = $this->getAncestorLocationsContentIds(
-            $content->versionInfo->contentInfo->ownerId
-        );
-        // Add owner user id as it can also be considered as user group.
-        $ancestorLocationsContentIds[] = $content->versionInfo->contentInfo->ownerId;
-
         $fields = array(
-            new Field(
-                'content',
-                $content->versionInfo->contentInfo->id,
-                new FieldType\IdentifierField()
-            ),
-            new Field(
-                'document_type',
-                self::DOCUMENT_TYPE_IDENTIFIER_CONTENT,
-                new FieldType\IdentifierField()
-            ),
-            new Field(
-                'type',
-                $content->versionInfo->contentInfo->contentTypeId,
-                new FieldType\IdentifierField()
-            ),
-            new Field(
-                'version_no',
-                $content->versionInfo->versionNo,
-                new FieldType\IntegerField()
-            ),
-            new Field(
-                'status',
-                $content->versionInfo->status,
-                new FieldType\IdentifierField()
-            ),
-            new Field(
-                'name',
-                $content->versionInfo->contentInfo->name,
-                new FieldType\StringField()
-            ),
-            new Field(
-                'creator',
-                $content->versionInfo->creatorId,
-                new FieldType\IdentifierField()
-            ),
-            new Field(
-                'owner',
-                $content->versionInfo->contentInfo->ownerId,
-                new FieldType\IdentifierField()
-            ),
-            new Field(
-                'owner_user_group',
-                $ancestorLocationsContentIds,
-                new FieldType\MultipleIdentifierField()
-            ),
-            new Field(
-                'section',
-                $content->versionInfo->contentInfo->sectionId,
-                new FieldType\IdentifierField()
-            ),
-            new Field(
-                'section_identifier',
-                $section->identifier,
-                new FieldType\IdentifierField()
-            ),
-            new Field(
-                'section_name',
-                $section->name,
-                new FieldType\StringField()
-            ),
-            new Field(
-                'remote_id',
-                $content->versionInfo->contentInfo->remoteId,
-                new FieldType\IdentifierField()
-            ),
-            new Field(
-                'modified',
-                $content->versionInfo->contentInfo->modificationDate,
-                new FieldType\DateField()
-            ),
-            new Field(
-                'published',
-                $content->versionInfo->contentInfo->publicationDate,
-                new FieldType\DateField()
-            ),
-            new Field(
-                'language_code',
-                array_keys($content->versionInfo->names),
-                new FieldType\MultipleStringField()
-            ),
-            new Field(
-                'main_language_code',
-                $content->versionInfo->contentInfo->mainLanguageCode,
-                new FieldType\StringField()
-            ),
-            new Field(
-                'always_available',
-                $content->versionInfo->contentInfo->alwaysAvailable,
-                new FieldType\BooleanField()
-            ),
             new Field(
                 'location_visible',
                 $isSomeLocationVisible,
@@ -354,17 +255,6 @@ class NativeDocumentMapper implements DocumentMapper
         }
 
         $contentType = $this->contentTypeHandler->load($content->versionInfo->contentInfo->contentTypeId);
-        $fields[] = new Field(
-            'group',
-            $contentType->groupIds,
-            new FieldType\MultipleIdentifierField()
-        );
-
-        $fields[] = new Field(
-            'object_state',
-            $this->getObjectStateIds($content->versionInfo->contentInfo->id),
-            new FieldType\MultipleIdentifierField()
-        );
 
         $blockFields = $this->getBlockFields($content);
         $contentFields = $this->getContentFields($content);

--- a/lib/DocumentMapper/NativeDocumentMapper.php
+++ b/lib/DocumentMapper/NativeDocumentMapper.php
@@ -17,15 +17,11 @@ use EzSystems\EzPlatformSolrSearchEngine\DocumentMapper;
 use eZ\Publish\SPI\Persistence\Content;
 use eZ\Publish\SPI\Persistence\Content\Type as ContentType;
 use eZ\Publish\SPI\Persistence\Content\Location;
-use eZ\Publish\SPI\Persistence\Content\Section;
 use eZ\Publish\SPI\Search\Field;
 use eZ\Publish\SPI\Search\Document;
 use eZ\Publish\SPI\Search\FieldType;
-use eZ\Publish\SPI\Persistence\Content\Handler as ContentHandler;
 use eZ\Publish\SPI\Persistence\Content\Location\Handler as LocationHandler;
 use eZ\Publish\SPI\Persistence\Content\Type\Handler as ContentTypeHandler;
-use eZ\Publish\SPI\Persistence\Content\ObjectState\Handler as ObjectStateHandler;
-use eZ\Publish\SPI\Persistence\Content\Section\Handler as SectionHandler;
 use eZ\Publish\Core\Search\Common\FieldRegistry;
 use eZ\Publish\Core\Search\Common\FieldNameGenerator;
 
@@ -67,13 +63,6 @@ class NativeDocumentMapper implements DocumentMapper
     protected $fieldRegistry;
 
     /**
-     * Content handler.
-     *
-     * @var \eZ\Publish\SPI\Persistence\Content\Handler
-     */
-    protected $contentHandler;
-
-    /**
      * Location handler.
      *
      * @var \eZ\Publish\SPI\Persistence\Content\Location\Handler
@@ -86,20 +75,6 @@ class NativeDocumentMapper implements DocumentMapper
      * @var \eZ\Publish\SPI\Persistence\Content\Type\Handler
      */
     protected $contentTypeHandler;
-
-    /**
-     * Object state handler.
-     *
-     * @var \eZ\Publish\SPI\Persistence\Content\ObjectState\Handler
-     */
-    protected $objectStateHandler;
-
-    /**
-     * Section handler.
-     *
-     * @var \eZ\Publish\SPI\Persistence\Content\Section\Handler
-     */
-    protected $sectionHandler;
 
     /**
      * Field name generator.
@@ -117,11 +92,8 @@ class NativeDocumentMapper implements DocumentMapper
      * @param \EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentTranslationFieldMapper $contentTranslationFieldMapper
      * @param \EzSystems\EzPlatformSolrSearchEngine\FieldMapper\LocationFieldMapper $locationFieldMapper
      * @param \eZ\Publish\Core\Search\Common\FieldRegistry $fieldRegistry
-     * @param \eZ\Publish\SPI\Persistence\Content\Handler $contentHandler
      * @param \eZ\Publish\SPI\Persistence\Content\Location\Handler $locationHandler
      * @param \eZ\Publish\SPI\Persistence\Content\Type\Handler $contentTypeHandler
-     * @param \eZ\Publish\SPI\Persistence\Content\ObjectState\Handler $objectStateHandler
-     * @param \eZ\Publish\SPI\Persistence\Content\Section\Handler $sectionHandler
      * @param \eZ\Publish\Core\Search\Common\FieldNameGenerator $fieldNameGenerator
      */
     public function __construct(
@@ -131,11 +103,8 @@ class NativeDocumentMapper implements DocumentMapper
         ContentTranslationFieldMapper $contentTranslationFieldMapper,
         LocationFieldMapper $locationFieldMapper,
         FieldRegistry $fieldRegistry,
-        ContentHandler $contentHandler,
         LocationHandler $locationHandler,
         ContentTypeHandler $contentTypeHandler,
-        ObjectStateHandler $objectStateHandler,
-        SectionHandler $sectionHandler,
         FieldNameGenerator $fieldNameGenerator
     ) {
         $this->blockFieldMapper = $blockFieldMapper;
@@ -144,11 +113,8 @@ class NativeDocumentMapper implements DocumentMapper
         $this->contentTranslationFieldMapper = $contentTranslationFieldMapper;
         $this->locationFieldMapper = $locationFieldMapper;
         $this->fieldRegistry = $fieldRegistry;
-        $this->contentHandler = $contentHandler;
         $this->locationHandler = $locationHandler;
         $this->contentTypeHandler = $contentTypeHandler;
-        $this->objectStateHandler = $objectStateHandler;
-        $this->sectionHandler = $sectionHandler;
         $this->fieldNameGenerator = $fieldNameGenerator;
     }
 
@@ -162,13 +128,7 @@ class NativeDocumentMapper implements DocumentMapper
     public function mapContentBlock(Content $content)
     {
         $locations = $this->locationHandler->loadLocationsByContent($content->versionInfo->contentInfo->id);
-        $section = $this->sectionHandler->load($content->versionInfo->contentInfo->sectionId);
         $mainLocation = null;
-        $locationFields = array();
-
-        foreach ($locations as $location) {
-            $locationFields[$location->id] = $this->mapLocationFields($location, $content, $section);
-        }
 
         $contentType = $this->contentTypeHandler->load($content->versionInfo->contentInfo->contentTypeId);
 
@@ -214,7 +174,6 @@ class NativeDocumentMapper implements DocumentMapper
                     array(
                         'id' => $this->generateLocationDocumentId($location->id, $languageCode),
                         'fields' => array_merge(
-                            $locationFields[$location->id],
                             $translationFields['regular'],
                             $metaFields,
                             $blockFields,
@@ -351,171 +310,6 @@ class NativeDocumentMapper implements DocumentMapper
         }
 
         return $fieldSets;
-    }
-
-    protected function mapLocationFields(Location $location, Content $content, Section $section)
-    {
-        $fields = [];
-
-        // UserGroups and Users are Content, but permissions cascade is achieved through
-        // Locations hierarchy. We index all ancestor Location Content ids of all
-        // Locations of an owner.
-        $ancestorLocationsContentIds = $this->getAncestorLocationsContentIds(
-            $content->versionInfo->contentInfo->ownerId
-        );
-        // Add owner user id as it can also be considered as user group.
-        $ancestorLocationsContentIds[] = $content->versionInfo->contentInfo->ownerId;
-        $fields[] = new Field(
-            'content_owner_user_group',
-            $ancestorLocationsContentIds,
-            new FieldType\MultipleIdentifierField()
-        );
-
-        $fields[] = new Field(
-            'content_id',
-            $content->versionInfo->contentInfo->id,
-            new FieldType\IdentifierField()
-        );
-        $fields[] = new Field(
-            'content_type',
-            $content->versionInfo->contentInfo->contentTypeId,
-            new FieldType\IdentifierField()
-        );
-        $fields[] = new Field(
-            'content_version_no',
-            $content->versionInfo->versionNo,
-            new FieldType\IntegerField()
-        );
-        $fields[] = new Field(
-            'content_status',
-            $content->versionInfo->status,
-            new FieldType\IdentifierField()
-        );
-        $fields[] = new Field(
-            'content_name',
-            $content->versionInfo->contentInfo->name,
-            new FieldType\StringField()
-        );
-        $fields[] = new Field(
-            'content_creator',
-            $content->versionInfo->creatorId,
-            new FieldType\IdentifierField()
-        );
-        $fields[] = new Field(
-            'content_owner',
-            $content->versionInfo->contentInfo->ownerId,
-            new FieldType\IdentifierField()
-        );
-        $fields[] = new Field(
-            'content_section',
-            $content->versionInfo->contentInfo->sectionId,
-            new FieldType\IdentifierField()
-        );
-        $fields[] = new Field(
-            'content_section_identifier',
-            $section->identifier,
-            new FieldType\IdentifierField()
-        );
-        $fields[] = new Field(
-            'content_section_name',
-            $section->name,
-            new FieldType\StringField()
-        );
-        $fields[] = new Field(
-            'content_remote_id',
-            $content->versionInfo->contentInfo->remoteId,
-            new FieldType\IdentifierField()
-        );
-        $fields[] = new Field(
-            'content_modified',
-            $content->versionInfo->contentInfo->modificationDate,
-            new FieldType\DateField()
-        );
-        $fields[] = new Field(
-            'content_published',
-            $content->versionInfo->contentInfo->publicationDate,
-            new FieldType\DateField()
-        );
-        $fields[] = new Field(
-            'language_code',
-            array_keys($content->versionInfo->names),
-            new FieldType\MultipleStringField()
-        );
-        $fields[] = new Field(
-            'content_always_available',
-            $content->versionInfo->contentInfo->alwaysAvailable,
-            new FieldType\BooleanField()
-        );
-        $fields[] = new Field(
-            'content_group',
-            $this->contentTypeHandler->load(
-                $content->versionInfo->contentInfo->contentTypeId
-            )->groupIds,
-            new FieldType\MultipleIdentifierField()
-        );
-        $fields[] = new Field(
-            'content_object_state',
-            $this->getObjectStateIds($content->versionInfo->contentInfo->id),
-            new FieldType\MultipleIdentifierField()
-        );
-
-        return $fields;
-    }
-
-    /**
-     * Returns Content ids of all ancestor Locations of all Locations
-     * of a Content with given $contentId.
-     *
-     * Used to determine user groups of a user with $contentId.
-     *
-     * @param int|string $contentId
-     *
-     * @return array
-     */
-    protected function getAncestorLocationsContentIds($contentId)
-    {
-        $locations = $this->locationHandler->loadLocationsByContent($contentId);
-        $ancestorLocationContentIds = array();
-        $ancestorLocationIds = array();
-
-        foreach ($locations as $location) {
-            $locationIds = explode('/', trim($location->pathString, '/'));
-            // Remove Location of Content with $contentId
-            array_pop($locationIds);
-            // Remove Root Location id (id==1 in legacy DB)
-            array_shift($locationIds);
-
-            $ancestorLocationIds = array_merge($ancestorLocationIds, $locationIds);
-        }
-
-        foreach (array_unique($ancestorLocationIds) as $locationId) {
-            $location = $this->locationHandler->load($locationId);
-
-            $ancestorLocationContentIds[$location->contentId] = true;
-        }
-
-        return array_keys($ancestorLocationContentIds);
-    }
-
-    /**
-     * Returns an array of object state ids of a Content with given $contentId.
-     *
-     * @param int|string $contentId
-     *
-     * @return array
-     */
-    protected function getObjectStateIds($contentId)
-    {
-        $objectStateIds = array();
-
-        foreach ($this->objectStateHandler->loadAllGroups() as $objectStateGroup) {
-            $objectStateIds[] = $this->objectStateHandler->getContentState(
-                $contentId,
-                $objectStateGroup->id
-            )->id;
-        }
-
-        return $objectStateIds;
     }
 
     /**

--- a/lib/DocumentMapper/NativeDocumentMapper.php
+++ b/lib/DocumentMapper/NativeDocumentMapper.php
@@ -148,26 +148,6 @@ class NativeDocumentMapper implements DocumentMapper
                 $languageCode
             );
 
-            $metaFields = array();
-            $metaFields[] = new Field(
-                'meta_indexed_language_code',
-                $languageCode,
-                new FieldType\StringField()
-            );
-            $metaFields[] = new Field(
-                'meta_indexed_is_main_translation',
-                ($languageCode === $content->versionInfo->contentInfo->mainLanguageCode),
-                new FieldType\BooleanField()
-            );
-            $metaFields[] = new Field(
-                'meta_indexed_is_main_translation_and_always_available',
-                (
-                    ($languageCode === $content->versionInfo->contentInfo->mainLanguageCode) &&
-                    $content->versionInfo->contentInfo->alwaysAvailable
-                ),
-                new FieldType\BooleanField()
-            );
-
             $translationLocationDocuments = array();
             foreach ($locations as $location) {
                 $translationLocationDocuments[] = new Document(
@@ -175,7 +155,6 @@ class NativeDocumentMapper implements DocumentMapper
                         'id' => $this->generateLocationDocumentId($location->id, $languageCode),
                         'fields' => array_merge(
                             $translationFields['regular'],
-                            $metaFields,
                             $blockFields,
                             $locationFieldsMap[$location->id],
                             $blockTranslationFields
@@ -203,7 +182,6 @@ class NativeDocumentMapper implements DocumentMapper
                     'fields' => array_merge(
                         $translationFields['regular'],
                         $translationFields['fulltext'],
-                        $metaFields,
                         $blockFields,
                         $contentFields,
                         $blockTranslationFields,

--- a/lib/DocumentMapper/NativeDocumentMapper.php
+++ b/lib/DocumentMapper/NativeDocumentMapper.php
@@ -10,14 +10,14 @@
  */
 namespace EzSystems\EzPlatformSolrSearchEngine\DocumentMapper;
 
+use EzSystems\EzPlatformSolrSearchEngine\DocumentMapper;
 use EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentFieldMapper;
 use EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentTranslationFieldMapper;
 use EzSystems\EzPlatformSolrSearchEngine\FieldMapper\LocationFieldMapper;
-use EzSystems\EzPlatformSolrSearchEngine\DocumentMapper;
 use eZ\Publish\SPI\Persistence\Content;
 use eZ\Publish\SPI\Persistence\Content\Location;
-use eZ\Publish\SPI\Search\Document;
 use eZ\Publish\SPI\Persistence\Content\Location\Handler as LocationHandler;
+use eZ\Publish\SPI\Search\Document;
 
 /**
  * NativeDocumentMapper maps Solr backend documents per Content translation.
@@ -91,14 +91,13 @@ class NativeDocumentMapper implements DocumentMapper
      */
     public function mapContentBlock(Content $content)
     {
-        $locations = $this->locationHandler->loadLocationsByContent($content->versionInfo->contentInfo->id);
-        $mainLocation = null;
-
+        $contentInfo = $content->versionInfo->contentInfo;
+        $locations = $this->locationHandler->loadLocationsByContent($contentInfo->id);
         $blockFields = $this->getBlockFields($content);
         $contentFields = $this->getContentFields($content);
-        $documents = array();
-
+        $documents = [];
         $locationFieldsMap = [];
+
         foreach ($locations as $location) {
             $locationFieldsMap[$location->id] = $this->getLocationFields($location);
         }
@@ -123,8 +122,8 @@ class NativeDocumentMapper implements DocumentMapper
                 );
             }
 
-            $isMainTranslation = ($content->versionInfo->contentInfo->mainLanguageCode === $languageCode);
-            $alwaysAvailable = ($isMainTranslation && $content->versionInfo->contentInfo->alwaysAvailable);
+            $isMainTranslation = ($contentInfo->mainLanguageCode === $languageCode);
+            $alwaysAvailable = ($isMainTranslation && $contentInfo->alwaysAvailable);
             $contentTranslationFields = $this->getContentTranslationFields(
                 $content,
                 $languageCode
@@ -133,7 +132,7 @@ class NativeDocumentMapper implements DocumentMapper
             $documents[] = new Document(
                 array(
                     'id' => $this->generateContentDocumentId(
-                        $content->versionInfo->contentInfo->id,
+                        $contentInfo->id,
                         $languageCode
                     ),
                     'languageCode' => $languageCode,

--- a/lib/DocumentMapper/NativeDocumentMapper.php
+++ b/lib/DocumentMapper/NativeDocumentMapper.php
@@ -164,94 +164,10 @@ class NativeDocumentMapper implements DocumentMapper
         $locations = $this->locationHandler->loadLocationsByContent($content->versionInfo->contentInfo->id);
         $section = $this->sectionHandler->load($content->versionInfo->contentInfo->sectionId);
         $mainLocation = null;
-        $isSomeLocationVisible = false;
-        $locationData = array();
         $locationFields = array();
 
         foreach ($locations as $location) {
             $locationFields[$location->id] = $this->mapLocationFields($location, $content, $section);
-
-            $locationData['ids'][] = $location->id;
-            $locationData['parent_ids'][] = $location->parentId;
-            $locationData['remote_ids'][] = $location->remoteId;
-            $locationData['path_strings'][] = $location->pathString;
-
-            if ($location->id == $content->versionInfo->contentInfo->mainLocationId) {
-                $mainLocation = $location;
-            }
-
-            if (!$location->hidden && !$location->invisible) {
-                $isSomeLocationVisible = true;
-            }
-        }
-
-        $fields = array(
-            new Field(
-                'location_visible',
-                $isSomeLocationVisible,
-                new FieldType\BooleanField()
-            ),
-        );
-
-        if (!empty($locationData)) {
-            $fields[] = new Field(
-                'location_id',
-                $locationData['ids'],
-                new FieldType\MultipleIdentifierField()
-            );
-            $fields[] = new Field(
-                'location_parent_id',
-                $locationData['parent_ids'],
-                new FieldType\MultipleIdentifierField()
-            );
-            $fields[] = new Field(
-                'location_remote_id',
-                $locationData['remote_ids'],
-                new FieldType\MultipleIdentifierField()
-            );
-            $fields[] = new Field(
-                'location_path_string',
-                $locationData['path_strings'],
-                new FieldType\MultipleIdentifierField()
-            );
-        }
-
-        if ($mainLocation !== null) {
-            $fields[] = new Field(
-                'main_location',
-                $mainLocation->id,
-                new FieldType\IdentifierField()
-            );
-            $fields[] = new Field(
-                'main_location_parent',
-                $mainLocation->parentId,
-                new FieldType\IdentifierField()
-            );
-            $fields[] = new Field(
-                'main_location_remote_id',
-                $mainLocation->remoteId,
-                new FieldType\IdentifierField()
-            );
-            $fields[] = new Field(
-                'main_location_visible',
-                !$mainLocation->hidden && !$mainLocation->invisible,
-                new FieldType\BooleanField()
-            );
-            $fields[] = new Field(
-                'main_location_path',
-                $mainLocation->pathString,
-                new FieldType\IdentifierField()
-            );
-            $fields[] = new Field(
-                'main_location_depth',
-                $mainLocation->depth,
-                new FieldType\IntegerField()
-            );
-            $fields[] = new Field(
-                'main_location_priority',
-                $mainLocation->priority,
-                new FieldType\IntegerField()
-            );
         }
 
         $contentType = $this->contentTypeHandler->load($content->versionInfo->contentInfo->contentTypeId);
@@ -326,7 +242,6 @@ class NativeDocumentMapper implements DocumentMapper
                     'alwaysAvailable' => $alwaysAvailable,
                     'isMainTranslation' => $isMainTranslation,
                     'fields' => array_merge(
-                        $fields,
                         $translationFields['regular'],
                         $translationFields['fulltext'],
                         $metaFields,

--- a/lib/DocumentMapper/NativeDocumentMapper.php
+++ b/lib/DocumentMapper/NativeDocumentMapper.php
@@ -154,7 +154,6 @@ class NativeDocumentMapper implements DocumentMapper
                     array(
                         'id' => $this->generateLocationDocumentId($location->id, $languageCode),
                         'fields' => array_merge(
-                            $translationFields['regular'],
                             $blockFields,
                             $locationFieldsMap[$location->id],
                             $blockTranslationFields
@@ -180,7 +179,6 @@ class NativeDocumentMapper implements DocumentMapper
                     'alwaysAvailable' => $alwaysAvailable,
                     'isMainTranslation' => $isMainTranslation,
                     'fields' => array_merge(
-                        $translationFields['regular'],
                         $translationFields['fulltext'],
                         $blockFields,
                         $contentFields,
@@ -250,7 +248,6 @@ class NativeDocumentMapper implements DocumentMapper
         foreach ($content->fields as $field) {
             if (!isset($fieldSets[$field->languageCode])) {
                 $fieldSets[$field->languageCode] = array(
-                    'regular' => array(),
                     'fulltext' => array(),
                 );
             }
@@ -280,8 +277,6 @@ class NativeDocumentMapper implements DocumentMapper
 
                     if ($documentField->type instanceof FieldType\FullTextField) {
                         $fieldSets[$field->languageCode]['fulltext'][] = $documentField;
-                    } else {
-                        $fieldSets[$field->languageCode]['regular'][] = $documentField;
                     }
                 }
             }

--- a/lib/FieldMapper/ContentFieldMapper/ContentDocumentBaseFields.php
+++ b/lib/FieldMapper/ContentFieldMapper/ContentDocumentBaseFields.php
@@ -1,0 +1,246 @@
+<?php
+
+/**
+ * This file is part of the eZ Platform Solr Search Engine package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentFieldMapper;
+
+use EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentFieldMapper as BaseContentFieldMapper;
+use EzSystems\EzPlatformSolrSearchEngine\DocumentMapper;
+use eZ\Publish\SPI\Persistence\Content\Location\Handler as LocationHandler;
+use eZ\Publish\SPI\Persistence\Content\Type\Handler as ContentTypeHandler;
+use eZ\Publish\SPI\Persistence\Content\ObjectState\Handler as ObjectStateHandler;
+use eZ\Publish\SPI\Persistence\Content\Section\Handler as SectionHandler;
+use eZ\Publish\SPI\Persistence\Content;
+use eZ\Publish\SPI\Search\Field;
+use eZ\Publish\SPI\Search\FieldType;
+
+/**
+ * Maps base Content related fields to a Content document.
+ */
+class ContentDocumentBaseFields extends BaseContentFieldMapper
+{
+    /**
+     * @var \eZ\Publish\SPI\Persistence\Content\Location\Handler
+     */
+    protected $locationHandler;
+
+    /**
+     * @var \eZ\Publish\SPI\Persistence\Content\Type\Handler
+     */
+    protected $contentTypeHandler;
+
+    /**
+     * @var \eZ\Publish\SPI\Persistence\Content\ObjectState\Handler
+     */
+    protected $objectStateHandler;
+
+    /**
+     * @var \eZ\Publish\SPI\Persistence\Content\Section\Handler
+     */
+    protected $sectionHandler;
+
+    /**
+     * @param \eZ\Publish\SPI\Persistence\Content\Location\Handler $locationHandler
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\Handler $contentTypeHandler
+     * @param \eZ\Publish\SPI\Persistence\Content\ObjectState\Handler $objectStateHandler
+     * @param \eZ\Publish\SPI\Persistence\Content\Section\Handler $sectionHandler
+     */
+    public function __construct(
+        LocationHandler $locationHandler,
+        ContentTypeHandler $contentTypeHandler,
+        ObjectStateHandler $objectStateHandler,
+        SectionHandler $sectionHandler
+    ) {
+        $this->locationHandler = $locationHandler;
+        $this->contentTypeHandler = $contentTypeHandler;
+        $this->objectStateHandler = $objectStateHandler;
+        $this->sectionHandler = $sectionHandler;
+    }
+
+    public function accept(Content $content)
+    {
+        return true;
+    }
+
+    public function mapFields(Content $content)
+    {
+        $versionInfo = $content->versionInfo;
+        $contentInfo = $content->versionInfo->contentInfo;
+
+        // UserGroups and Users are Content, but permissions cascade is achieved through
+        // Locations hierarchy. We index all ancestor Location Content ids of all
+        // Locations of an owner.
+        $ancestorLocationsContentIds = $this->getAncestorLocationsContentIds(
+            $contentInfo->ownerId
+        );
+        // Add owner user id as it can also be considered as user group.
+        $ancestorLocationsContentIds[] = $contentInfo->ownerId;
+
+        $section = $this->sectionHandler->load($contentInfo->sectionId);
+
+        return [
+            new Field(
+                'content',
+                $contentInfo->id,
+                new FieldType\IdentifierField()
+            ),
+            new Field(
+                'document_type',
+                DocumentMapper::DOCUMENT_TYPE_IDENTIFIER_CONTENT,
+                new FieldType\IdentifierField()
+            ),
+            new Field(
+                'type',
+                $contentInfo->contentTypeId,
+                new FieldType\IdentifierField()
+            ),
+            new Field(
+                'version_no',
+                $versionInfo->versionNo,
+                new FieldType\IntegerField()
+            ),
+            new Field(
+                'status',
+                $versionInfo->status,
+                new FieldType\IdentifierField()
+            ),
+            new Field(
+                'name',
+                $contentInfo->name,
+                new FieldType\StringField()
+            ),
+            new Field(
+                'creator',
+                $versionInfo->creatorId,
+                new FieldType\IdentifierField()
+            ),
+            new Field(
+                'owner',
+                $contentInfo->ownerId,
+                new FieldType\IdentifierField()
+            ),
+            new Field(
+                'section',
+                $contentInfo->sectionId,
+                new FieldType\IdentifierField()
+            ),
+            new Field(
+                'remote_id',
+                $contentInfo->remoteId,
+                new FieldType\IdentifierField()
+            ),
+            new Field(
+                'modified',
+                $contentInfo->modificationDate,
+                new FieldType\DateField()
+            ),
+            new Field(
+                'published',
+                $contentInfo->publicationDate,
+                new FieldType\DateField()
+            ),
+            new Field(
+                'language_code',
+                array_keys($versionInfo->names),
+                new FieldType\MultipleStringField()
+            ),
+            new Field(
+                'main_language_code',
+                $contentInfo->mainLanguageCode,
+                new FieldType\StringField()
+            ),
+            new Field(
+                'always_available',
+                $contentInfo->alwaysAvailable,
+                new FieldType\BooleanField()
+            ),
+            new Field(
+                'owner_user_group',
+                $ancestorLocationsContentIds,
+                new FieldType\MultipleIdentifierField()
+            ),
+            new Field(
+                'section_identifier',
+                $section->identifier,
+                new FieldType\IdentifierField()
+            ),
+            new Field(
+                'section_name',
+                $section->name,
+                new FieldType\StringField()
+            ),
+            new Field(
+                'group',
+                $this->contentTypeHandler->load($contentInfo->contentTypeId)->groupIds,
+                new FieldType\MultipleIdentifierField()
+            ),
+            new Field(
+                'object_state',
+                $this->getObjectStateIds($contentInfo->id),
+                new FieldType\MultipleIdentifierField()
+            ),
+        ];
+    }
+
+    /**
+     * Returns an array of object state ids of a Content with given $contentId.
+     *
+     * @param int|string $contentId
+     *
+     * @return array
+     */
+    protected function getObjectStateIds($contentId)
+    {
+        $objectStateIds = array();
+
+        foreach ($this->objectStateHandler->loadAllGroups() as $objectStateGroup) {
+            $objectStateIds[] = $this->objectStateHandler->getContentState(
+                $contentId,
+                $objectStateGroup->id
+            )->id;
+        }
+
+        return $objectStateIds;
+    }
+
+    /**
+     * Returns Content ids of all ancestor Locations of all Locations
+     * of a Content with given $contentId.
+     *
+     * Used to determine user groups of a user with $contentId.
+     *
+     * @param int|string $contentId
+     *
+     * @return array
+     */
+    protected function getAncestorLocationsContentIds($contentId)
+    {
+        $locations = $this->locationHandler->loadLocationsByContent($contentId);
+        $ancestorLocationContentIds = array();
+        $ancestorLocationIds = array();
+
+        foreach ($locations as $location) {
+            $locationIds = explode('/', trim($location->pathString, '/'));
+            // Remove Location of Content with $contentId
+            array_pop($locationIds);
+            // Remove Root Location id (id==1 in legacy DB)
+            array_shift($locationIds);
+
+            $ancestorLocationIds = array_merge($ancestorLocationIds, $locationIds);
+        }
+
+        foreach (array_unique($ancestorLocationIds) as $locationId) {
+            $location = $this->locationHandler->load($locationId);
+
+            $ancestorLocationContentIds[$location->contentId] = true;
+        }
+
+        return array_keys($ancestorLocationContentIds);
+    }
+}

--- a/lib/FieldMapper/ContentFieldMapper/ContentDocumentBaseFields.php
+++ b/lib/FieldMapper/ContentFieldMapper/ContentDocumentBaseFields.php
@@ -5,25 +5,23 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- *
- * @version //autogentag//
  */
 namespace EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentFieldMapper;
 
-use EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentFieldMapper as BaseContentFieldMapper;
 use EzSystems\EzPlatformSolrSearchEngine\DocumentMapper;
+use EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentFieldMapper;
+use eZ\Publish\SPI\Persistence\Content;
 use eZ\Publish\SPI\Persistence\Content\Location\Handler as LocationHandler;
-use eZ\Publish\SPI\Persistence\Content\Type\Handler as ContentTypeHandler;
 use eZ\Publish\SPI\Persistence\Content\ObjectState\Handler as ObjectStateHandler;
 use eZ\Publish\SPI\Persistence\Content\Section\Handler as SectionHandler;
-use eZ\Publish\SPI\Persistence\Content;
+use eZ\Publish\SPI\Persistence\Content\Type\Handler as ContentTypeHandler;
 use eZ\Publish\SPI\Search\Field;
 use eZ\Publish\SPI\Search\FieldType;
 
 /**
  * Maps base Content related fields to a Content document.
  */
-class ContentDocumentBaseFields extends BaseContentFieldMapper
+class ContentDocumentBaseFields extends ContentFieldMapper
 {
     /**
      * @var \eZ\Publish\SPI\Persistence\Content\Location\Handler

--- a/lib/FieldMapper/ContentFieldMapper/ContentDocumentLocationFields.php
+++ b/lib/FieldMapper/ContentFieldMapper/ContentDocumentLocationFields.php
@@ -5,8 +5,6 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- *
- * @version //autogentag//
  */
 namespace EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentFieldMapper;
 

--- a/lib/FieldMapper/ContentFieldMapper/ContentDocumentLocationFields.php
+++ b/lib/FieldMapper/ContentFieldMapper/ContentDocumentLocationFields.php
@@ -10,7 +10,7 @@
  */
 namespace EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentFieldMapper;
 
-use EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentFieldMapper as BaseContentFieldMapper;
+use EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentFieldMapper;
 use eZ\Publish\SPI\Persistence\Content;
 use eZ\Publish\SPI\Persistence\Content\Location\Handler as LocationHandler;
 use eZ\Publish\SPI\Search\Field;
@@ -19,7 +19,7 @@ use eZ\Publish\SPI\Search\FieldType;
 /**
  * Maps Location related fields to a Content document.
  */
-class ContentDocumentLocationFields extends BaseContentFieldMapper
+class ContentDocumentLocationFields extends ContentFieldMapper
 {
     /**
      * @var \eZ\Publish\SPI\Persistence\Content\Location\Handler

--- a/lib/FieldMapper/ContentFieldMapper/ContentDocumentLocationFields.php
+++ b/lib/FieldMapper/ContentFieldMapper/ContentDocumentLocationFields.php
@@ -1,0 +1,134 @@
+<?php
+
+/**
+ * This file is part of the eZ Platform Solr Search Engine package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentFieldMapper;
+
+use EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentFieldMapper as BaseContentFieldMapper;
+use eZ\Publish\SPI\Persistence\Content;
+use eZ\Publish\SPI\Persistence\Content\Location\Handler as LocationHandler;
+use eZ\Publish\SPI\Search\Field;
+use eZ\Publish\SPI\Search\FieldType;
+
+/**
+ * Maps Location related fields to a Content document.
+ */
+class ContentDocumentLocationFields extends BaseContentFieldMapper
+{
+    /**
+     * @var \eZ\Publish\SPI\Persistence\Content\Location\Handler
+     */
+    protected $locationHandler;
+
+    /**
+     * @param \eZ\Publish\SPI\Persistence\Content\Location\Handler $locationHandler
+     */
+    public function __construct(LocationHandler $locationHandler)
+    {
+        $this->locationHandler = $locationHandler;
+    }
+
+    public function accept(Content $content)
+    {
+        return true;
+    }
+
+    public function mapFields(Content $content)
+    {
+        $locations = $this->locationHandler->loadLocationsByContent($content->versionInfo->contentInfo->id);
+        $mainLocation = null;
+        $isSomeLocationVisible = false;
+        $locationData = [];
+        $fields = [];
+
+        foreach ($locations as $location) {
+            $locationData['ids'][] = $location->id;
+            $locationData['parent_ids'][] = $location->parentId;
+            $locationData['remote_ids'][] = $location->remoteId;
+            $locationData['path_strings'][] = $location->pathString;
+
+            if ($location->id == $content->versionInfo->contentInfo->mainLocationId) {
+                $mainLocation = $location;
+            }
+
+            if (!$location->hidden && !$location->invisible) {
+                $isSomeLocationVisible = true;
+            }
+        }
+
+        if (!empty($locationData)) {
+            $fields[] = new Field(
+                'location_id',
+                $locationData['ids'],
+                new FieldType\MultipleIdentifierField()
+            );
+            $fields[] = new Field(
+                'location_parent_id',
+                $locationData['parent_ids'],
+                new FieldType\MultipleIdentifierField()
+            );
+            $fields[] = new Field(
+                'location_remote_id',
+                $locationData['remote_ids'],
+                new FieldType\MultipleIdentifierField()
+            );
+            $fields[] = new Field(
+                'location_path_string',
+                $locationData['path_strings'],
+                new FieldType\MultipleIdentifierField()
+            );
+        }
+
+        if ($mainLocation !== null) {
+            $fields[] = new Field(
+                'main_location',
+                $mainLocation->id,
+                new FieldType\IdentifierField()
+            );
+            $fields[] = new Field(
+                'main_location_parent',
+                $mainLocation->parentId,
+                new FieldType\IdentifierField()
+            );
+            $fields[] = new Field(
+                'main_location_remote_id',
+                $mainLocation->remoteId,
+                new FieldType\IdentifierField()
+            );
+            $fields[] = new Field(
+                'main_location_visible',
+                !$mainLocation->hidden && !$mainLocation->invisible,
+                new FieldType\BooleanField()
+            );
+            $fields[] = new Field(
+                'main_location_path',
+                $mainLocation->pathString,
+                new FieldType\IdentifierField()
+            );
+            $fields[] = new Field(
+                'main_location_depth',
+                $mainLocation->depth,
+                new FieldType\IntegerField()
+            );
+            $fields[] = new Field(
+                'main_location_priority',
+                $mainLocation->priority,
+                new FieldType\IntegerField()
+            );
+        }
+
+        $fields[] = new Field(
+            'location_visible',
+            $isSomeLocationVisible,
+            new FieldType\BooleanField()
+        );
+
+        return $fields;
+    }
+}

--- a/lib/FieldMapper/ContentTranslationFieldMapper/BlockDocumentsContentFields.php
+++ b/lib/FieldMapper/ContentTranslationFieldMapper/BlockDocumentsContentFields.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * This file is part of the eZ Platform Solr Search Engine package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentTranslationFieldMapper;
+
+use EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentTranslationFieldMapper;
+use eZ\Publish\SPI\Persistence\Content;
+use eZ\Publish\SPI\Search\Field;
+use eZ\Publish\SPI\Search\FieldType;
+use eZ\Publish\SPI\Persistence\Content\Type\Handler as ContentTypeHandler;
+use eZ\Publish\Core\Search\Common\FieldRegistry;
+use eZ\Publish\Core\Search\Common\FieldNameGenerator;
+
+/**
+ * Maps Content fields to block documents (Content and Location).
+ */
+class BlockDocumentsContentFields extends ContentTranslationFieldMapper
+{
+    /**
+     * @var \eZ\Publish\SPI\Persistence\Content\Type\Handler
+     */
+    protected $contentTypeHandler;
+
+    /**
+     * @var \eZ\Publish\Core\Search\Common\FieldRegistry
+     */
+    protected $fieldRegistry;
+
+    /**
+     * @var \eZ\Publish\Core\Search\Common\FieldNameGenerator
+     */
+    protected $fieldNameGenerator;
+
+    /**
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\Handler $contentTypeHandler
+     * @param \eZ\Publish\Core\Search\Common\FieldRegistry $fieldRegistry
+     * @param \eZ\Publish\Core\Search\Common\FieldNameGenerator $fieldNameGenerator
+     */
+    public function __construct(
+        ContentTypeHandler $contentTypeHandler,
+        FieldRegistry $fieldRegistry,
+        FieldNameGenerator $fieldNameGenerator
+    ) {
+        $this->contentTypeHandler = $contentTypeHandler;
+        $this->fieldRegistry = $fieldRegistry;
+        $this->fieldNameGenerator = $fieldNameGenerator;
+    }
+
+    public function accept(Content $content, $languageCode)
+    {
+        return true;
+    }
+
+    public function mapFields(Content $content, $languageCode)
+    {
+        $fields = [];
+        $contentType = $this->contentTypeHandler->load(
+            $content->versionInfo->contentInfo->contentTypeId
+        );
+
+        foreach ($content->fields as $field) {
+            if ($field->languageCode !== $languageCode) {
+                continue;
+            }
+
+            foreach ($contentType->fieldDefinitions as $fieldDefinition) {
+                if ($fieldDefinition->id !== $field->fieldDefinitionId) {
+                    continue;
+                }
+
+                $fieldType = $this->fieldRegistry->getType($field->type);
+                $indexFields = $fieldType->getIndexData($field, $fieldDefinition);
+
+                foreach ($indexFields as $indexField) {
+                    if ($indexField->value === null) {
+                        continue;
+                    }
+
+                    $documentField = new Field(
+                        $name = $this->fieldNameGenerator->getName(
+                            $indexField->name,
+                            $fieldDefinition->identifier,
+                            $contentType->identifier
+                        ),
+                        $indexField->value,
+                        $indexField->type
+                    );
+
+                    $this->appendField($fields, $documentField);
+                }
+            }
+        }
+
+        return $fields;
+    }
+
+    /**
+     * Appends given $documentField to $fields collection, depending on a condition.
+     *
+     * @param array $fields
+     * @param \eZ\Publish\SPI\Search\Field $documentField
+     */
+    protected function appendField(array &$fields, Field $documentField)
+    {
+        if (!$documentField->type instanceof FieldType\FullTextField) {
+            $fields[] = $documentField;
+        }
+    }
+}

--- a/lib/FieldMapper/ContentTranslationFieldMapper/BlockDocumentsContentFields.php
+++ b/lib/FieldMapper/ContentTranslationFieldMapper/BlockDocumentsContentFields.php
@@ -9,12 +9,12 @@
 namespace EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentTranslationFieldMapper;
 
 use EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentTranslationFieldMapper;
+use eZ\Publish\Core\Search\Common\FieldNameGenerator;
+use eZ\Publish\Core\Search\Common\FieldRegistry;
 use eZ\Publish\SPI\Persistence\Content;
+use eZ\Publish\SPI\Persistence\Content\Type\Handler as ContentTypeHandler;
 use eZ\Publish\SPI\Search\Field;
 use eZ\Publish\SPI\Search\FieldType;
-use eZ\Publish\SPI\Persistence\Content\Type\Handler as ContentTypeHandler;
-use eZ\Publish\Core\Search\Common\FieldRegistry;
-use eZ\Publish\Core\Search\Common\FieldNameGenerator;
 
 /**
  * Maps Content fields to block documents (Content and Location).

--- a/lib/FieldMapper/ContentTranslationFieldMapper/BlockDocumentsMetaFields.php
+++ b/lib/FieldMapper/ContentTranslationFieldMapper/BlockDocumentsMetaFields.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentTranslationFieldMapper;
+
+use EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentTranslationFieldMapper as BaseContentTranslationFieldMapper;
+use eZ\Publish\SPI\Persistence\Content;
+use eZ\Publish\SPI\Search\Field;
+use eZ\Publish\SPI\Search\FieldType;
+
+/**
+ * Maps meta fields to block documents (Content and Location).
+ */
+class BlockDocumentsMetaFields extends BaseContentTranslationFieldMapper
+{
+    public function accept(Content $content, $languageCode)
+    {
+        return true;
+    }
+
+    public function mapFields(Content $content, $languageCode)
+    {
+        return [
+            new Field(
+                'meta_indexed_language_code',
+                $languageCode,
+                new FieldType\StringField()
+            ),
+            new Field(
+                'meta_indexed_is_main_translation',
+                ($languageCode === $content->versionInfo->contentInfo->mainLanguageCode),
+                new FieldType\BooleanField()
+            ),
+            new Field(
+                'meta_indexed_is_main_translation_and_always_available',
+                (
+                    ($languageCode === $content->versionInfo->contentInfo->mainLanguageCode) &&
+                    $content->versionInfo->contentInfo->alwaysAvailable
+                ),
+                new FieldType\BooleanField()
+            ),
+        ];
+    }
+}

--- a/lib/FieldMapper/ContentTranslationFieldMapper/BlockDocumentsMetaFields.php
+++ b/lib/FieldMapper/ContentTranslationFieldMapper/BlockDocumentsMetaFields.php
@@ -1,12 +1,14 @@
 <?php
 
 /**
+ * This file is part of the eZ Platform Solr Search Engine package.
+ *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentTranslationFieldMapper;
 
-use EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentTranslationFieldMapper as BaseContentTranslationFieldMapper;
+use EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentTranslationFieldMapper;
 use eZ\Publish\SPI\Persistence\Content;
 use eZ\Publish\SPI\Search\Field;
 use eZ\Publish\SPI\Search\FieldType;
@@ -14,7 +16,7 @@ use eZ\Publish\SPI\Search\FieldType;
 /**
  * Maps meta fields to block documents (Content and Location).
  */
-class BlockDocumentsMetaFields extends BaseContentTranslationFieldMapper
+class BlockDocumentsMetaFields extends ContentTranslationFieldMapper
 {
     public function accept(Content $content, $languageCode)
     {

--- a/lib/FieldMapper/ContentTranslationFieldMapper/ContentDocumentFulltextFields.php
+++ b/lib/FieldMapper/ContentTranslationFieldMapper/ContentDocumentFulltextFields.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * This file is part of the eZ Platform Solr Search Engine package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentTranslationFieldMapper;
+
+use eZ\Publish\SPI\Search\Field;
+use eZ\Publish\SPI\Search\FieldType;
+
+/**
+ * Maps Content fulltext fields to Content document.
+ */
+class ContentDocumentFulltextFields extends BlockDocumentsContentFields
+{
+    protected function appendField(array &$fields, Field $documentField)
+    {
+        if ($documentField->type instanceof FieldType\FullTextField) {
+            $fields[] = $documentField;
+        }
+    }
+}

--- a/lib/FieldMapper/ContentTranslationFieldMapper/ContentDocumentFulltextFields.php
+++ b/lib/FieldMapper/ContentTranslationFieldMapper/ContentDocumentFulltextFields.php
@@ -16,6 +16,12 @@ use eZ\Publish\SPI\Search\FieldType;
  */
 class ContentDocumentFulltextFields extends BlockDocumentsContentFields
 {
+    /**
+     * {@inheritdoc}
+     *
+     * Overridden to append only full text fields, instead of everything but full text fields
+     * in the base implementation.
+     */
     protected function appendField(array &$fields, Field $documentField)
     {
         if ($documentField->type instanceof FieldType\FullTextField) {

--- a/lib/FieldMapper/LocationFieldMapper/LocationDocumentBaseFields.php
+++ b/lib/FieldMapper/LocationFieldMapper/LocationDocumentBaseFields.php
@@ -1,0 +1,106 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformSolrSearchEngine\FieldMapper\LocationFieldMapper;
+
+use EzSystems\EzPlatformSolrSearchEngine\DocumentMapper;
+use EzSystems\EzPlatformSolrSearchEngine\FieldMapper\LocationFieldMapper as BaseLocationFieldMapper;
+use eZ\Publish\SPI\Persistence\Content\Handler as ContentHandler;
+use eZ\Publish\SPI\Persistence\Content\Location;
+use eZ\Publish\SPI\Search\Field;
+use eZ\Publish\SPI\Search\FieldType;
+
+/**
+ * Maps base Location related fields to a Location document.
+ */
+class LocationDocumentBaseFields extends BaseLocationFieldMapper
+{
+    /**
+     * @var \eZ\Publish\SPI\Persistence\Content\Handler
+     */
+    protected $contentHandler;
+
+    /**
+     * @param \eZ\Publish\SPI\Persistence\Content\Handler $contentHandler
+     */
+    public function __construct(ContentHandler $contentHandler)
+    {
+        $this->contentHandler = $contentHandler;
+    }
+
+    public function accept(Location $location)
+    {
+        return true;
+    }
+
+    public function mapFields(Location $location)
+    {
+        $contentInfo = $this->contentHandler->loadContentInfo($location->contentId);
+
+        return [
+            new Field(
+                'location',
+                $location->id,
+                new FieldType\IdentifierField()
+            ),
+            new Field(
+                'document_type',
+                DocumentMapper::DOCUMENT_TYPE_IDENTIFIER_LOCATION,
+                new FieldType\IdentifierField()
+            ),
+            new Field(
+                'priority',
+                $location->priority,
+                new FieldType\IntegerField()
+            ),
+            new Field(
+                'hidden',
+                $location->hidden,
+                new FieldType\BooleanField()
+            ),
+            new Field(
+                'invisible',
+                $location->invisible,
+                new FieldType\BooleanField()
+            ),
+            new Field(
+                'remote_id',
+                $location->remoteId,
+                new FieldType\IdentifierField()
+            ),
+            new Field(
+                'parent_id',
+                $location->parentId,
+                new FieldType\IdentifierField()
+            ),
+            new Field(
+                'path_string',
+                $location->pathString,
+                new FieldType\IdentifierField()
+            ),
+            new Field(
+                'depth',
+                $location->depth,
+                new FieldType\IntegerField()
+            ),
+            new Field(
+                'sort_field',
+                $location->sortField,
+                new FieldType\IdentifierField()
+            ),
+            new Field(
+                'sort_order',
+                $location->sortOrder,
+                new FieldType\IdentifierField()
+            ),
+            new Field(
+                'is_main_location',
+                ($location->id == $contentInfo->mainLocationId),
+                new FieldType\BooleanField()
+            ),
+        ];
+    }
+}

--- a/lib/FieldMapper/LocationFieldMapper/LocationDocumentBaseFields.php
+++ b/lib/FieldMapper/LocationFieldMapper/LocationDocumentBaseFields.php
@@ -1,13 +1,15 @@
 <?php
 
 /**
+ * This file is part of the eZ Platform Solr Search Engine package.
+ *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace EzSystems\EzPlatformSolrSearchEngine\FieldMapper\LocationFieldMapper;
 
 use EzSystems\EzPlatformSolrSearchEngine\DocumentMapper;
-use EzSystems\EzPlatformSolrSearchEngine\FieldMapper\LocationFieldMapper as BaseLocationFieldMapper;
+use EzSystems\EzPlatformSolrSearchEngine\FieldMapper\LocationFieldMapper;
 use eZ\Publish\SPI\Persistence\Content\Handler as ContentHandler;
 use eZ\Publish\SPI\Persistence\Content\Location;
 use eZ\Publish\SPI\Search\Field;
@@ -16,7 +18,7 @@ use eZ\Publish\SPI\Search\FieldType;
 /**
  * Maps base Location related fields to a Location document.
  */
-class LocationDocumentBaseFields extends BaseLocationFieldMapper
+class LocationDocumentBaseFields extends LocationFieldMapper
 {
     /**
      * @var \eZ\Publish\SPI\Persistence\Content\Handler

--- a/lib/FieldMapper/LocationFieldMapper/LocationDocumentContentFields.php
+++ b/lib/FieldMapper/LocationFieldMapper/LocationDocumentContentFields.php
@@ -10,20 +10,20 @@
  */
 namespace EzSystems\EzPlatformSolrSearchEngine\FieldMapper\LocationFieldMapper;
 
-use EzSystems\EzPlatformSolrSearchEngine\FieldMapper\LocationFieldMapper as BaseLocationFieldMapper;
+use EzSystems\EzPlatformSolrSearchEngine\FieldMapper\LocationFieldMapper;
 use eZ\Publish\SPI\Persistence\Content\Handler as ContentHandler;
+use eZ\Publish\SPI\Persistence\Content\Location;
 use eZ\Publish\SPI\Persistence\Content\Location\Handler as LocationHandler;
-use eZ\Publish\SPI\Persistence\Content\Type\Handler as ContentTypeHandler;
 use eZ\Publish\SPI\Persistence\Content\ObjectState\Handler as ObjectStateHandler;
 use eZ\Publish\SPI\Persistence\Content\Section\Handler as SectionHandler;
-use eZ\Publish\SPI\Persistence\Content\Location;
+use eZ\Publish\SPI\Persistence\Content\Type\Handler as ContentTypeHandler;
 use eZ\Publish\SPI\Search\Field;
 use eZ\Publish\SPI\Search\FieldType;
 
 /**
  * Maps Content related fields to a Location document.
  */
-class LocationDocumentContentFields extends BaseLocationFieldMapper
+class LocationDocumentContentFields extends LocationFieldMapper
 {
     /**
      * @var \eZ\Publish\SPI\Persistence\Content\Handler

--- a/lib/FieldMapper/LocationFieldMapper/LocationDocumentContentFields.php
+++ b/lib/FieldMapper/LocationFieldMapper/LocationDocumentContentFields.php
@@ -1,0 +1,252 @@
+<?php
+
+/**
+ * This file is part of the eZ Platform Solr Search Engine package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace EzSystems\EzPlatformSolrSearchEngine\FieldMapper\LocationFieldMapper;
+
+use EzSystems\EzPlatformSolrSearchEngine\FieldMapper\LocationFieldMapper as BaseLocationFieldMapper;
+use eZ\Publish\SPI\Persistence\Content\Handler as ContentHandler;
+use eZ\Publish\SPI\Persistence\Content\Location\Handler as LocationHandler;
+use eZ\Publish\SPI\Persistence\Content\Type\Handler as ContentTypeHandler;
+use eZ\Publish\SPI\Persistence\Content\ObjectState\Handler as ObjectStateHandler;
+use eZ\Publish\SPI\Persistence\Content\Section\Handler as SectionHandler;
+use eZ\Publish\SPI\Persistence\Content\Location;
+use eZ\Publish\SPI\Search\Field;
+use eZ\Publish\SPI\Search\FieldType;
+
+/**
+ * Maps Content related fields to a Location document.
+ */
+class LocationDocumentContentFields extends BaseLocationFieldMapper
+{
+    /**
+     * @var \eZ\Publish\SPI\Persistence\Content\Handler
+     */
+    protected $contentHandler;
+
+    /**
+     * @var \eZ\Publish\SPI\Persistence\Content\Location\Handler
+     */
+    protected $locationHandler;
+
+    /**
+     * @var \eZ\Publish\SPI\Persistence\Content\Type\Handler
+     */
+    protected $contentTypeHandler;
+
+    /**
+     * @var \eZ\Publish\SPI\Persistence\Content\ObjectState\Handler
+     */
+    protected $objectStateHandler;
+
+    /**
+     * @var \eZ\Publish\SPI\Persistence\Content\Section\Handler
+     */
+    protected $sectionHandler;
+
+    /**
+     * @param \eZ\Publish\SPI\Persistence\Content\Handler $contentHandler
+     * @param \eZ\Publish\SPI\Persistence\Content\Location\Handler $locationHandler
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\Handler $contentTypeHandler
+     * @param \eZ\Publish\SPI\Persistence\Content\ObjectState\Handler $objectStateHandler
+     * @param \eZ\Publish\SPI\Persistence\Content\Section\Handler $sectionHandler
+     */
+    public function __construct(
+        ContentHandler $contentHandler,
+        LocationHandler $locationHandler,
+        ContentTypeHandler $contentTypeHandler,
+        ObjectStateHandler $objectStateHandler,
+        SectionHandler $sectionHandler
+    ) {
+        $this->contentHandler = $contentHandler;
+        $this->locationHandler = $locationHandler;
+        $this->contentTypeHandler = $contentTypeHandler;
+        $this->objectStateHandler = $objectStateHandler;
+        $this->sectionHandler = $sectionHandler;
+    }
+
+    public function accept(Location $location)
+    {
+        return true;
+    }
+
+    public function mapFields(Location $location)
+    {
+        $contentInfo = $this->contentHandler->loadContentInfo($location->contentId);
+        $versionInfo = $this->contentHandler->loadVersionInfo(
+            $location->contentId,
+            $contentInfo->currentVersionNo
+        );
+
+        // UserGroups and Users are Content, but permissions cascade is achieved through
+        // Locations hierarchy. We index all ancestor Location Content ids of all
+        // Locations of an owner.
+        $ancestorLocationsContentIds = $this->getAncestorLocationsContentIds(
+            $contentInfo->ownerId
+        );
+        // Add owner user id as it can also be considered as user group.
+        $ancestorLocationsContentIds[] = $contentInfo->ownerId;
+
+        $section = $this->sectionHandler->load($contentInfo->sectionId);
+
+        return [
+            new Field(
+                'content_id',
+                $contentInfo->id,
+                new FieldType\IdentifierField()
+            ),
+            new Field(
+                'content_type',
+                $contentInfo->contentTypeId,
+                new FieldType\IdentifierField()
+            ),
+            new Field(
+                'content_version_no',
+                $versionInfo->versionNo,
+                new FieldType\IntegerField()
+            ),
+            new Field(
+                'content_status',
+                $versionInfo->status,
+                new FieldType\IdentifierField()
+            ),
+            new Field(
+                'content_name',
+                $contentInfo->name,
+                new FieldType\StringField()
+            ),
+            new Field(
+                'content_creator',
+                $versionInfo->creatorId,
+                new FieldType\IdentifierField()
+            ),
+            new Field(
+                'content_owner',
+                $contentInfo->ownerId,
+                new FieldType\IdentifierField()
+            ),
+            new Field(
+                'content_section',
+                $contentInfo->sectionId,
+                new FieldType\IdentifierField()
+            ),
+            new Field(
+                'content_remote_id',
+                $contentInfo->remoteId,
+                new FieldType\IdentifierField()
+            ),
+            new Field(
+                'content_modified',
+                $contentInfo->modificationDate,
+                new FieldType\DateField()
+            ),
+            new Field(
+                'content_published',
+                $contentInfo->publicationDate,
+                new FieldType\DateField()
+            ),
+            new Field(
+                'language_code',
+                array_keys($versionInfo->names),
+                new FieldType\MultipleStringField()
+            ),
+            new Field(
+                'main_language_code',
+                $contentInfo->mainLanguageCode,
+                new FieldType\StringField()
+            ),
+            new Field(
+                'content_always_available',
+                $contentInfo->alwaysAvailable,
+                new FieldType\BooleanField()
+            ),
+            new Field(
+                'content_owner_user_group',
+                $ancestorLocationsContentIds,
+                new FieldType\MultipleIdentifierField()
+            ),
+            new Field(
+                'content_section_identifier',
+                $section->identifier,
+                new FieldType\IdentifierField()
+            ),
+            new Field(
+                'content_section_name',
+                $section->name,
+                new FieldType\StringField()
+            ),
+            new Field(
+                'content_group',
+                $this->contentTypeHandler->load($contentInfo->contentTypeId)->groupIds,
+                new FieldType\MultipleIdentifierField()
+            ),
+            new Field(
+                'content_object_state',
+                $this->getObjectStateIds($contentInfo->id),
+                new FieldType\MultipleIdentifierField()
+            ),
+        ];
+    }
+
+    /**
+     * Returns an array of object state ids of a Content with given $contentId.
+     *
+     * @param int|string $contentId
+     *
+     * @return array
+     */
+    protected function getObjectStateIds($contentId)
+    {
+        $objectStateIds = array();
+
+        foreach ($this->objectStateHandler->loadAllGroups() as $objectStateGroup) {
+            $objectStateIds[] = $this->objectStateHandler->getContentState(
+                $contentId,
+                $objectStateGroup->id
+            )->id;
+        }
+
+        return $objectStateIds;
+    }
+
+    /**
+     * Returns Content ids of all ancestor Locations of all Locations
+     * of a Content with given $contentId.
+     *
+     * Used to determine user groups of a user with $contentId.
+     *
+     * @param int|string $contentId
+     *
+     * @return array
+     */
+    protected function getAncestorLocationsContentIds($contentId)
+    {
+        $locations = $this->locationHandler->loadLocationsByContent($contentId);
+        $ancestorLocationContentIds = array();
+        $ancestorLocationIds = array();
+
+        foreach ($locations as $location) {
+            $locationIds = explode('/', trim($location->pathString, '/'));
+            // Remove Location of Content with $contentId
+            array_pop($locationIds);
+            // Remove Root Location id (id==1 in legacy DB)
+            array_shift($locationIds);
+
+            $ancestorLocationIds = array_merge($ancestorLocationIds, $locationIds);
+        }
+
+        foreach (array_unique($ancestorLocationIds) as $locationId) {
+            $location = $this->locationHandler->load($locationId);
+
+            $ancestorLocationContentIds[$location->contentId] = true;
+        }
+
+        return array_keys($ancestorLocationContentIds);
+    }
+}

--- a/lib/FieldMapper/LocationFieldMapper/LocationDocumentContentFields.php
+++ b/lib/FieldMapper/LocationFieldMapper/LocationDocumentContentFields.php
@@ -5,8 +5,6 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- *
- * @version //autogentag//
  */
 namespace EzSystems\EzPlatformSolrSearchEngine\FieldMapper\LocationFieldMapper;
 

--- a/lib/Resources/config/container/solr.yml
+++ b/lib/Resources/config/container/solr.yml
@@ -1,5 +1,6 @@
 imports:
     - {resource: solr/criterion_visitors.yml}
+    - {resource: solr/field_mappers.yml}
     - {resource: solr/facet_builder_visitors.yml}
     - {resource: solr/services.yml}
     - {resource: solr/sort_clause_visitors.yml}

--- a/lib/Resources/config/container/solr.yml
+++ b/lib/Resources/config/container/solr.yml
@@ -53,10 +53,7 @@ services:
             - "@ezpublish.search.solr.field_mapper.content"
             - "@ezpublish.search.solr.field_mapper.content_translation"
             - "@ezpublish.search.solr.field_mapper.location"
-            - "@ezpublish.search.common.field_registry"
             - "@ezpublish.spi.persistence.location_handler"
-            - "@ezpublish.spi.persistence.content_type_handler"
-            - "@ezpublish.search.common.field_name_generator"
 
     ezpublish.search.solr.document_mapper:
         alias: ezpublish.search.solr.document_mapper.native

--- a/lib/Resources/config/container/solr.yml
+++ b/lib/Resources/config/container/solr.yml
@@ -54,11 +54,8 @@ services:
             - "@ezpublish.search.solr.field_mapper.content_translation"
             - "@ezpublish.search.solr.field_mapper.location"
             - "@ezpublish.search.common.field_registry"
-            - "@ezpublish.spi.persistence.content_handler"
             - "@ezpublish.spi.persistence.location_handler"
             - "@ezpublish.spi.persistence.content_type_handler"
-            - "@ezpublish.spi.persistence.object_state_handler"
-            - "@ezpublish.spi.persistence.section_handler"
             - "@ezpublish.search.common.field_name_generator"
 
     ezpublish.search.solr.document_mapper:

--- a/lib/Resources/config/container/solr/field_mappers.yml
+++ b/lib/Resources/config/container/solr/field_mappers.yml
@@ -1,7 +1,18 @@
 parameters:
+    ezpublish.search.solr.field_mapper.content.content_document_base_fields.class: EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentFieldMapper\ContentDocumentBaseFields
     ezpublish.search.solr.field_mapper.location.location_document_base_fields.class: EzSystems\EzPlatformSolrSearchEngine\FieldMapper\LocationFieldMapper\LocationDocumentBaseFields
 
 services:
+    ezpublish.search.solr.field_mapper.content.content_document_base_fields:
+        class: '%ezpublish.search.solr.field_mapper.content.content_document_base_fields.class%'
+        arguments:
+            - '@ezpublish.spi.persistence.location_handler'
+            - '@ezpublish.spi.persistence.content_type_handler'
+            - '@ezpublish.spi.persistence.object_state_handler'
+            - '@ezpublish.spi.persistence.section_handler'
+        tags:
+            - {name: ezpublish.search.solr.field_mapper.content}
+
     ezpublish.search.solr.field_mapper.location.location_document_base_fields:
         class: '%ezpublish.search.solr.field_mapper.location.location_document_base_fields.class%'
         arguments:

--- a/lib/Resources/config/container/solr/field_mappers.yml
+++ b/lib/Resources/config/container/solr/field_mappers.yml
@@ -2,6 +2,7 @@ parameters:
     ezpublish.search.solr.field_mapper.content.content_document_base_fields.class: EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentFieldMapper\ContentDocumentBaseFields
     ezpublish.search.solr.field_mapper.content.content_document_location_fields.class: EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentFieldMapper\ContentDocumentLocationFields
     ezpublish.search.solr.field_mapper.location.location_document_base_fields.class: EzSystems\EzPlatformSolrSearchEngine\FieldMapper\LocationFieldMapper\LocationDocumentBaseFields
+    ezpublish.search.solr.field_mapper.location.location_document_content_fields.class: EzSystems\EzPlatformSolrSearchEngine\FieldMapper\LocationFieldMapper\LocationDocumentContentFields
 
 services:
     ezpublish.search.solr.field_mapper.content.content_document_base_fields:
@@ -25,5 +26,16 @@ services:
         class: '%ezpublish.search.solr.field_mapper.location.location_document_base_fields.class%'
         arguments:
             - '@ezpublish.spi.persistence.content_handler'
+        tags:
+            - {name: ezpublish.search.solr.field_mapper.location}
+
+    ezpublish.search.solr.field_mapper.location.location_document_content_fields:
+        class: '%ezpublish.search.solr.field_mapper.location.location_document_content_fields.class%'
+        arguments:
+            - '@ezpublish.spi.persistence.content_handler'
+            - '@ezpublish.spi.persistence.location_handler'
+            - '@ezpublish.spi.persistence.content_type_handler'
+            - '@ezpublish.spi.persistence.object_state_handler'
+            - '@ezpublish.spi.persistence.section_handler'
         tags:
             - {name: ezpublish.search.solr.field_mapper.location}

--- a/lib/Resources/config/container/solr/field_mappers.yml
+++ b/lib/Resources/config/container/solr/field_mappers.yml
@@ -1,0 +1,10 @@
+parameters:
+    ezpublish.search.solr.field_mapper.location.location_document_base_fields.class: EzSystems\EzPlatformSolrSearchEngine\FieldMapper\LocationFieldMapper\LocationDocumentBaseFields
+
+services:
+    ezpublish.search.solr.field_mapper.location.location_document_base_fields:
+        class: '%ezpublish.search.solr.field_mapper.location.location_document_base_fields.class%'
+        arguments:
+            - '@ezpublish.spi.persistence.content_handler'
+        tags:
+            - {name: ezpublish.search.solr.field_mapper.location}

--- a/lib/Resources/config/container/solr/field_mappers.yml
+++ b/lib/Resources/config/container/solr/field_mappers.yml
@@ -1,5 +1,6 @@
 parameters:
     ezpublish.search.solr.field_mapper.content.content_document_base_fields.class: EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentFieldMapper\ContentDocumentBaseFields
+    ezpublish.search.solr.field_mapper.content.content_document_location_fields.class: EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentFieldMapper\ContentDocumentLocationFields
     ezpublish.search.solr.field_mapper.location.location_document_base_fields.class: EzSystems\EzPlatformSolrSearchEngine\FieldMapper\LocationFieldMapper\LocationDocumentBaseFields
 
 services:
@@ -10,6 +11,13 @@ services:
             - '@ezpublish.spi.persistence.content_type_handler'
             - '@ezpublish.spi.persistence.object_state_handler'
             - '@ezpublish.spi.persistence.section_handler'
+        tags:
+            - {name: ezpublish.search.solr.field_mapper.content}
+
+    ezpublish.search.solr.field_mapper.content.content_document_location_fields:
+        class: '%ezpublish.search.solr.field_mapper.content.content_document_location_fields.class%'
+        arguments:
+            - '@ezpublish.spi.persistence.location_handler'
         tags:
             - {name: ezpublish.search.solr.field_mapper.content}
 

--- a/lib/Resources/config/container/solr/field_mappers.yml
+++ b/lib/Resources/config/container/solr/field_mappers.yml
@@ -1,10 +1,16 @@
 parameters:
+    ezpublish.search.solr.field_mapper.block_translation.block_documents_meta_fields.class: EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentTranslationFieldMapper\BlockDocumentsMetaFields
     ezpublish.search.solr.field_mapper.content.content_document_base_fields.class: EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentFieldMapper\ContentDocumentBaseFields
     ezpublish.search.solr.field_mapper.content.content_document_location_fields.class: EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentFieldMapper\ContentDocumentLocationFields
     ezpublish.search.solr.field_mapper.location.location_document_base_fields.class: EzSystems\EzPlatformSolrSearchEngine\FieldMapper\LocationFieldMapper\LocationDocumentBaseFields
     ezpublish.search.solr.field_mapper.location.location_document_content_fields.class: EzSystems\EzPlatformSolrSearchEngine\FieldMapper\LocationFieldMapper\LocationDocumentContentFields
 
 services:
+    ezpublish.search.solr.field_mapper.block_translation.block_documents_meta_fields:
+        class: '%ezpublish.search.solr.field_mapper.block_translation.block_documents_meta_fields.class%'
+        tags:
+            - {name: ezpublish.search.solr.field_mapper.block_translation}
+
     ezpublish.search.solr.field_mapper.content.content_document_base_fields:
         class: '%ezpublish.search.solr.field_mapper.content.content_document_base_fields.class%'
         arguments:

--- a/lib/Resources/config/container/solr/field_mappers.yml
+++ b/lib/Resources/config/container/solr/field_mappers.yml
@@ -3,6 +3,7 @@ parameters:
     ezpublish.search.solr.field_mapper.block_translation.block_documents_meta_fields.class: EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentTranslationFieldMapper\BlockDocumentsMetaFields
     ezpublish.search.solr.field_mapper.content.content_document_base_fields.class: EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentFieldMapper\ContentDocumentBaseFields
     ezpublish.search.solr.field_mapper.content.content_document_location_fields.class: EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentFieldMapper\ContentDocumentLocationFields
+    ezpublish.search.solr.field_mapper.content_translation.content_document_fulltext_fields.class: EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentTranslationFieldMapper\ContentDocumentFulltextFields
     ezpublish.search.solr.field_mapper.location.location_document_base_fields.class: EzSystems\EzPlatformSolrSearchEngine\FieldMapper\LocationFieldMapper\LocationDocumentBaseFields
     ezpublish.search.solr.field_mapper.location.location_document_content_fields.class: EzSystems\EzPlatformSolrSearchEngine\FieldMapper\LocationFieldMapper\LocationDocumentContentFields
 
@@ -37,6 +38,15 @@ services:
             - '@ezpublish.spi.persistence.location_handler'
         tags:
             - {name: ezpublish.search.solr.field_mapper.content}
+
+    ezpublish.search.solr.field_mapper.content_translation.content_document_fulltext_fields:
+        class: '%ezpublish.search.solr.field_mapper.content_translation.content_document_fulltext_fields.class%'
+        arguments:
+            - '@ezpublish.spi.persistence.content_type_handler'
+            - '@ezpublish.search.common.field_registry'
+            - '@ezpublish.search.common.field_name_generator'
+        tags:
+            - {name: ezpublish.search.solr.field_mapper.content_translation}
 
     ezpublish.search.solr.field_mapper.location.location_document_base_fields:
         class: '%ezpublish.search.solr.field_mapper.location.location_document_base_fields.class%'

--- a/lib/Resources/config/container/solr/field_mappers.yml
+++ b/lib/Resources/config/container/solr/field_mappers.yml
@@ -1,4 +1,5 @@
 parameters:
+    ezpublish.search.solr.field_mapper.block_translation.block_documents_content_fields.class: EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentTranslationFieldMapper\BlockDocumentsContentFields
     ezpublish.search.solr.field_mapper.block_translation.block_documents_meta_fields.class: EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentTranslationFieldMapper\BlockDocumentsMetaFields
     ezpublish.search.solr.field_mapper.content.content_document_base_fields.class: EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentFieldMapper\ContentDocumentBaseFields
     ezpublish.search.solr.field_mapper.content.content_document_location_fields.class: EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentFieldMapper\ContentDocumentLocationFields
@@ -6,6 +7,15 @@ parameters:
     ezpublish.search.solr.field_mapper.location.location_document_content_fields.class: EzSystems\EzPlatformSolrSearchEngine\FieldMapper\LocationFieldMapper\LocationDocumentContentFields
 
 services:
+    ezpublish.search.solr.field_mapper.block_translation.block_documents_content_fields:
+        class: '%ezpublish.search.solr.field_mapper.block_translation.block_documents_content_fields.class%'
+        arguments:
+            - '@ezpublish.spi.persistence.content_type_handler'
+            - '@ezpublish.search.common.field_registry'
+            - '@ezpublish.search.common.field_name_generator'
+        tags:
+            - {name: ezpublish.search.solr.field_mapper.block_translation}
+
     ezpublish.search.solr.field_mapper.block_translation.block_documents_meta_fields:
         class: '%ezpublish.search.solr.field_mapper.block_translation.block_documents_meta_fields.class%'
         tags:


### PR DESCRIPTION
This PR resolves https://jira.ez.no/browse/EZP-26668

Following on https://jira.ez.no/browse/EZP-26368, this refactors `NativeDocumentMapper` implementation to use only field mappers to map document fields.

Duplication of internal methods in `ContentFieldMapper/ContentDocumentBaseFields` and `LocationFieldMapper/LocationDocumentContentFields` is intentional and temporary, since the followup to this is normalization of field names between Content and Location documents, which will enable replacing these with a common block document level field mapper.