### PR TITLE
EZP-26707: Search with Solr does not respect isSearchable setting of fields

### DIFF
--- a/lib/DocumentMapper/NativeDocumentMapper.php
+++ b/lib/DocumentMapper/NativeDocumentMapper.php
@@ -470,10 +470,10 @@ class NativeDocumentMapper implements DocumentMapper
                         $indexField->type
                     );
 
-                    if ($documentField->type instanceof FieldType\FullTextField) {
-                        $fieldSets[$field->languageCode]['fulltext'][] = $documentField;
-                    } else {
+                    if (!$documentField->type instanceof FieldType\FullTextField) {
                         $fieldSets[$field->languageCode]['regular'][] = $documentField;
+                    } elseif ($fieldDefinition->isSearchable) {
+                        $fieldSets[$field->languageCode]['fulltext'][] = $documentField;
                     }
                 }
             }


### PR DESCRIPTION
This PR resolves https://jira.ez.no/browse/EZP-26707

This skips indexing full text data if the field is marked as not searchable (`FieldDefinitions::$isSearchable` property).
*Regular* fields are still indexed, since `isSearchable` is checked when resolving query for `Field` criterion/sort clause (and we're also going for `isSearchable` meaning only full text searchable).

### TODOs
- [x] integration test on https://github.com/ezsystems/ezpublish-kernel side