### PR TITLE
Deprecate ezplatform:solr_create_index command

### DIFF
--- a/bundle/Command/SolrCreateIndexCommand.php
+++ b/bundle/Command/SolrCreateIndexCommand.php
@@ -21,6 +21,9 @@ use EzSystems\EzPlatformSolrSearchEngine\Handler as SolrSearchEngineHandler;
 use RuntimeException;
 use PDO;
 
+/**
+ * @deprecated since 1.2, use ezplatform:reindex command instead.
+ */
 class SolrCreateIndexCommand extends ContainerAwareCommand
 {
     protected function configure()
@@ -38,6 +41,11 @@ EOT
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        @trigger_error(
+            sprintf('%s is deprecated since 1.2. Use ezplatform:reindex command instead', $this->getName()),
+            E_USER_DEPRECATED
+        );
+
         $this->logger = $this->getContainer()->get('logger');
 
         $bulkCount = $input->getArgument('bulk_count');


### PR DESCRIPTION
> Status: **Ready for a review**

This PR deprecates `ezplatform:solr_create_index` command in favor of the new `ezplatform:reindex` command.

**TODO**:
- [x] Deprecate `ezplatform:solr_create_index` by following [Symfony Conventions](http://symfony.com/doc/current/contributing/code/conventions.html#deprecations) (2c0b791).