### PR TITLE
[Travis] Fix missing Java by using previous image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@
 sudo: required
 dist: trusty
 
+# Workaround for the issue found in the stable image promoted on Dec 1, 2016.
+# See https://github.com/travis-ci/travis-ci/issues/6928#issuecomment-264227708
+group: deprecated
+
 language: php
 
 cache:


### PR DESCRIPTION
Workaround for the issue found in the stable image promoted on Dec 1, 2016.
See https://github.com/travis-ci/travis-ci/issues/6928#issuecomment-264227708