### PR TITLE
EZP-26774: switch from q.alt to q parameter to enable use of spellchecker in future version

### DIFF
--- a/lib/CoreFilter/NativeCoreFilter.php
+++ b/lib/CoreFilter/NativeCoreFilter.php
@@ -103,13 +103,16 @@ class NativeCoreFilter extends CoreFilter
             $languageSettings['useAlwaysAvailable'] === true
         );
 
-        $query->filter = new LogicalAnd(
-            array(
-                new CustomField(self::FIELD_DOCUMENT_TYPE, Operator::EQ, $documentTypeIdentifier),
-                $query->filter,
-                $this->getCoreCriterion($languages, $useAlwaysAvailable),
-            )
-        );
+        $criteria = [
+            new CustomField(self::FIELD_DOCUMENT_TYPE, Operator::EQ, $documentTypeIdentifier),
+            $this->getCoreCriterion($languages, $useAlwaysAvailable),
+        ];
+
+        if ($query->filter !== null) {
+            $criteria[] = $query->filter;
+        }
+
+        $query->filter = new LogicalAnd($criteria);
     }
 
     /**

--- a/lib/Handler.php
+++ b/lib/Handler.php
@@ -187,7 +187,6 @@ class Handler implements SearchHandlerInterface
     public function findLocations(LocationQuery $query, array $fieldFilters = array())
     {
         $query = clone $query;
-        $query->filter = $query->filter ?: new Criterion\MatchAll();
         $query->query = $query->query ?: new Criterion\MatchAll();
 
         $this->coreFilter->apply(

--- a/lib/Query/Common/CriterionVisitor/LogicalAnd.php
+++ b/lib/Query/Common/CriterionVisitor/LogicalAnd.php
@@ -12,6 +12,7 @@ namespace EzSystems\EzPlatformSolrSearchEngine\Query\Common\CriterionVisitor;
 
 use EzSystems\EzPlatformSolrSearchEngine\Query\CriterionVisitor;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use RuntimeException;
 
 /**
  * Visits the LogicalAnd criterion.
@@ -40,16 +41,22 @@ class LogicalAnd extends CriterionVisitor
      */
     public function visit(Criterion $criterion, CriterionVisitor $subVisitor = null)
     {
-        return '(' .
-            implode(
-                ' AND ',
-                array_map(
-                    function ($value) use ($subVisitor) {
-                        return $subVisitor->visit($value);
-                    },
-                    $criterion->criteria
-                )
-            ) .
-            ')';
+        /** @var \eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalAnd $criterion */
+        if (!isset($criterion->criteria[0])) {
+            throw new RuntimeException('Invalid aggregation in LogicalAnd criterion.');
+        }
+
+        $subCriteria = array_map(
+            function ($value) use ($subVisitor) {
+                return $subVisitor->visit($value);
+            },
+            $criterion->criteria
+        );
+
+        if (count($subCriteria) === 1) {
+            return reset($subCriteria);
+        }
+
+        return '(' . implode(' AND ', $subCriteria) . ')';
     }
 }

--- a/lib/Query/Common/CriterionVisitor/MatchNone.php
+++ b/lib/Query/Common/CriterionVisitor/MatchNone.php
@@ -38,6 +38,6 @@ class MatchNone extends CriterionVisitor
      */
     public function visit(Criterion $criterion, CriterionVisitor $subVisitor = null)
     {
-        return 'NOT (*:*)';
+        return '(NOT *:*)';
     }
 }

--- a/lib/Query/Common/QueryConverter/NativeQueryConverter.php
+++ b/lib/Query/Common/QueryConverter/NativeQueryConverter.php
@@ -63,8 +63,8 @@ class NativeQueryConverter extends QueryConverter
     {
         $params = array(
             'defType' => 'edismax',
-            'q.alt' => $this->criterionVisitor->visit($query->query),
-            'fq' => $this->criterionVisitor->visit($query->filter),
+            'q' => '{!lucene}' . $this->criterionVisitor->visit($query->query),
+            'fq' => '{!lucene}' . $this->criterionVisitor->visit($query->filter),
             'sort' => $this->getSortClauses($query->sortClauses),
             'start' => $query->offset,
             'rows' => $query->limit,


### PR DESCRIPTION
This PR resolves https://jira.ez.no/browse/EZP-26774

Counterpart on `ezpublish-kernel`: https://github.com/ezsystems/ezpublish-kernel/pull/1859

This switches used Solr query parameter from `q.alt` to `q`.
This is internal thing to the Solr backend, will enable using suggestions/spellchecking on the generated query.

Note: suggestions/spellchecking in this context is about handling it on the Solr backend side, not in the Solr search engine.

Related PR: https://github.com/ezsystems/ezplatform-solr-search-engine/pull/57

Also exposed and fixed:
- `MatchNone` visitor was not handled as subquery, which could result in unwanted pure negative query when used with other criteria
- removed unnecessary usage of `MatchAll` criterion
- refactored logical criteria visitors to avoid generating unnecessary parentheses