### PR TITLE
EZP-26775: supported Solr backend v6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,17 @@ matrix:
         - php: 7.0
           env: TEST_CONFIG="phpunit.xml"
         - php: 5.6
-          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="4.10.4" CORES_SETUP="dedicated" SOLR_CONFS="lib/Resources/config/solr/schema.xml lib/Resources/config/solr/custom-fields-types.xml lib/Resources/config/solr/language-fieldtypes.xml" SOLR_CORES="core0 core1 core2 core3"
+          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="4.10.4" CORES_SETUP="dedicated"
         - php: 5.6
-          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="4.10.4" CORES_SETUP="shared"    SOLR_CONFS="lib/Resources/config/solr/schema.xml lib/Resources/config/solr/custom-fields-types.xml lib/Resources/config/solr/language-fieldtypes.xml" SOLR_CORES="core0 core1 core2 core3"
+          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="4.10.4" CORES_SETUP="shared"
         - php: 7.0
-          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="4.10.4" CORES_SETUP="single"    SOLR_CONFS="lib/Resources/config/solr/schema.xml lib/Resources/config/solr/custom-fields-types.xml lib/Resources/config/solr/language-fieldtypes.xml"
+          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="4.10.4" CORES_SETUP="single" SOLR_CORES="collection1"
+        - php: 5.6
+          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="6.3.0"  CORES_SETUP="dedicated"
+        - php: 5.6
+          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="6.3.0"  CORES_SETUP="shared"
+        - php: 7.0
+          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="6.3.0"  CORES_SETUP="single" SOLR_CORES="collection1"
 
 # test only master and stable branches (+ Pull requests against those)
 branches:

--- a/README.md
+++ b/README.md
@@ -67,11 +67,9 @@ For Contributing to this Bundle, you should make sure to run both unit and integ
 
 4. Start Solr
 
-    *Note: In this case in seperate terminal for debug use*
-
     ```bash
-    cd solr-4.10.4/example
-    java -Djetty.port=8983 -jar start.jar
+    cd solr-6.3.0
+    bin/solr start
     ```
 
 5. Run integration tests

--- a/bin/.travis/init_solr.sh
+++ b/bin/.travis/init_solr.sh
@@ -1,27 +1,102 @@
 #!/usr/bin/env bash
 
+default_config_files[1]='lib/Resources/config/solr/schema.xml'
+default_config_files[2]='lib/Resources/config/solr/custom-fields-types.xml'
+default_config_files[3]='lib/Resources/config/solr/language-fieldtypes.xml'
+
+default_cores[0]='core0'
+default_cores[1]='core1'
+default_cores[2]='core2'
+default_cores[3]='core3'
+
 SOLR_PORT=${SOLR_PORT:-8983}
-SOLR_VERSION=${SOLR_VERSION:-4.10.4}
-DEBUG=${DEBUG:-false}
+SOLR_VERSION=${SOLR_VERSION:-6.3.0}
+SOLR_DEBUG=${SOLR_DEBUG:-false}
+SOLR_HOME=${SOLR_HOME:-ez}
+SOLR_CONFIG=${SOLR_CONFIG:-${default_config_files[*]}}
+SOLR_CORES=${SOLR_CORES:-${default_cores[*]}}
+SOLR_DIR=${SOLR_DIR:-__solr}
+SOLR_INSTALL_DIR="${SOLR_DIR}/${SOLR_VERSION}"
 
 download() {
-    FILE="$2.tgz"
-    if [ -f $FILE ];
-    then
-       echo "File $FILE exists."
-       tar -zxf $FILE
+    case ${SOLR_VERSION} in
+        4.10.4|6.3.0 )
+            url="http://archive.apache.org/dist/lucene/solr/${SOLR_VERSION}/solr-${SOLR_VERSION}.tgz"
+            ;;
+        *)
+            echo "Version '${SOLR_VERSION}' is not supported or not valid"
+            exit 1
+            ;;
+    esac
+
+    create_dir ${SOLR_DIR}
+
+    archive_file_name="${SOLR_VERSION}.tgz"
+    installation_archive_file="${SOLR_DIR}/${archive_file_name}"
+
+    if [ ! -d ${SOLR_INSTALL_DIR} ] ; then
+        echo "Installation ${SOLR_VERSION} does not exists"
+
+        if [ ! -f ${installation_archive_file} ] ; then
+            echo "Installation archive ${archive_file_name} does not exist"
+            echo "Downloading Solr from ${url}..."
+            curl -o ${installation_archive_file} ${url}
+            echo 'Downloaded'
+        fi
+
+        echo "Extracting from installation archive ${archive_file_name}..."
+        create_dir ${SOLR_INSTALL_DIR}
+        tar -zxf ${installation_archive_file} -C ${SOLR_INSTALL_DIR} --strip-components=1
+        echo 'Extracted'
     else
-       echo "File $FILE does not exist. Downloading solr from $1..."
-       curl -O $1
-       tar -zxf $FILE
+        echo "Found existing ${SOLR_VERSION} installation"
     fi
-    echo "Downloaded!"
 }
 
-is_solr_up(){
-    echo "Checking if solr is up on http://localhost:$SOLR_PORT/solr/admin/cores"
-    http_code=`echo $(curl -s -o /dev/null -w "%{http_code}" "http://localhost:$SOLR_PORT/solr/admin/cores")`
-    return `test $http_code = "200"`
+copy_files() {
+    destination_dir_name=$1
+    shift
+    files=("$@")
+
+    for file in ${files} ; do
+        copy_file ${file} ${destination_dir_name}
+    done
+}
+
+copy_file() {
+    file=$1
+    destination_dir=$2
+
+    if [ -f "${file}" ] ; then
+        cp ${file} ${destination_dir}
+        echo "Copied file '${file}' to directory '${destination_dir}'"
+    else
+        echo "${file} is not valid"
+        exit 1
+    fi
+}
+
+create_dir() {
+    dir_name=$1
+
+    if [ ! -d ${dir_name} ] ; then
+        mkdir ${dir_name}
+        echo "Created directory '${dir_name}'"
+    fi
+}
+
+exit_on_error() {
+    message=$1
+
+    echo "ERROR: ${message}"
+    exit 1
+}
+
+is_solr_up() {
+    address="http://localhost:${SOLR_PORT}/solr/admin/cores"
+    http_code=`echo $(curl -s -o /dev/null -w "%{http_code}" ${address})`
+    echo "Checking if Solr is up on ${address}"
+    return `test ${http_code} = "200"`
 }
 
 wait_for_solr(){
@@ -30,246 +105,121 @@ wait_for_solr(){
     done
 }
 
-run() {
-    dir_name=$1
-    solr_port=$2
-    mode=$3
-    # Run solr
-    echo "Running with folder ${dir_name} in ${mode} mode"
-    echo "Starting solr on port ${solr_port}..."
+solr4_configure() {
+    # remove default cores configuration
+    sed -i.bak 's/<core name=".*" instanceDir=".*" \/>//g' "${SOLR_INSTALL_DIR}/example/multicore/solr.xml"
 
-    # go to the solr folder
-    cd $dir_name/example
-
-    if [ "$DEBUG" = "true" ]
-    then
-        if [ "$mode" = "multi" ]
-        then
-            java -Djetty.port=$solr_port -Dsolr.solr.home=multicore -jar start.jar &
-        else
-            java -Djetty.port=$solr_port -jar start.jar &
-        fi
-    else
-        if [ "$mode" = "multi" ]
-        then
-            java -Djetty.port=$solr_port -Dsolr.solr.home=multicore -jar start.jar > /dev/null 2>&1 &
-        else
-            java -Djetty.port=$solr_port -jar start.jar > /dev/null 2>&1 &
-        fi
-    fi
-    wait_for_solr
-    cd ../../
-    echo "Started"
+    for solr_core in ${SOLR_CORES} ; do
+        solr4_add_core ${solr_core}
+    done
 }
 
-download_and_run() {
-    case $1 in
-        3.5.0)
-            url="http://archive.apache.org/dist/lucene/solr/3.5.0/apache-solr-3.5.0.tgz"
-            dir_name="apache-solr-3.5.0"
-            dir_conf="conf/"
-            ;;
-        3.6.0)
-            url="http://archive.apache.org/dist/lucene/solr/3.6.0/apache-solr-3.6.0.tgz"
-            dir_name="apache-solr-3.6.0"
-            dir_conf="conf/"
-            ;;
-        3.6.1)
-            url="http://archive.apache.org/dist/lucene/solr/3.6.1/apache-solr-3.6.1.tgz"
-            dir_name="apache-solr-3.6.1"
-            dir_conf="conf/"
-            ;;
-        3.6.2)
-            url="http://archive.apache.org/dist/lucene/solr/3.6.2/apache-solr-3.6.2.tgz"
-            dir_name="apache-solr-3.6.2"
-            dir_conf="conf/"
-            ;;
-        4.0.0)
-            url="http://archive.apache.org/dist/lucene/solr/4.0.0/apache-solr-4.0.0.tgz"
-            dir_name="apache-solr-4.0.0"
-            dir_conf="collection1/conf/"
-            ;;
-        4.1.0)
-            url="http://archive.apache.org/dist/lucene/solr/4.1.0/solr-4.1.0.tgz"
-            dir_name="solr-4.1.0"
-            dir_conf="collection1/conf/"
-            ;;
-        4.2.0)
-            url="http://archive.apache.org/dist/lucene/solr/4.2.0/solr-4.2.0.tgz"
-            dir_name="solr-4.2.0"
-            dir_conf="collection1/conf/"
-            ;;
-        4.2.1)
-            url="http://archive.apache.org/dist/lucene/solr/4.2.1/solr-4.2.1.tgz"
-            dir_name="solr-4.2.1"
-            dir_conf="collection1/conf/"
-            ;;
-        4.3.1)
-            url="http://archive.apache.org/dist/lucene/solr/4.3.1/solr-4.3.1.tgz"
-            dir_name="solr-4.3.1"
-            dir_conf="collection1/conf/"
-            ;;
-        4.4.0)
-            url="http://archive.apache.org/dist/lucene/solr/4.4.0/solr-4.4.0.tgz"
-            dir_name="solr-4.4.0"
-            dir_conf="collection1/conf/"
-            ;;
-        4.5.0)
-            url="http://archive.apache.org/dist/lucene/solr/4.5.0/solr-4.5.0.tgz"
-            dir_name="solr-4.5.0"
-            dir_conf="collection1/conf/"
-            ;;
-        4.5.1)
-            url="http://archive.apache.org/dist/lucene/solr/4.5.1/solr-4.5.1.tgz"
-            dir_name="solr-4.5.1"
-            dir_conf="collection1/conf/"
-            ;;
-        4.6.0)
-            url="http://archive.apache.org/dist/lucene/solr/4.6.0/solr-4.6.0.tgz"
-            dir_name="solr-4.6.0"
-            dir_conf="collection1/conf/"
-            ;;
-        4.6.1)
-            url="http://archive.apache.org/dist/lucene/solr/4.6.1/solr-4.6.1.tgz"
-            dir_name="solr-4.6.1"
-            dir_conf="collection1/conf/"
-            ;;
-        4.7.0)
-            url="http://archive.apache.org/dist/lucene/solr/4.7.0/solr-4.7.0.tgz"
-            dir_name="solr-4.7.0"
-            dir_conf="collection1/conf/"
-            ;;
-        4.7.1)
-            url="http://archive.apache.org/dist/lucene/solr/4.7.1/solr-4.7.1.tgz"
-            dir_name="solr-4.7.1"
-            dir_conf="collection1/conf/"
-            ;;
-        4.7.2)
-            url="http://archive.apache.org/dist/lucene/solr/4.7.2/solr-4.7.2.tgz"
-            dir_name="solr-4.7.2"
-            dir_conf="collection1/conf/"
-            ;;
-        4.8.0)
-            url="http://archive.apache.org/dist/lucene/solr/4.8.0/solr-4.8.0.tgz"
-            dir_name="solr-4.8.0"
-            dir_conf="collection1/conf/"
-            ;;
-        4.8.1)
-            url="http://archive.apache.org/dist/lucene/solr/4.8.1/solr-4.8.1.tgz"
-            dir_name="solr-4.8.1"
-            dir_conf="collection1/conf/"
-            ;;
-        4.9.0)
-            url="http://archive.apache.org/dist/lucene/solr/4.9.0/solr-4.9.0.tgz"
-            dir_name="solr-4.9.0"
-            dir_conf="collection1/conf/"
-            ;;
-        4.9.1)
-            url="http://archive.apache.org/dist/lucene/solr/4.9.1/solr-4.9.1.tgz"
-            dir_name="solr-4.9.1"
-            dir_conf="collection1/conf/"
-            ;;
-        4.10.0)
-            url="http://archive.apache.org/dist/lucene/solr/4.10.0/solr-4.10.0.tgz"
-            dir_name="solr-4.10.0"
-            dir_conf="collection1/conf/"
-            ;;
-        4.10.1)
-            url="http://archive.apache.org/dist/lucene/solr/4.10.1/solr-4.10.1.tgz"
-            dir_name="solr-4.10.1"
-            dir_conf="collection1/conf/"
-            ;;
-        4.10.2)
-            url="http://archive.apache.org/dist/lucene/solr/4.10.2/solr-4.10.2.tgz"
-            dir_name="solr-4.10.2"
-            dir_conf="collection1/conf/"
-            ;;
-        4.10.3)
-            url="http://archive.apache.org/dist/lucene/solr/4.10.3/solr-4.10.3.tgz"
-            dir_name="solr-4.10.3"
-            dir_conf="collection1/conf/"
-            ;;
-        4.10.4)
-            url="http://archive.apache.org/dist/lucene/solr/4.10.4/solr-4.10.4.tgz"
-            dir_name="solr-4.10.4"
-            dir_conf="collection1/conf/"
-            ;;
-    esac
-
-    download $url $dir_name
-
-    if [ ${#SOLR_CORES[@]} -eq 0 ]; then
-        destination_dir_name="$dir_name/example/solr/$dir_conf"
-        copy_configuration $destination_dir_name
-        mode="single"
-    else
-        # remove default cores configuration
-        sed -i.bak 's/<core name=".*" instanceDir=".*" \/>//g' $dir_name/example/multicore/solr.xml
-        for solr_core in ${SOLR_CORES[@]};
-        do
-            add_core $dir_name $dir_conf $solr_core
-        done
-        mode="multi"
-    fi
-
-    run $dir_name $SOLR_PORT $mode
-}
-
-add_core() {
-    dir_name=$1
-    dir_conf=$2
-    solr_core=$3
+solr4_add_core() {
+    solr_core=$1
+    core_dir="${SOLR_INSTALL_DIR}/example/multicore/${solr_core}"
+    core_conf_dir="${core_dir}/conf"
+    config_dir="${SOLR_INSTALL_DIR}/example/solr/collection1/conf"
 
     # add core configuration
-    sed -i.bak "s/<shardHandlerFactory/<core name=\"$solr_core\" instanceDir=\"$solr_core\" \/><shardHandlerFactory/g" $dir_name/example/multicore/solr.xml
+    sed -i.bak "s/<shardHandlerFactory/<core name=\"$solr_core\" instanceDir=\"$solr_core\" \/><shardHandlerFactory/g" ${SOLR_INSTALL_DIR}/example/multicore/solr.xml
 
     # prepare core directories
-    [[ -d "${dir_name}/example/multicore/${solr_core}" ]] || mkdir $dir_name/example/multicore/$solr_core
-    [[ -d "${dir_name}/example/multicore/${solr_core}/conf" ]] || mkdir $dir_name/example/multicore/$solr_core/conf
+    create_dir ${core_dir}
+    create_dir ${core_conf_dir}
 
-    # copy currency.xml, stopwords.txt and synonyms.txt
-    cp $dir_name/example/solr/collection1/conf/currency.xml $dir_name/example/multicore/$solr_core/conf/
-    cp $dir_name/example/solr/collection1/conf/stopwords.txt $dir_name/example/multicore/$solr_core/conf/
-    cp $dir_name/example/solr/collection1/conf/synonyms.txt $dir_name/example/multicore/$solr_core/conf/
+    files=${SOLR_CONFIG}
+    files+=("${config_dir}/currency.xml")
+    files+=("${config_dir}/stopwords.txt")
+    files+=("${config_dir}/synonyms.txt")
+
+    copy_files ${core_conf_dir} "${files[*]}"
 
     # copy core0 solrconfig.xml and patch it for current core
-    if [ ! -f $dir_name/example/multicore/$solr_core/conf/solrconfig.xml ]; then
-        cp $dir_name/example/multicore/core0/conf/solrconfig.xml $dir_name/example/multicore/$solr_core/conf/
-        sed -i.bak s/core0/"$solr_core"/g $dir_name/example/multicore/$solr_core/conf/solrconfig.xml
+    if [ ! -f ${core_conf_dir}/solrconfig.xml ] ; then
+        copy_file "${SOLR_INSTALL_DIR}/example/multicore/core0/conf/solrconfig.xml" ${core_conf_dir}
+        sed -i.bak s/core0/"${solr_core}"/g ${core_conf_dir}/solrconfig.xml
     fi
 
-    destination_dir_name="$dir_name/example/multicore/$solr_core/conf"
-    copy_configuration $destination_dir_name
+    echo "Configured core ${solr_core}"
 }
 
-copy_configuration() {
-    destination_dir_name=$1
+solr4_run() {
+    echo "Running with version ${SOLR_VERSION}"
+    echo "Starting solr on port ${SOLR_PORT}..."
 
-    if [ -d "${SOLR_CONFS}" ] ; then
-      cp -R $SOLR_CONFS/* $destination_dir_name
+    cd ${SOLR_INSTALL_DIR}/example
+
+    if [ "$SOLR_DEBUG" = "true" ] ; then
+        java -Djetty.port=${SOLR_PORT} -Dsolr.solr.home=multicore -jar start.jar &
     else
-      for file in $SOLR_CONFS
-      do
-        if [ -f "${file}" ]; then
-            cp $file $destination_dir_name
-            echo "Copied $file into solr conf directory."
-        else
-            echo "${file} is not valid";
-            exit 1
-        fi
-      done
+        java -Djetty.port=${SOLR_PORT} -Dsolr.solr.home=multicore -jar start.jar > /dev/null 2>&1 &
     fi
+
+    wait_for_solr
+
+    cd ../../../
+    echo 'Started'
 }
 
-check_version() {
-    case $1 in
-        3.5.0|3.6.0|3.6.1|3.6.2|4.0.0|4.1.0|4.2.0|4.2.1|4.3.1|4.4.0|4.5.0|4.5.1|4.6.0|4.6.1|4.7.0|4.7.1|4.7.2|4.8.0|4.8.1|4.9.0|4.9.1|4.10.0|4.10.1|4.10.2|4.10.3|4.10.4);;
-        *)
-            echo "Sorry, $1 is not supported or not valid version."
-            exit 1
-            ;;
-    esac
+configure() {
+    home_dir="${SOLR_INSTALL_DIR}/server/${SOLR_HOME}"
+    template_dir="${home_dir}/template"
+    config_dir="${SOLR_INSTALL_DIR}/server/solr/configsets/basic_configs/conf"
+
+    create_dir ${home_dir}
+    create_dir ${template_dir}
+
+    files=${SOLR_CONFIG}
+    files+=("${config_dir}/currency.xml")
+    files+=("${config_dir}/solrconfig.xml")
+    files+=("${config_dir}/stopwords.txt")
+    files+=("${config_dir}/synonyms.txt")
+    files+=("${config_dir}/elevate.xml")
+
+    copy_files ${template_dir} "${files[*]}"
+    copy_file "${SOLR_INSTALL_DIR}/server/solr/solr.xml" ${home_dir}
+
+    # modify solrconfig.xml to remove section that doesn't agree with our schema
+    sed -i.bak '/<updateRequestProcessorChain name="add-unknown-fields-to-the-schema">/,/<\/updateRequestProcessorChain>/d' "${template_dir}/solrconfig.xml"
 }
 
-check_version $SOLR_VERSION
-download_and_run $SOLR_VERSION
+run() {
+    echo "Running with version ${SOLR_VERSION} in standalone mode"
+    echo "Starting solr on port ${SOLR_PORT}..."
+
+    ./${SOLR_INSTALL_DIR}/bin/solr -p ${SOLR_PORT} -s ${SOLR_HOME} || exit_on_error "Can't start Solr"
+
+    echo "Started"
+
+    create_cores
+}
+
+create_cores() {
+    home_dir="${SOLR_INSTALL_DIR}/server/${SOLR_HOME}"
+    template_dir="${home_dir}/template"
+
+    for solr_core in ${SOLR_CORES} ; do
+        if [ ! -d "${home_dir}/${solr_core}" ] ; then
+            create_core ${solr_core} ${template_dir}
+        else
+            echo "Core ${solr_core} already exists, skipping"
+        fi
+    done
+}
+
+create_core() {
+    core_name=$1
+    config_dir=$2
+
+    ./${SOLR_INSTALL_DIR}/bin/solr create_core -c ${core_name} -d ${config_dir} || exit_on_error "Can't create core"
+}
+
+download
+
+if [[ ${SOLR_VERSION} == 6* ]] ; then
+    configure
+    run
+else
+    solr4_configure
+    solr4_run
+fi

--- a/lib/Resources/config/solr/language-fieldtypes.xml
+++ b/lib/Resources/config/solr/language-fieldtypes.xml
@@ -1,12 +1,12 @@
     <fieldType name="text" class="solr.TextField" positionIncrementGap="100">
       <analyzer type="index">
         <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" enablePositionIncrements="true" />
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
         <filter class="solr.LowerCaseFilterFactory"/>
       </analyzer>
       <analyzer type="query">
         <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" enablePositionIncrements="true" />
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
         <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
         <filter class="solr.LowerCaseFilterFactory"/>
       </analyzer>


### PR DESCRIPTION
This PR resolves https://jira.ez.no/browse/EZP-26775

`ezpublish-kernel` counterpart: https://github.com/ezsystems/ezpublish-kernel/pull/1864

This refactors Travis Solr initialization script and adds ability to test Solr `6.3.0`.
This is still standalone/multicore setup, no Solr Cloud testing is done. It would be possible to set that up, but the implementation requires some work before support for it would be sensible (we would be limited to 1 replica per shard).

From default full text field configuration `enablePositionIncrements` flag is removed as it's invalid with Solr v5+, and it was not used anyway since Solr v4.3.
See [Stop Filter documentation](https://cwiki.apache.org/confluence/display/solr/Filter+Descriptions#FilterDescriptions-StopFilter) for more details.

### TODOs

- [x] update `README.md`
- [x] PR on `ezpublish-kernel`: https://github.com/ezsystems/ezpublish-kernel/pull/1864