### PR TITLE
Add deprecated implementation for BC reasons

### DIFF
--- a/lib/Query/Common/CriterionVisitor/Field.php
+++ b/lib/Query/Common/CriterionVisitor/Field.php
@@ -18,7 +18,9 @@ use eZ\Publish\SPI\Search\Field as SearchField;
 use eZ\Publish\SPI\Search\FieldType;
 
 /**
- * Visits the Field criterion.
+ * Base class for Field criterion visitors.
+ *
+ * @api
  */
 abstract class Field extends CriterionVisitor
 {

--- a/lib/Query/Content/CriterionVisitor/Field.php
+++ b/lib/Query/Content/CriterionVisitor/Field.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * This file is part of the eZ Platform Solr Search Engine package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformSolrSearchEngine\Query\Content\CriterionVisitor;
+
+use EzSystems\EzPlatformSolrSearchEngine\Query\Common\CriterionVisitor\Field as FieldBase;
+
+/**
+ * Kept for BC reasons.
+ *
+ * @deprecated since 1.2, to be removed in 2.0. Use extended class instead.
+ *
+ * @see \EzSystems\EzPlatformSolrSearchEngine\Query\Common\CriterionVisitor\Field
+ */
+abstract class Field extends FieldBase
+{
+}


### PR DESCRIPTION
Adds deprecated implementation for the abstract `Field` criterion visitor on the previous namespace.

See https://github.com/ezsystems/ezplatform-solr-search-engine/pull/72