### PR TITLE
Revert "[Travis] Fix missing Java by using previous image (#79)"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@
 sudo: required
 dist: trusty
 
-# Workaround for the issue found in the stable image promoted on Dec 1, 2016.
-# See https://github.com/travis-ci/travis-ci/issues/6928#issuecomment-264227708
-group: deprecated
-
 language: php
 
 cache:


### PR DESCRIPTION
This reverts commit 2d6b6705d7775121276fdaf294c3fb00c185c9fd.


Should not be needed anymore.