### PR TITLE
EZP-27227: Implement index-time boosting

### DIFF
--- a/bundle/ApiLoader/BoostFactorProviderFactory.php
+++ b/bundle/ApiLoader/BoostFactorProviderFactory.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * This file is part of the eZ Platform Solr Search Engine package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace EzSystems\EzPlatformSolrSearchEngineBundle\ApiLoader;
+
+use eZ\Bundle\EzPublishCoreBundle\ApiLoader\RepositoryConfigurationProvider;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+
+class BoostFactorProviderFactory implements ContainerAwareInterface
+{
+    use ContainerAwareTrait;
+
+    /**
+     * @var \eZ\Bundle\EzPublishCoreBundle\ApiLoader\RepositoryConfigurationProvider
+     */
+    private $repositoryConfigurationProvider;
+
+    /**
+     * @var string
+     */
+    private $defaultConnection;
+
+    /**
+     * @var string
+     */
+    private $boostFactorProviderClass;
+
+    /**
+     * @param \eZ\Bundle\EzPublishCoreBundle\ApiLoader\RepositoryConfigurationProvider $repositoryConfigurationProvider
+     * @param string $defaultConnection
+     * @param string $boostFactorProviderClass
+     */
+    public function __construct(
+        RepositoryConfigurationProvider $repositoryConfigurationProvider,
+        $defaultConnection,
+        $boostFactorProviderClass
+    ) {
+        $this->repositoryConfigurationProvider = $repositoryConfigurationProvider;
+        $this->defaultConnection = $defaultConnection;
+        $this->boostFactorProviderClass = $boostFactorProviderClass;
+    }
+
+    public function buildService()
+    {
+        $repositoryConfig = $this->repositoryConfigurationProvider->getRepositoryConfig();
+
+        $connection = $this->defaultConnection;
+        if (isset($repositoryConfig['search']['connection'])) {
+            $connection = $repositoryConfig['search']['connection'];
+        }
+
+        return new $this->boostFactorProviderClass(
+            $this->container->getParameter(
+                "ez_search_engine_solr.connection.{$connection}.boost_factor_map_id"
+            )
+        );
+    }
+}

--- a/bundle/ApiLoader/BoostFactorProviderFactory.php
+++ b/bundle/ApiLoader/BoostFactorProviderFactory.php
@@ -12,6 +12,9 @@ use eZ\Bundle\EzPublishCoreBundle\ApiLoader\RepositoryConfigurationProvider;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
+/**
+ * BoostFactorProvider service factory takes into account boost factor semantic configuration.
+ */
 class BoostFactorProviderFactory implements ContainerAwareInterface
 {
     use ContainerAwareTrait;

--- a/bundle/ApiLoader/BoostFactorProviderFactory.php
+++ b/bundle/ApiLoader/BoostFactorProviderFactory.php
@@ -5,8 +5,6 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- *
- * @version //autogentag//
  */
 namespace EzSystems\EzPlatformSolrSearchEngineBundle\ApiLoader;
 

--- a/bundle/DependencyInjection/Configuration.php
+++ b/bundle/DependencyInjection/Configuration.php
@@ -250,7 +250,13 @@ class Configuration implements ConfigurationInterface
                     ->end()
                     ->arrayNode('boost_factors')
                         ->addDefaultsIfNotSet()
-                        ->info('Index-time field boost factor mapping.')
+                        ->info(
+                            "Index-time field boost factor mapping.\n\n" .
+                            'Note: Changes to this configuration are not reflected on the Solr index without ' .
+                            'manually re-indexing the affected content or executing a full re-index. ' .
+                            'To avoid that a future version might apply boost factors on the query instead ' .
+                            '(also known as query-time boost).'
+                        )
                         ->children()
                             ->arrayNode('content_type')
                                 ->info('A map of ContentType identifiers and boost factors for fields.')

--- a/bundle/DependencyInjection/Configuration.php
+++ b/bundle/DependencyInjection/Configuration.php
@@ -334,7 +334,7 @@ class Configuration implements ConfigurationInterface
                                     ->useAttributeAsKey('meta_field_name')
                                     ->validate()
                                         ->ifTrue(
-                                            function($v) {
+                                            function (array $v) {
                                                 foreach (array_keys($v) as $key) {
                                                     if (!in_array($key, $this->metaFieldNames, true)) {
                                                         return true;

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -1,5 +1,6 @@
 parameters:
     ezpublish.solr.engine_factory.class: EzSystems\EzPlatformSolrSearchEngineBundle\ApiLoader\SolrEngineFactory
+    ezpublish.solr.boost_factor_provider_factory.class: EzSystems\EzPlatformSolrSearchEngineBundle\ApiLoader\BoostFactorProviderFactory
     ez_search_engine_solr.default_connection: ~
 
 services:
@@ -9,5 +10,14 @@ services:
             - "@ezpublish.api.repository_configuration_provider"
             - "%ez_search_engine_solr.default_connection%"
             - "%ezpublish.spi.search.solr.class%"
+        calls:
+            - [setContainer, ["@service_container"]]
+
+    ezpublish.solr.boost_factor_provider_factory:
+        class: "%ezpublish.solr.boost_factor_provider_factory.class%"
+        arguments:
+            - "@ezpublish.api.repository_configuration_provider"
+            - "%ez_search_engine_solr.default_connection%"
+            - "%ezpublish.search.solr.boost_factor_provider.class%"
         calls:
             - [setContainer, ["@service_container"]]

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "~5.6|~7.0",
-        "ezsystems/ezpublish-kernel": "^6.7.0@dev|^7.0@dev"
+        "ezsystems/ezpublish-kernel": "~6.7.4@dev|^6.9.1@dev|^7.0@dev"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.7",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "~5.6|~7.0",
-        "ezsystems/ezpublish-kernel": "^6.7.0@dev|^7.0@dev"
+        "ezsystems/ezpublish-kernel": "dev-index-time-boost"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.7",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "~5.6|~7.0",
-        "ezsystems/ezpublish-kernel": "dev-index-time-boost"
+        "ezsystems/ezpublish-kernel": "^6.7.0@dev|^7.0@dev"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.7",

--- a/lib/FieldMapper/BoostFactorProvider.php
+++ b/lib/FieldMapper/BoostFactorProvider.php
@@ -5,8 +5,6 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- *
- * @version //autogentag//
  */
 namespace EzSystems\EzPlatformSolrSearchEngine\FieldMapper;
 

--- a/lib/FieldMapper/BoostFactorProvider.php
+++ b/lib/FieldMapper/BoostFactorProvider.php
@@ -1,0 +1,149 @@
+<?php
+
+/**
+ * This file is part of the eZ Platform Solr Search Engine package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace EzSystems\EzPlatformSolrSearchEngine\FieldMapper;
+
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
+use eZ\Publish\SPI\Persistence\Content\Type as ContentType;
+
+/**
+ * BoostFactorProvider provides boost factors for indexed fields.
+ */
+class BoostFactorProvider
+{
+    /**
+     * Internal map key used to access Content field boost factors.
+     *
+     * @var string
+     */
+    private static $keyContentFields = 'content-fields';
+
+    /**
+     * Internal map key used to access meta field boost factors.
+     *
+     * @var string
+     */
+    private static $keyMetaFields = 'meta-fields';
+
+    /**
+     * Internal map wildcard type key.
+     *
+     * @var string
+     */
+    private static $keyAny = '*';
+
+    /**
+     * Internal map of field boost factors.
+     *
+     * ```php
+     * $map = [
+     *     'content-fields' => [
+     *         '*' => [
+     *             'title' => 1.5,
+     *             'name' = 2.5,
+     *         ],
+     *         'article' => [
+     *             'title' => 3.0,
+     *             '*' => 2.0,
+     *         ],
+     *         'news' => [
+     *             'description' => 3.0,
+     *         ],
+     *     ],
+     *     'meta-fields' => [
+     *         '*' => [
+     *             'name' = 2.5,
+     *             'text' => 1.5,
+     *         ],
+     *         'article' => [
+     *             'name' => 3.0,
+     *             '*' => 2.0,
+     *         ],
+     *         'news' => [
+     *             'text' => 2.0,
+     *         ],
+     *     ],
+     * ];
+     * ```
+     *
+     * @var array
+     */
+    private $map;
+
+    /**
+     * Boost factor to be used if no mapping is found.
+     *
+     * @var float
+     */
+    private $defaultBoostFactor = 1.0;
+
+    /**
+     * @param array $map
+     */
+    public function __construct(array $map = [])
+    {
+        $this->map = $map;
+    }
+
+    /**
+     * Get boost factor for a Content field by the given $contentType and $fieldDefinition.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content\Type $contentType
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
+     *
+     * @return float
+     */
+    public function getContentFieldBoostFactor(ContentType $contentType, FieldDefinition $fieldDefinition)
+    {
+        $typeIdentifier = $contentType->identifier;
+        $fieldIdentifier = $fieldDefinition->identifier;
+
+        if (!isset($this->map[self::$keyContentFields][$typeIdentifier])) {
+            $typeIdentifier = self::$keyAny;
+        }
+
+        if (!isset($this->map[self::$keyContentFields][$typeIdentifier][$fieldIdentifier])) {
+            $fieldIdentifier = self::$keyAny;
+        }
+
+        if (isset($this->map[self::$keyContentFields][$typeIdentifier][$fieldIdentifier])) {
+            return $this->map[self::$keyContentFields][$typeIdentifier][$fieldIdentifier];
+        }
+
+        return $this->defaultBoostFactor;
+    }
+
+    /**
+     * Get boost factor for a Content meta field by the given $fieldName.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content\Type $contentType
+     * @param string $fieldName
+     *
+     * @return float
+     */
+    public function getContentMetaFieldBoostFactor(ContentType $contentType, $fieldName)
+    {
+        $typeIdentifier = $contentType->identifier;
+
+        if (!isset($this->map[self::$keyMetaFields][$typeIdentifier])) {
+            $typeIdentifier = self::$keyAny;
+        }
+
+        if (!isset($this->map[self::$keyMetaFields][$typeIdentifier][$fieldName])) {
+            $fieldName = self::$keyAny;
+        }
+
+        if (isset($this->map[self::$keyMetaFields][$typeIdentifier][$fieldName])) {
+            return $this->map[self::$keyMetaFields][$typeIdentifier][$fieldName];
+        }
+
+        return $this->defaultBoostFactor;
+    }
+}

--- a/lib/FieldMapper/ContentTranslationFieldMapper/BlockDocumentsContentFields.php
+++ b/lib/FieldMapper/ContentTranslationFieldMapper/BlockDocumentsContentFields.php
@@ -126,6 +126,10 @@ class BlockDocumentsContentFields extends ContentTranslationFieldMapper
         FieldDefinition $fieldDefinition,
         FieldType $fieldType
     ) {
+        if (!$fieldType instanceof FieldType\TextField) {
+            return $fieldType;
+        }
+
         $fieldType = clone $fieldType;
         $fieldType->boost = $this->boostFactorProvider->getContentFieldBoostFactor(
             $contentType,

--- a/lib/FieldMapper/ContentTranslationFieldMapper/ContentDocumentTranslatedContentNameField.php
+++ b/lib/FieldMapper/ContentTranslationFieldMapper/ContentDocumentTranslatedContentNameField.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * This file is part of the eZ Platform Solr Search Engine package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentTranslationFieldMapper;
+
+use EzSystems\EzPlatformSolrSearchEngine\FieldMapper\BoostFactorProvider;
+use EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentTranslationFieldMapper;
+use eZ\Publish\SPI\Persistence\Content;
+use eZ\Publish\SPI\Persistence\Content\Type\Handler as ContentTypeHandler;
+use eZ\Publish\SPI\Search\Field;
+use eZ\Publish\SPI\Search\FieldType;
+
+/**
+ * Maps Content fulltext fields to Content document.
+ */
+class ContentDocumentTranslatedContentNameField extends ContentTranslationFieldMapper
+{
+    /**
+     * Field name, untyped.
+     *
+     * @var string
+     */
+    private static $fieldName = 'meta_content__name';
+
+    /**
+     * @var \eZ\Publish\SPI\Persistence\Content\Type\Handler
+     */
+    protected $contentTypeHandler;
+
+    /**
+     * @var \EzSystems\EzPlatformSolrSearchEngine\FieldMapper\BoostFactorProvider
+     */
+    protected $boostFactorProvider;
+
+    /**
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\Handler $contentTypeHandler
+     * @param \EzSystems\EzPlatformSolrSearchEngine\FieldMapper\BoostFactorProvider $boostFactorProvider
+     */
+    public function __construct(
+        ContentTypeHandler $contentTypeHandler,
+        BoostFactorProvider $boostFactorProvider
+    ) {
+        $this->contentTypeHandler = $contentTypeHandler;
+        $this->boostFactorProvider = $boostFactorProvider;
+    }
+
+    public function accept(Content $content, $languageCode)
+    {
+        return true;
+    }
+
+    public function mapFields(Content $content, $languageCode)
+    {
+        if (!isset($content->versionInfo->names[$languageCode])) {
+            return [];
+        }
+
+        $contentName = $content->versionInfo->names[$languageCode];
+        $contentType = $this->contentTypeHandler->load(
+            $content->versionInfo->contentInfo->contentTypeId
+        );
+
+        return [
+            new Field(
+                self::$fieldName,
+                $contentName,
+                new FieldType\StringField()
+            ),
+            new Field(
+                self::$fieldName,
+                $contentName,
+                new FieldType\TextField(
+                    [
+                        'boost' => $this->boostFactorProvider->getContentMetaFieldBoostFactor(
+                            $contentType,
+                            'name'
+                        ),
+                    ]
+                )
+            )
+        ];
+    }
+}

--- a/lib/FieldMapper/ContentTranslationFieldMapper/ContentDocumentTranslatedContentNameField.php
+++ b/lib/FieldMapper/ContentTranslationFieldMapper/ContentDocumentTranslatedContentNameField.php
@@ -82,7 +82,7 @@ class ContentDocumentTranslatedContentNameField extends ContentTranslationFieldM
                         ),
                     ]
                 )
-            )
+            ),
         ];
     }
 }

--- a/lib/Gateway/UpdateSerializer.php
+++ b/lib/Gateway/UpdateSerializer.php
@@ -5,8 +5,6 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- *
- * @version //autogentag//
  */
 namespace EzSystems\EzPlatformSolrSearchEngine\Gateway;
 

--- a/lib/Gateway/UpdateSerializer.php
+++ b/lib/Gateway/UpdateSerializer.php
@@ -1,0 +1,141 @@
+<?php
+
+/**
+ * This file is part of the eZ Platform Solr Search Engine package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace EzSystems\EzPlatformSolrSearchEngine\Gateway;
+
+use eZ\Publish\Core\Search\Common\FieldValueMapper;
+use eZ\Publish\Core\Search\Common\FieldNameGenerator;
+use eZ\Publish\SPI\Search\Field;
+use eZ\Publish\SPI\Search\FieldType;
+use eZ\Publish\SPI\Search\Document;
+use XMLWriter;
+
+/**
+ * Update serializer converts an array of document objects to the XML string that
+ * can be posted to Solr backend for indexing.
+ */
+class UpdateSerializer
+{
+    /**
+     * @var \eZ\Publish\Core\Search\Common\FieldValueMapper
+     */
+    protected $fieldValueMapper;
+
+    /**
+     * @var \eZ\Publish\Core\Search\Common\FieldNameGenerator
+     */
+    protected $nameGenerator;
+
+    /**
+     * @param \eZ\Publish\Core\Search\Common\FieldValueMapper $fieldValueMapper
+     * @param \eZ\Publish\Core\Search\Common\FieldNameGenerator $nameGenerator
+     */
+    public function __construct(
+        FieldValueMapper $fieldValueMapper,
+        FieldNameGenerator $nameGenerator
+    ) {
+        $this->fieldValueMapper = $fieldValueMapper;
+        $this->nameGenerator = $nameGenerator;
+    }
+
+    /**
+     * Create update XML for the given array of $documents.
+     *
+     * @param \eZ\Publish\SPI\Search\Document[] $documents
+     *
+     * @return string
+     */
+    public function serialize(array $documents)
+    {
+        $xmlWriter = new XMLWriter();
+        $xmlWriter->openMemory();
+        $xmlWriter->startElement('add');
+
+        foreach ($documents as $document) {
+            if (empty($document->documents)) {
+                $document->documents[] = $this->getNestedDummyDocument($document->id);
+            }
+
+            $this->writeDocument($xmlWriter, $document);
+        }
+
+        $xmlWriter->endElement();
+
+        return $xmlWriter->outputMemory(true);
+    }
+
+    private function writeDocument(XMLWriter $xmlWriter, Document $document)
+    {
+        $xmlWriter->startElement('doc');
+
+        $this->writeField(
+            $xmlWriter,
+            new Field(
+                'id',
+                $document->id,
+                new FieldType\IdentifierField()
+            )
+        );
+
+        foreach ($document->fields as $field) {
+            $this->writeField($xmlWriter, $field);
+        }
+
+        foreach ($document->documents as $subDocument) {
+            $this->writeDocument($xmlWriter, $subDocument);
+        }
+
+        $xmlWriter->endElement();
+    }
+
+    private function writeField(XMLWriter $xmlWriter, Field $field)
+    {
+        $values = (array)$this->fieldValueMapper->map($field);
+        $name = $this->nameGenerator->getTypedName($field->name, $field->type);
+
+        foreach ($values as $value) {
+            $xmlWriter->startElement('field');
+            $xmlWriter->writeAttribute('name', $name);
+            $xmlWriter->writeAttribute('boost', $field->type->boost);
+            $xmlWriter->text($value);
+            $xmlWriter->endElement();
+        }
+    }
+
+    /**
+     * Returns a 'dummy' document.
+     *
+     * This is intended to be indexed as nested document of Content, in order to enforce
+     * document block when Content does not have other nested documents (Locations).
+     * Not intended to be matched or returned as a search result.
+     *
+     * For more info see:
+     * @link http://grokbase.com/t/lucene/solr-user/14chqr73nv/converting-to-parent-child-block-indexing
+     * @link https://issues.apache.org/jira/browse/SOLR-5211
+     *
+     * @param string $id
+     * @return \eZ\Publish\SPI\Search\Document
+     */
+    private function getNestedDummyDocument($id)
+    {
+        return new Document(
+            [
+                'id' => $id . '_nested_dummy',
+                'fields' => [
+                    new Field(
+                        'document_type',
+                        'nested_dummy',
+                        new FieldType\IdentifierField()
+                    ),
+                ],
+            ]
+        );
+    }
+}

--- a/lib/Query/Content/CriterionVisitor/FullText.php
+++ b/lib/Query/Content/CriterionVisitor/FullText.php
@@ -76,7 +76,7 @@ class FullText extends CriterionVisitor
         $string = $this->prepareSearchString($criterion);
         $queries = [];
 
-        $queries[] = "text:({$string})";
+        $queries[] = "meta_content__text_t:({$string})";
 
         foreach ($criterion->boost as $field => $boost) {
             $searchFields = $this->getSearchFields($criterion, $field);

--- a/lib/Resources/config/container/solr.yml
+++ b/lib/Resources/config/container/solr.yml
@@ -13,10 +13,12 @@ parameters:
     ezpublish.search.solr.gateway.native.class: EzSystems\EzPlatformSolrSearchEngine\Gateway\Native
     ezpublish.search.solr.gateway.endpoint_registry.class: EzSystems\EzPlatformSolrSearchEngine\Gateway\EndpointRegistry
     ezpublish.search.solr.gateway.endpoint_resolver.native.class: EzSystems\EzPlatformSolrSearchEngine\Gateway\EndpointResolver\NativeEndpointResolver
+    ezpublish.search.solr.gateway.update_serializer.class: EzSystems\EzPlatformSolrSearchEngine\Gateway\UpdateSerializer
     ezpublish.search.solr.core_filter.native.class: EzSystems\EzPlatformSolrSearchEngine\CoreFilter\NativeCoreFilter
     ezpublish.search.solr.document_mapper.native.class: EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\NativeDocumentMapper
     ezpublish.search.solr.result_extractor.native.class: EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\NativeResultExtractor
     ezpublish.search.solr.query_converter.class: EzSystems\EzPlatformSolrSearchEngine\Query\Common\QueryConverter\NativeQueryConverter
+    ezpublish.search.solr.boost_factor_provider.class: EzSystems\EzPlatformSolrSearchEngine\FieldMapper\BoostFactorProvider
     # Endpoint resolver arguments must be set in order to be overrideable
     ezpublish.search.solr.entry_endpoints: []
     ezpublish.search.solr.cluster_endpoints: []
@@ -81,6 +83,12 @@ services:
             - "@ezpublish.search.solr.query.location.sort_clause_visitor.aggregate"
             - "@ezpublish.search.solr.query.location.facet_builder_visitor.aggregate"
 
+    ezpublish.search.solr.gateway.update_serializer:
+        class: "%ezpublish.search.solr.gateway.update_serializer.class%"
+        arguments:
+            - "@ezpublish.search.common.field_value_mapper.aggregate"
+            - "@ezpublish.search.common.field_name_generator"
+
     ezpublish.search.solr.gateway.native:
         class: "%ezpublish.search.solr.gateway.native.class%"
         arguments:
@@ -89,8 +97,7 @@ services:
             - "@ezpublish.search.solr.gateway.endpoint_registry"
             - "@ezpublish.search.solr.query_converter.content"
             - "@ezpublish.search.solr.query_converter.location"
-            - "@ezpublish.search.common.field_value_mapper.aggregate"
-            - "@ezpublish.search.common.field_name_generator"
+            - "@ezpublish.search.solr.gateway.update_serializer"
 
     ezpublish.search.solr.gateway:
         alias: ezpublish.search.solr.gateway.native

--- a/lib/Resources/config/container/solr/field_mappers.yml
+++ b/lib/Resources/config/container/solr/field_mappers.yml
@@ -5,6 +5,7 @@ parameters:
     ezpublish.search.solr.field_mapper.content.content_document_base_fields.class: EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentFieldMapper\ContentDocumentBaseFields
     ezpublish.search.solr.field_mapper.content.content_document_location_fields.class: EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentFieldMapper\ContentDocumentLocationFields
     ezpublish.search.solr.field_mapper.content_translation.content_document_fulltext_fields.class: EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentTranslationFieldMapper\ContentDocumentFulltextFields
+    ezpublish.search.solr.field_mapper.content_translation.content_document_translated_content_name_field.class: EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentTranslationFieldMapper\ContentDocumentTranslatedContentNameField
     ezpublish.search.solr.field_mapper.location.location_document_base_fields.class: EzSystems\EzPlatformSolrSearchEngine\FieldMapper\LocationFieldMapper\LocationDocumentBaseFields
 
 services:
@@ -51,6 +52,14 @@ services:
             - '@ezpublish.spi.persistence.content_type_handler'
             - '@ezpublish.search.common.field_registry'
             - '@ezpublish.search.common.field_name_generator'
+            - '@ezpublish.search.solr.field_mapper.boost_factor_provider'
+        tags:
+            - {name: ezpublish.search.solr.field_mapper.content_translation}
+
+    ezpublish.search.solr.field_mapper.content_translation.content_document_translated_content_name_field:
+        class: '%ezpublish.search.solr.field_mapper.content_translation.content_document_translated_content_name_field.class%'
+        arguments:
+            - '@ezpublish.spi.persistence.content_type_handler'
             - '@ezpublish.search.solr.field_mapper.boost_factor_provider'
         tags:
             - {name: ezpublish.search.solr.field_mapper.content_translation}

--- a/lib/Resources/config/container/solr/field_mappers.yml
+++ b/lib/Resources/config/container/solr/field_mappers.yml
@@ -24,6 +24,7 @@ services:
             - '@ezpublish.spi.persistence.content_type_handler'
             - '@ezpublish.search.common.field_registry'
             - '@ezpublish.search.common.field_name_generator'
+            - '@ezpublish.search.solr.field_mapper.boost_factor_provider'
         tags:
             - {name: ezpublish.search.solr.field_mapper.block_translation}
 
@@ -50,6 +51,7 @@ services:
             - '@ezpublish.spi.persistence.content_type_handler'
             - '@ezpublish.search.common.field_registry'
             - '@ezpublish.search.common.field_name_generator'
+            - '@ezpublish.search.solr.field_mapper.boost_factor_provider'
         tags:
             - {name: ezpublish.search.solr.field_mapper.content_translation}
 

--- a/lib/Resources/config/container/solr/services.yml
+++ b/lib/Resources/config/container/solr/services.yml
@@ -8,6 +8,8 @@ parameters:
     ezpublish.search.solr.field_mapper.content.class: EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentFieldMapper\Aggregate
     ezpublish.search.solr.field_mapper.content_translation.class: EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentTranslationFieldMapper\Aggregate
     ezpublish.search.solr.field_mapper.location.class: EzSystems\EzPlatformSolrSearchEngine\FieldMapper\LocationFieldMapper\Aggregate
+    ezpublish.search.solr.field_mapper.boost_factor_provider.class: EzSystems\EzPlatformSolrSearchEngine\FieldMapper\BoostFactorProvider
+    ezpublish.search.solr.field_mapper.boost_factor_provider.map: []
 
 services:
     ezpublish.search.solr.gateway.client.http.stream:
@@ -67,3 +69,8 @@ services:
     # are registered to this one using compilation pass
     ezpublish.search.solr.field_mapper.location:
         class: "%ezpublish.search.solr.field_mapper.location.class%"
+
+    ezpublish.search.solr.field_mapper.boost_factor_provider:
+        class: "%ezpublish.search.solr.field_mapper.boost_factor_provider.class%"
+        arguments:
+            - "%ezpublish.search.solr.field_mapper.boost_factor_provider.map%"

--- a/lib/Resources/config/solr/schema.xml
+++ b/lib/Resources/config/solr/schema.xml
@@ -92,7 +92,7 @@ should not remove or drastically change the existing definitions.
     <dynamicField name="*_s" type="string" indexed="true" stored="true"/>
     <dynamicField name="*_ms" type="string" indexed="true" stored="true" multiValued="true"/>
     <dynamicField name="*_l" type="long" indexed="true" stored="true"/>
-    <dynamicField name="*_t" type="text" indexed="true" stored="true"/>
+    <dynamicField name="*_t" type="text" indexed="true" stored="true" multiValued="true" omitNorms="false"/>
     <dynamicField name="*_b" type="boolean" indexed="true" stored="true"/>
     <dynamicField name="*_mb" type="boolean" indexed="true" stored="true" multiValued="true"/>
     <dynamicField name="*_f" type="float" indexed="true" stored="true"/>

--- a/lib/Resources/config/solr/schema.xml
+++ b/lib/Resources/config/solr/schema.xml
@@ -104,13 +104,6 @@ should not remove or drastically change the existing definitions.
     <dynamicField name="*_c" type="currency" indexed="true" stored="true"/>
 
     <!--
-      Full text field is indexed through proxy fields matching '*_fulltext' pattern.
-    -->
-    <field name="text" type="text" indexed="true" multiValued="true" stored="false"/>
-    <dynamicField name="*_fulltext" type="text" indexed="false" multiValued="true" stored="false"/>
-    <copyField source="*_fulltext" dest="text" />
-
-    <!--
       This field is required since Solr 4
     -->
     <field name="_version_" type="long" indexed="true" stored="true" multiValued="false" />

--- a/tests/bundle/DependencyInjection/EzPublishEzPlatformSolrSearchEngineExtensionTest.php
+++ b/tests/bundle/DependencyInjection/EzPublishEzPlatformSolrSearchEngineExtensionTest.php
@@ -441,4 +441,207 @@ class EzPublishEzPlatformSolrSearchEngineExtensionTest extends AbstractExtension
             'ez_search_engine_solr.connection.connection1.gateway_id'
         );
     }
+
+    public function dataProvideForTestBoostFactorMap()
+    {
+        return [
+            [
+                [
+                    'connections' => [
+                        'connection1' => [],
+                    ],
+                ],
+                [],
+            ],
+            [
+                [
+                    'connections' => [
+                        'connection1' => [
+                            'boost_factors' => [],
+                        ],
+                    ],
+                ],
+                [],
+            ],
+            [
+                [
+                    'connections' => [
+                        'connection1' => [
+                            'boost_factors' => [
+                                'content_type' => [
+                                    'article' => 1.5,
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'content-fields' => [
+                        'article' => [
+                            '*' => 1.5,
+                        ],
+                    ],
+                    'meta-fields' => [
+                        'article' => [
+                            '*' => 1.5,
+                        ],
+                    ],
+                ],
+            ],
+            [
+                [
+                    'connections' => [
+                        'connection1' => [
+                            'boost_factors' => [
+                                'field_definition' => [
+                                    'title' => 1.5,
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'content-fields' => [
+                        '*' => [
+                            'title' => 1.5,
+                        ],
+                    ],
+                ],
+            ],
+            [
+                [
+                    'connections' => [
+                        'connection1' => [
+                            'boost_factors' => [
+                                'field_definition' => [
+                                    'title' => 2.2,
+                                    'article' => [
+                                        'title' => 1.5,
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'content-fields' => [
+                        '*' => [
+                            'title' => 2.2,
+                        ],
+                        'article' => [
+                            'title' => 1.5,
+                        ],
+                    ],
+                ],
+            ],
+            [
+                [
+                    'connections' => [
+                        'connection1' => [
+                            'boost_factors' => [
+                                'content_type' => [
+                                    'article' => 5.5,
+                                ],
+                                'field_definition' => [
+                                    'title' => 2.2,
+                                    'article' => [
+                                        'title' => 1.5,
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'content-fields' => [
+                        'article' => [
+                            '*' => 5.5,
+                            'title' => 1.5,
+                        ],
+                        '*' => [
+                            'title' => 2.2,
+                        ],
+                    ],
+                    'meta-fields' => [
+                        'article' => [
+                            '*' => 5.5,
+                        ],
+                    ],
+                ],
+            ],
+            [
+                [
+                    'connections' => [
+                        'connection1' => [
+                            'boost_factors' => [
+                                'content_type' => [
+                                    'article' => 5.5,
+                                ],
+                                'meta_field' => [
+                                    'text' => 2.2,
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'content-fields' => [
+                        'article' => [
+                            '*' => 5.5,
+                        ],
+                    ],
+                    'meta-fields' => [
+                        'article' => [
+                            '*' => 5.5,
+                        ],
+                        '*' => [
+                            'text' => 2.2,
+                        ],
+                    ],
+                ],
+            ],
+            [
+                [
+                    'connections' => [
+                        'connection1' => [
+                            'boost_factors' => [
+                                'meta_field' => [
+                                    'text' => 2.2,
+                                    'article' => [
+                                        'name' => 7.8,
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'meta-fields' => [
+                        '*' => [
+                            'text' => 2.2,
+                        ],
+                        'article' => [
+                            'name' => 7.8,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProvideForTestBoostFactorMap
+     *
+     * @param array $configuration
+     * @param array $map
+     */
+    public function testBoostFactorMap(array $configuration, array $map)
+    {
+        $this->load($configuration);
+
+        $this->assertContainerBuilderHasParameter(
+            'ez_search_engine_solr.connection.connection1.boost_factor_map_id',
+            $map
+        );
+    }
 }

--- a/tests/lib/Search/FieldMapper/BoostFactorProviderTest.php
+++ b/tests/lib/Search/FieldMapper/BoostFactorProviderTest.php
@@ -92,6 +92,21 @@ class BoostFactorProviderTest extends TestCase
                 'title',
                 1.0,
             ],
+            [
+                [
+                    'content-fields' => [
+                        'article' => [
+                            '*' => 3.3,
+                        ],
+                        '*' => [
+                            'name' => 2.2,
+                        ],
+                    ],
+                ],
+                'article',
+                'name',
+                3.3,
+            ],
         ];
     }
 
@@ -203,6 +218,21 @@ class BoostFactorProviderTest extends TestCase
                 'news',
                 'name',
                 1.0,
+            ],
+            [
+                [
+                    'meta-fields' => [
+                        'article' => [
+                            '*' => 3.3,
+                        ],
+                        '*' => [
+                            'text' => 2.2,
+                        ],
+                    ],
+                ],
+                'article',
+                'text',
+                3.3,
             ],
         ];
     }

--- a/tests/lib/Search/FieldMapper/BoostFactorProviderTest.php
+++ b/tests/lib/Search/FieldMapper/BoostFactorProviderTest.php
@@ -5,8 +5,6 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- *
- * @version //autogentag//
  */
 namespace EzSystems\EzPlatformSolrSearchEngine\Tests\Search\FieldMapper;
 

--- a/tests/lib/Search/FieldMapper/BoostFactorProviderTest.php
+++ b/tests/lib/Search/FieldMapper/BoostFactorProviderTest.php
@@ -1,0 +1,256 @@
+<?php
+
+/**
+ * This file is part of the eZ Platform Solr Search Engine package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace EzSystems\EzPlatformSolrSearchEngine\Tests\Search\FieldMapper;
+
+use eZ\Publish\SPI\Persistence\Content\Type as SPIContentType;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition as SPIFieldDefinition;
+use EzSystems\EzPlatformSolrSearchEngine\FieldMapper\BoostFactorProvider;
+use EzSystems\EzPlatformSolrSearchEngine\Tests\Search\TestCase;
+
+/**
+ * Test case for the boost factor provider.
+ */
+class BoostFactorProviderTest extends TestCase
+{
+    public function providerForTestGetContentFieldBoostFactor()
+    {
+        return [
+            [
+                [
+                    'content-fields' => [
+                        'article' => [
+                            'title' => 5.5,
+                        ],
+                    ],
+                ],
+                'article',
+                'title',
+                5.5,
+            ],
+            [
+                [
+                    'content-fields' => [
+                        'article' => [
+                            'title' => 5.5,
+                        ],
+                    ],
+                ],
+                'blog_post',
+                'title',
+                1.0,
+            ],
+            [
+                [
+                    'content-fields' => [
+                        'article' => [
+                            '*' => 3.3,
+                            'title' => 5.5,
+                        ],
+                    ],
+                ],
+                'article',
+                'name',
+                3.3,
+            ],
+            [
+                [
+                    'content-fields' => [
+                        'article' => [
+                            '*' => 3.3,
+                            'title' => 5.5,
+                        ],
+                        '*' => [
+                            'name' => 2.2,
+                        ],
+                    ],
+                ],
+                'news',
+                'name',
+                2.2,
+            ],
+            [
+                [
+                    'content-fields' => [
+                        'article' => [
+                            '*' => 3.3,
+                            'title' => 5.5,
+                        ],
+                        '*' => [
+                            'name' => 2.2,
+                        ],
+                    ],
+                ],
+                'news',
+                'title',
+                1.0,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerForTestGetContentFieldBoostFactor
+     *
+     * @param array $map
+     * @param string $contentTypeIdentifier
+     * @param string $fieldDefinitionIdentifier
+     * @param float $expectedBoostFactor
+     */
+    public function testGetContentFieldBoostFactor(
+        array $map,
+        $contentTypeIdentifier,
+        $fieldDefinitionIdentifier,
+        $expectedBoostFactor
+    ) {
+        $provider = $this->getFieldBoostProvider($map);
+
+        $boostFactor = $provider->getContentFieldBoostFactor(
+            $this->getContentTypeStub($contentTypeIdentifier),
+            $this->getFieldDefinitionStub($fieldDefinitionIdentifier)
+        );
+
+        $this->assertEquals($expectedBoostFactor, $boostFactor);
+    }
+
+    public function providerForTestGetContentMetaFieldBoostFactor()
+    {
+        return [
+            [
+                [
+                    'meta-fields' => [
+                        'article' => [
+                            'name' => 5.5,
+                        ],
+                    ],
+                ],
+                'article',
+                'name',
+                5.5,
+            ],
+            [
+                [
+                    'meta-fields' => [
+                        'article' => [
+                            'name' => 5.5,
+                        ],
+                    ],
+                ],
+                'article',
+                'text',
+                1.0,
+            ],
+            [
+                [
+                    'meta-fields' => [
+                        'article' => [
+                            '*' => 3.3,
+                            'text' => 5.5,
+                        ],
+                    ],
+                ],
+                'article',
+                'name',
+                3.3,
+            ],
+            [
+                [
+                    'meta-fields' => [
+                        'article' => [
+                            '*' => 3.3,
+                            'text' => 5.5,
+                        ],
+                    ],
+                ],
+                'blog_post',
+                'name',
+                1.0,
+            ],
+            [
+                [
+                    'meta-fields' => [
+                        'article' => [
+                            '*' => 3.3,
+                            'name' => 5.5,
+                        ],
+                        '*' => [
+                            'text' => 2.2,
+                        ],
+                    ],
+                ],
+                'news',
+                'text',
+                2.2,
+            ],
+            [
+                [
+                    'meta-fields' => [
+                        'article' => [
+                            '*' => 3.3,
+                            'name' => 5.5,
+                        ],
+                        '*' => [
+                            'text' => 2.2,
+                        ],
+                    ],
+                ],
+                'news',
+                'name',
+                1.0,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerForTestGetContentMetaFieldBoostFactor
+     *
+     * @param array $map
+     * @param string $contentTypeIdentifier
+     * @param string $fieldName
+     * @param float $expectedBoostFactor
+     */
+    public function testGetContentMetaFieldBoostFactor(
+        array $map,
+        $contentTypeIdentifier,
+        $fieldName,
+        $expectedBoostFactor
+    ) {
+        $provider = $this->getFieldBoostProvider($map);
+
+        $boostFactor = $provider->getContentMetaFieldBoostFactor(
+            $this->getContentTypeStub($contentTypeIdentifier),
+            $fieldName
+        );
+
+        $this->assertEquals($expectedBoostFactor, $boostFactor);
+    }
+
+    protected function getFieldBoostProvider(array $map)
+    {
+        return new BoostFactorProvider($map);
+    }
+
+    protected function getContentTypeStub($identifier)
+    {
+        return new SPIContentType(
+            [
+                'identifier' => $identifier,
+            ]
+        );
+    }
+
+    protected function getFieldDefinitionStub($identifier)
+    {
+        return new SPIFieldDefinition(
+            [
+                'identifier' => $identifier,
+            ]
+        );
+    }
+}

--- a/tests/lib/Search/Query/CriterionVisitor/FullTextTest.php
+++ b/tests/lib/Search/Query/CriterionVisitor/FullTextTest.php
@@ -66,7 +66,7 @@ class FullTextTest extends TestCase
         $criterion = new Criterion\FullText('Hello');
 
         $this->assertEquals(
-            '(text:(Hello))',
+            '(meta_content__text_t:(Hello))',
             $visitor->visit($criterion)
         );
     }
@@ -78,7 +78,7 @@ class FullTextTest extends TestCase
         $criterion = new Criterion\FullText('Hello World');
 
         $this->assertEquals(
-            '(text:(Hello World))',
+            '(meta_content__text_t:(Hello World))',
             $visitor->visit($criterion)
         );
     }
@@ -91,7 +91,7 @@ class FullTextTest extends TestCase
         $criterion->fuzziness = .5;
 
         $this->assertEquals(
-            '(text:(Hello~0.5))',
+            '(meta_content__text_t:(Hello~0.5))',
             $visitor->visit($criterion)
         );
     }
@@ -104,7 +104,7 @@ class FullTextTest extends TestCase
         $criterion->fuzziness = .5;
 
         $this->assertEquals(
-            '(text:(Hello~0.5 World~0.5))',
+            '(meta_content__text_t:(Hello~0.5 World~0.5))',
             $visitor->visit($criterion)
         );
     }
@@ -123,7 +123,7 @@ class FullTextTest extends TestCase
         $criterion->boost = array('title' => 2);
 
         $this->assertEquals(
-            '(text:(Hello) OR title_1_s:(Hello)^2 OR title_2_s:(Hello)^2)',
+            '(meta_content__text_t:(Hello) OR title_1_s:(Hello)^2 OR title_2_s:(Hello)^2)',
             $visitor->visit($criterion)
         );
     }
@@ -142,7 +142,7 @@ class FullTextTest extends TestCase
         $criterion->boost = array('title' => 2);
 
         $this->assertEquals(
-            '(text:(Hello World) OR title_1_s:(Hello World)^2 OR title_2_s:(Hello World)^2)',
+            '(meta_content__text_t:(Hello World) OR title_1_s:(Hello World)^2 OR title_2_s:(Hello World)^2)',
             $visitor->visit($criterion)
         );
     }
@@ -157,7 +157,7 @@ class FullTextTest extends TestCase
         );
 
         $this->assertEquals(
-            '(text:(Hello))',
+            '(meta_content__text_t:(Hello))',
             $visitor->visit($criterion)
         );
     }
@@ -172,7 +172,7 @@ class FullTextTest extends TestCase
         );
 
         $this->assertEquals(
-            '(text:(Hello World))',
+            '(meta_content__text_t:(Hello World))',
             $visitor->visit($criterion)
         );
     }
@@ -191,7 +191,7 @@ class FullTextTest extends TestCase
         $criterion->boost = array('title' => 2);
 
         $this->assertEquals(
-            '(text:(Hello~0.5) OR title_1_s:(Hello~0.5)^2 OR title_2_s:(Hello~0.5)^2)',
+            '(meta_content__text_t:(Hello~0.5) OR title_1_s:(Hello~0.5)^2 OR title_2_s:(Hello~0.5)^2)',
             $visitor->visit($criterion)
         );
     }
@@ -210,7 +210,7 @@ class FullTextTest extends TestCase
         $criterion->boost = array('title' => 2);
 
         $this->assertEquals(
-            '(text:(Hello~0.5 World~0.5) OR title_1_s:(Hello~0.5 World~0.5)^2 OR title_2_s:(Hello~0.5 World~0.5)^2)',
+            '(meta_content__text_t:(Hello~0.5 World~0.5) OR title_1_s:(Hello~0.5 World~0.5)^2 OR title_2_s:(Hello~0.5 World~0.5)^2)',
             $visitor->visit($criterion)
         );
     }


### PR DESCRIPTION
### JIRA issue: https://jira.ez.no/browse/EZP-27227

This implements index-time boost functionality, similar to the [one existing in eZ Find](https://github.com/ezsystems/ezfind/blob/master/settings/ezfind.ini#L215).

One problem found when implementing this was usage of [Solr's `copyField` directive](https://cwiki.apache.org/confluence/display/solr/Copying+Fields) to index full-text data to the `text` field. It was not possible to keep this, because in order for a field to have boost factor it must have [norms](https://cwiki.apache.org/confluence/display/solr/Field+Type+Definitions+and+Properties) (attribute `omitNorms="false"` in the schema). Field that has norms also must be indexed, which voids the whole approach with having non-indexed `*_fulltext` fields that are only copied to the destination `text` field.

For that reason `copyField` approach is replaced with collecting all full-text data and indexing it directly in a [`TextField` type field](https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/SPI/Search/FieldType/TextField.php). In future [`FullTextField` type field](https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/SPI/Search/FieldType/FullTextField.php) could be removed in favour of explicit `getFullTextData()` method on the FieldType's [`Indexable` interface](https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/SPI/FieldType/Indexable.php). For more details see commit https://github.com/ezsystems/ezplatform-solr-search-engine/commit/9b1e9702733fddc6a3cab46975218bff3d06be85 where field mappers for Content fields were refactored.

Boost factors are provided by the [`BoostFactorProvider`](https://github.com/netgen/ezplatform-solr-search-engine/blob/index-time-boost/lib/FieldMapper/BoostFactorProvider.php) service, which is configured with boost factor map by the Symfony's semantic configuration. It has only two methods to get the boost factor:

- `getContentFieldBoostFactor(ContentType $contentType, FieldDefinition $fieldDefinition)`
- `getContentMetaFieldBoostFactor(ContentType $contentType, $fieldName)`

Boost factor configuration is a part of the connection configuration for the search engine. It's probably best described by an example:

```yaml
ez_search_engine_solr:
    connections:
        default:
            boost_factors:
                content_type:
                    article: 2.0
                field_definition:
                    title: 3.0
                    blog_post:
                        title: 1.5
                meta_field:
                    name: 10.0
                    article:
                        text: 5.0
```

Boost can be mapped for regular Content fields and for Content's meta fields. Two meta fields are recognized, `name` (translated Content name) and `text` (catch-all language analyzed field for full-text search). Names `name` and `text` are configuration-level names, mapped to the Solr backend fields which are not directly exposed. Boost factors can be mapped by the ContentType, FieldDefinition and meta field name.

With the configuration example above, the behavior is as follows:

- `getContentFieldBoostFactor('article', 'title')` returns `2.0`
- `getContentFieldBoostFactor('news', 'title')` returns `3.0`
- `getContentFieldBoostFactor('blog_post', 'title')` returns `1.5`
- `getContentFieldBoostFactor('news', 'description')` returns `1.0` (default)
- `getContentMetaFieldBoostFactor('article', 'text')` returns `5.0`
- `getContentMetaFieldBoostFactor('blog_post', 'name')` returns `10.0`
- `getContentMetaFieldBoostFactor('article', 'name')` returns `2.0`

That means mapping under `content_type` key acts both as a default and an override for the factor mapping under `field_definition` and `meta_field` keys. It acts as an override when the factors are mapped through the FieldDefinition identifier/meta field name only. On the other hand, it will be overriden by the mapping when the factor is mapped through the ContentType identifier as well.

We discussed this a bit in the office, and the agreement was that behavior is sensible, as mapping though a ContentType is more specific than through a FieldDefinition/field name.

### UpdateSerializer

`UpdateSerializer` is a service creating XML that is posted to the Solr's `/update` resource and it was extracted out of the Gateway implementation.

### Fulltext catch-all field name change

Name of the language analyzed field where all Content's text is indexed has been changed from `text` to `meta_content__all_text_t`. I did this because keeping the name would require special handling when creating the update XML. In retrospect it seems like it might be worth to keep the name, as it will mean a BC break if it was used directly. (Feedback welcome)

### Indexing translated Content name

A [dedicated field mapper](https://github.com/netgen/ezplatform-solr-search-engine/blob/index-time-boost/lib/FieldMapper/ContentTranslationFieldMapper/ContentDocumentTranslatedContentNameField.php) is implemented for indexing translated Content name. It will index the name both as a string (keyword) and text field (language analyzed and boosted).

Same as `text` meta field, `name` is indexed on the Content document only.

### Limitations

In order for boost factor to be applicable on the Solr field, the field must store norms (attribute `omitNorms="false"` in the schema). Otherwise Solr will respond with an exception, as was introduced in [SOLR-3241](https://issues.apache.org/jira/browse/SOLR-3241). This setting affects both the size of the storage and memory usage. In the schema norms are explicitly allowed only on the `text` type Solr field (language analyzed field). configured boosts will also be applied only on the field of that type through checking for [`TextField` type field](https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/SPI/Search/FieldType/TextField.php).

In order for boosts to be used on other fields, custom field mappers will have to be implemented and schema will have to be modified so that norms can be stored on them. The goal of this is to provide a way to easily improve relevancy for full-text search by boosting on Content name and per ContentType, which should be enough for most cases. We can also improve this implementation when/if the needs become clear, but anything more than that, we would be much better off with a proper boost API using boost query functionality in `eDisMax` parser, than trying to force it through something that is quite limited by it's nature.

Also, index-time boosting needs to be limited to Solr, as [Elasticsearch does not support it anymore](https://www.elastic.co/guide/en/elasticsearch/reference/5.2/index-boost.html). So we should also go for [removing it from SPI](https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/SPI/Search/FieldType.php#L46).

### Missing pieces

Currently the only way to target text-type field in Solr is through `CustomFieldCrierion`. Using that requires hardcoding field names that are indexed out of the box. Also, Content meta fields `text` and `name` are indexed on the Content document, so with those fields, it can work with Content search only. We should improve this somehow in a followup, some ideas:

- introduce `ContentName` criterion
- introduce `TEXT` operator on `Field` criterion (and a way to use different indexed field per operator)
- implement general purpose `Text` criterion that would work on Location search as well (through block join)
- provide a way to get meta field name and indexed FieldType field name in `FieldNameResolver`

### TODOs

- [x] ~~PR on https://github.com/ezsystems/ezpublish-kernel~~
  See https://github.com/ezsystems/ezpublish-kernel/pull/1948