### PR TITLE
EZP-27327: Fix User / ContentType / Section facet support in Solr

### DIFF
--- a/lib/Container/Compiler/AggregateFacetBuilderVisitorPass.php
+++ b/lib/Container/Compiler/AggregateFacetBuilderVisitorPass.php
@@ -24,15 +24,21 @@ class AggregateFacetBuilderVisitorPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        if (!$container->hasDefinition('ezpublish.search.solr.query.content.facet_builder_visitor.aggregate')) {
+        $this->processVisitors($container, 'content');
+        $this->processVisitors($container, 'location');
+    }
+
+    private function processVisitors(ContainerBuilder $container, $name = 'content')
+    {
+        if (!$container->hasDefinition("ezpublish.search.solr.query.${name}.facet_builder_visitor.aggregate")) {
             return;
         }
 
         $aggregateFacetBuilderVisitorDefinition = $container->getDefinition(
-            'ezpublish.search.solr.query.content.facet_builder_visitor.aggregate'
+            "ezpublish.search.solr.query.${name}.facet_builder_visitor.aggregate"
         );
 
-        foreach ($container->findTaggedServiceIds('ezpublish.search.solr.query.content.facet_builder_visitor') as $id => $attributes) {
+        foreach ($container->findTaggedServiceIds("ezpublish.search.solr.query.${name}.facet_builder_visitor") as $id => $attributes) {
             $aggregateFacetBuilderVisitorDefinition->addMethodCall(
                 'addVisitor',
                 array(

--- a/lib/Handler.php
+++ b/lib/Handler.php
@@ -127,7 +127,8 @@ class Handler implements SearchHandlerInterface
         );
 
         return $this->resultExtractor->extract(
-            $this->gateway->findContent($query, $fieldFilters)
+            $this->gateway->findContent($query, $fieldFilters),
+            $query->facetBuilders
         );
     }
 
@@ -196,7 +197,8 @@ class Handler implements SearchHandlerInterface
         );
 
         return $this->resultExtractor->extract(
-            $this->gateway->findLocations($query, $fieldFilters)
+            $this->gateway->findLocations($query, $fieldFilters),
+            $query->facetBuilders
         );
     }
 

--- a/lib/Query/Common/FacetBuilderVisitor/Aggregate.php
+++ b/lib/Query/Common/FacetBuilderVisitor/Aggregate.php
@@ -13,7 +13,6 @@ namespace EzSystems\EzPlatformSolrSearchEngine\Query\Common\FacetBuilderVisitor;
 use EzSystems\EzPlatformSolrSearchEngine\Query\FacetBuilderVisitor;
 use EzSystems\EzPlatformSolrSearchEngine\Query\FacetFieldVisitor;
 use eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder;
-use eZ\Publish\API\Repository\Exceptions\NotImplementedException;
 
 /**
  * Visits the facet builder tree into a Solr query.
@@ -89,8 +88,8 @@ class Aggregate extends FacetBuilderVisitor implements FacetFieldVisitor
             }
         }
 
-        throw new NotImplementedException(
-            'No visitor available for: ' . get_class($facetBuilder)
-        );
+        // Ignore unsupported FacetBuilders, don't block the query for it
+        // ref: https://github.com/ezsystems/ezpublish-kernel/commit/435624d6fb8aa03ec219818ff7cb6755944b8d7b
+        return [];
     }
 }

--- a/lib/Query/Common/FacetBuilderVisitor/Aggregate.php
+++ b/lib/Query/Common/FacetBuilderVisitor/Aggregate.php
@@ -11,13 +11,14 @@
 namespace EzSystems\EzPlatformSolrSearchEngine\Query\Common\FacetBuilderVisitor;
 
 use EzSystems\EzPlatformSolrSearchEngine\Query\FacetBuilderVisitor;
+use EzSystems\EzPlatformSolrSearchEngine\Query\FacetFieldVisitor;
 use eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder;
 use eZ\Publish\API\Repository\Exceptions\NotImplementedException;
 
 /**
  * Visits the facet builder tree into a Solr query.
  */
-class Aggregate extends FacetBuilderVisitor
+class Aggregate extends FacetBuilderVisitor implements FacetFieldVisitor
 {
     /**
      * Array of available visitors.
@@ -49,29 +50,17 @@ class Aggregate extends FacetBuilderVisitor
     }
 
     /**
-     * Check if visitor is applicable to current facet result.
+     * {@inheritdoc}.
      *
-     * @param string $field
-     *
-     * @return bool
+     * @deprecated Internal support for nullable $facetBuilder will be removed in 2.0, here now to support facetBuilders
+     *             that has not adapted yet.
      */
-    public function canMap($field)
-    {
-        return true;
-    }
-
-    /**
-     * Map Solr facet result back to facet objects.
-     *
-     * @param string $field
-     * @param array $data
-     *
-     * @return \eZ\Publish\API\Repository\Values\Content\Search\Facet
-     */
-    public function map($field, array $data)
+    public function mapField($field, array $data, FacetBuilder $facetBuilder = null)
     {
         foreach ($this->visitors as $visitor) {
-            if ($visitor->canMap($field)) {
+            if ($facetBuilder && $visitor instanceof FacetFieldVisitor && $visitor->canVisit($facetBuilder)) {
+                return $visitor->mapField($field, $data, $facetBuilder);
+            } elseif (!$facetBuilder && $visitor->canMap($field)) {
                 return $visitor->map($field, $data);
             }
         }
@@ -80,11 +69,7 @@ class Aggregate extends FacetBuilderVisitor
     }
 
     /**
-     * CHeck if visitor is applicable to current facet builder.
-     *
-     * @param FacetBuilder $facetBuilder
-     *
-     * @return bool
+     * {@inheritdoc}.
      */
     public function canVisit(FacetBuilder $facetBuilder)
     {
@@ -92,19 +77,15 @@ class Aggregate extends FacetBuilderVisitor
     }
 
     /**
-     * Map field value to a proper Solr representation.
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotImplementedException
-     *
-     * @param FacetBuilder $facetBuilder
-     *
-     * @return string
+     * {@inheritdoc}.
      */
-    public function visit(FacetBuilder $facetBuilder)
+    public function visitBuilder(FacetBuilder $facetBuilder, $fieldId)
     {
         foreach ($this->visitors as $visitor) {
             if ($visitor->canVisit($facetBuilder)) {
-                return $visitor->visit($facetBuilder);
+                return $visitor instanceof FacetFieldVisitor ?
+                    $visitor->visitBuilder($facetBuilder, $fieldId) :
+                    $visitor->visit($facetBuilder);
             }
         }
 

--- a/lib/Query/Common/FacetBuilderVisitor/ContentType.php
+++ b/lib/Query/Common/FacetBuilderVisitor/ContentType.php
@@ -11,50 +11,30 @@
 namespace EzSystems\EzPlatformSolrSearchEngine\Query\Common\FacetBuilderVisitor;
 
 use EzSystems\EzPlatformSolrSearchEngine\Query\FacetBuilderVisitor;
+use EzSystems\EzPlatformSolrSearchEngine\Query\FacetFieldVisitor;
 use eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder;
 use eZ\Publish\API\Repository\Values\Content\Search\Facet;
 
 /**
  * Visits the ContentType facet builder.
  */
-class ContentType extends FacetBuilderVisitor
+class ContentType extends FacetBuilderVisitor implements FacetFieldVisitor
 {
     /**
-     * Check if visitor is applicable to current facet result.
-     *
-     * @param string $field
-     *
-     * @return bool
+     * {@inheritdoc}.
      */
-    public function canMap($field)
-    {
-        return $field === 'content_type_id_id';
-    }
-
-    /**
-     * Map Solr facet result back to facet objects.
-     *
-     * @param string $field
-     * @param array $data
-     *
-     * @return Facet
-     */
-    public function map($field, array $data)
+    public function mapField($field, array $data, FacetBuilder $facetBuilder)
     {
         return new Facet\ContentTypeFacet(
             array(
-                'name' => 'type',
+                'name' => $facetBuilder->name,
                 'entries' => $this->mapData($data),
             )
         );
     }
 
     /**
-     * Check if visitor is applicable to current facet builder.
-     *
-     * @param FacetBuilder $facetBuilder
-     *
-     * @return bool
+     * {@inheritdoc}.
      */
     public function canVisit(FacetBuilder $facetBuilder)
     {
@@ -62,16 +42,12 @@ class ContentType extends FacetBuilderVisitor
     }
 
     /**
-     * Map field value to a proper Solr representation.
-     *
-     * @param FacetBuilder $facetBuilder;
-     *
-     * @return string
+     * {@inheritdoc}.
      */
-    public function visit(FacetBuilder $facetBuilder)
+    public function visitBuilder(FacetBuilder $facetBuilder, $fieldId)
     {
         return array(
-            'facet.field' => 'content_type_id_id',
+            'facet.field' => "{!ex=dt key=${fieldId}}content_type_id_id",
             'f.content_type_id_id.facet.limit' => $facetBuilder->limit,
             'f.content_type_id_id.facet.mincount' => $facetBuilder->minCount,
         );

--- a/lib/Query/Common/FacetBuilderVisitor/Section.php
+++ b/lib/Query/Common/FacetBuilderVisitor/Section.php
@@ -11,50 +11,30 @@
 namespace EzSystems\EzPlatformSolrSearchEngine\Query\Common\FacetBuilderVisitor;
 
 use EzSystems\EzPlatformSolrSearchEngine\Query\FacetBuilderVisitor;
+use EzSystems\EzPlatformSolrSearchEngine\Query\FacetFieldVisitor;
 use eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder;
 use eZ\Publish\API\Repository\Values\Content\Search\Facet;
 
 /**
  * Visits the Section facet builder.
  */
-class Section extends FacetBuilderVisitor
+class Section extends FacetBuilderVisitor implements FacetFieldVisitor
 {
     /**
-     * Check if visitor is applicable to current facet result.
-     *
-     * @param string $field
-     *
-     * @return bool
+     * {@inheritdoc}.
      */
-    public function canMap($field)
-    {
-        return $field === 'content_section_id_id';
-    }
-
-    /**
-     * Map Solr facet result back to facet objects.
-     *
-     * @param string $field
-     * @param array $data
-     *
-     * @return Facet
-     */
-    public function map($field, array $data)
+    public function mapField($field, array $data, FacetBuilder $facetBuilder)
     {
         return new Facet\SectionFacet(
             array(
-                'name' => 'section',
+                'name' => $facetBuilder->name,
                 'entries' => $this->mapData($data),
             )
         );
     }
 
     /**
-     * Check if visitor is applicable to current facet builder.
-     *
-     * @param FacetBuilder $facetBuilder
-     *
-     * @return bool
+     * {@inheritdoc}.
      */
     public function canVisit(FacetBuilder $facetBuilder)
     {
@@ -62,16 +42,12 @@ class Section extends FacetBuilderVisitor
     }
 
     /**
-     * Map field value to a proper Solr representation.
-     *
-     * @param FacetBuilder $facetBuilder;
-     *
-     * @return string
+     * {@inheritdoc}.
      */
-    public function visit(FacetBuilder $facetBuilder)
+    public function visitBuilder(FacetBuilder $facetBuilder, $fieldId)
     {
         return array(
-            'facet.field' => 'content_section_id_id',
+            'facet.field' => "{!ex=dt key=${fieldId}}content_section_id_id",
             'f.content_section_id_id.facet.limit' => $facetBuilder->limit,
             'f.content_section_id_id.facet.mincount' => $facetBuilder->minCount,
         );

--- a/lib/Query/Common/FacetBuilderVisitor/User.php
+++ b/lib/Query/Common/FacetBuilderVisitor/User.php
@@ -11,50 +11,30 @@
 namespace EzSystems\EzPlatformSolrSearchEngine\Query\Common\FacetBuilderVisitor;
 
 use EzSystems\EzPlatformSolrSearchEngine\Query\FacetBuilderVisitor;
+use EzSystems\EzPlatformSolrSearchEngine\Query\FacetFieldVisitor;
 use eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder;
 use eZ\Publish\API\Repository\Values\Content\Search\Facet;
 
 /**
  * Visits the User facet builder.
  */
-class User extends FacetBuilderVisitor
+class User extends FacetBuilderVisitor implements FacetFieldVisitor
 {
     /**
-     * Check if visitor is applicable to current facet result.
-     *
-     * @param string $field
-     *
-     * @return bool
+     * {@inheritdoc}.
      */
-    public function canMap($field)
-    {
-        return $field === 'content_version_creator_user_id_id';
-    }
-
-    /**
-     * Map Solr facet result back to facet objects.
-     *
-     * @param string $field
-     * @param array $data
-     *
-     * @return Facet
-     */
-    public function map($field, array $data)
+    public function mapField($field, array $data, FacetBuilder $facetBuilder)
     {
         return new Facet\UserFacet(
             array(
-                'name' => 'creator',
+                'name' => $facetBuilder->name,
                 'entries' => $this->mapData($data),
             )
         );
     }
 
     /**
-     * Check if visitor is applicable to current facet builder.
-     *
-     * @param FacetBuilder $facetBuilder
-     *
-     * @return bool
+     * {@inheritdoc}.
      */
     public function canVisit(FacetBuilder $facetBuilder)
     {
@@ -62,16 +42,12 @@ class User extends FacetBuilderVisitor
     }
 
     /**
-     * Map field value to a proper Solr representation.
-     *
-     * @param FacetBuilder $facetBuilder;
-     *
-     * @return string
+     * {@inheritdoc}.
      */
-    public function visit(FacetBuilder $facetBuilder)
+    public function visitBuilder(FacetBuilder $facetBuilder, $fieldId)
     {
         return array(
-            'facet.field' => 'content_version_creator_user_id_id',
+            'facet.field' => "{!ex=dt key=${fieldId}}content_version_creator_user_id_id",
             'f.content_version_creator_user_id_id.facet.limit' => $facetBuilder->limit,
             'f.content_version_creator_user_id_id.facet.mincount' => $facetBuilder->minCount,
         );

--- a/lib/Query/Common/FacetBuilderVisitor/User.php
+++ b/lib/Query/Common/FacetBuilderVisitor/User.php
@@ -13,6 +13,7 @@ namespace EzSystems\EzPlatformSolrSearchEngine\Query\Common\FacetBuilderVisitor;
 use EzSystems\EzPlatformSolrSearchEngine\Query\FacetBuilderVisitor;
 use EzSystems\EzPlatformSolrSearchEngine\Query\FacetFieldVisitor;
 use eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder;
+use eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder\UserFacetBuilder;
 use eZ\Publish\API\Repository\Values\Content\Search\Facet;
 
 /**
@@ -20,6 +21,15 @@ use eZ\Publish\API\Repository\Values\Content\Search\Facet;
  */
 class User extends FacetBuilderVisitor implements FacetFieldVisitor
 {
+    /**
+     * @internal Will be marked private when we require PHP 7.0 and can do that.
+     */
+    const DOC_FIELD_MAP = [
+        UserFacetBuilder::OWNER => 'content_owner_user_id_id',
+        UserFacetBuilder::GROUP => 'content_owner_user_group_ids_mid',
+        UserFacetBuilder::MODIFIER => 'content_version_creator_user_id_id',
+    ];
+
     /**
      * {@inheritdoc}.
      */
@@ -38,7 +48,7 @@ class User extends FacetBuilderVisitor implements FacetFieldVisitor
      */
     public function canVisit(FacetBuilder $facetBuilder)
     {
-        return $facetBuilder instanceof FacetBuilder\UserFacetBuilder;
+        return $facetBuilder instanceof UserFacetBuilder;
     }
 
     /**
@@ -46,10 +56,13 @@ class User extends FacetBuilderVisitor implements FacetFieldVisitor
      */
     public function visitBuilder(FacetBuilder $facetBuilder, $fieldId)
     {
+        /** @var \eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder\UserFacetBuilder $facetBuilder */
+        $field = self::DOC_FIELD_MAP[$facetBuilder->type];
+
         return array(
-            'facet.field' => "{!ex=dt key=${fieldId}}content_version_creator_user_id_id",
-            'f.content_version_creator_user_id_id.facet.limit' => $facetBuilder->limit,
-            'f.content_version_creator_user_id_id.facet.mincount' => $facetBuilder->minCount,
+            'facet.field' => "{!ex=dt key=${fieldId}}$field",
+            "f.${field}.facet.limit" => $facetBuilder->limit,
+            "f.${field}.facet.mincount" => $facetBuilder->minCount,
         );
     }
 }

--- a/lib/Query/Common/QueryConverter/NativeQueryConverter.php
+++ b/lib/Query/Common/QueryConverter/NativeQueryConverter.php
@@ -14,7 +14,7 @@ use eZ\Publish\API\Repository\Values\Content\Query;
 use EzSystems\EzPlatformSolrSearchEngine\Query\QueryConverter;
 use EzSystems\EzPlatformSolrSearchEngine\Query\CriterionVisitor;
 use EzSystems\EzPlatformSolrSearchEngine\Query\SortClauseVisitor;
-use EzSystems\EzPlatformSolrSearchEngine\Query\FacetBuilderVisitor;
+use EzSystems\EzPlatformSolrSearchEngine\Query\FacetFieldVisitor;
 
 /**
  * Native implementation of Query Converter.
@@ -38,7 +38,7 @@ class NativeQueryConverter extends QueryConverter
     /**
      * Facet builder visitor.
      *
-     * @var \EzSystems\EzPlatformSolrSearchEngine\Query\FacetBuilderVisitor
+     * @var \EzSystems\EzPlatformSolrSearchEngine\Query\FacetFieldVisitor
      */
     protected $facetBuilderVisitor;
 
@@ -47,12 +47,12 @@ class NativeQueryConverter extends QueryConverter
      *
      * @param \EzSystems\EzPlatformSolrSearchEngine\Query\CriterionVisitor $criterionVisitor
      * @param \EzSystems\EzPlatformSolrSearchEngine\Query\SortClauseVisitor $sortClauseVisitor
-     * @param \EzSystems\EzPlatformSolrSearchEngine\Query\FacetBuilderVisitor $facetBuilderVisitor
+     * @param \EzSystems\EzPlatformSolrSearchEngine\Query\FacetFieldVisitor $facetBuilderVisitor
      */
     public function __construct(
         CriterionVisitor $criterionVisitor,
         SortClauseVisitor $sortClauseVisitor,
-        FacetBuilderVisitor $facetBuilderVisitor
+        FacetFieldVisitor $facetBuilderVisitor
     ) {
         $this->criterionVisitor = $criterionVisitor;
         $this->sortClauseVisitor = $sortClauseVisitor;
@@ -103,6 +103,9 @@ class NativeQueryConverter extends QueryConverter
     /**
      * Converts an array of facet builder objects to a Solr query parameters representation.
      *
+     * This method uses spl_object_hash() to get id of each and every facet builder, as this
+     * is expected by {@link \EzSystems\EzPlatformSolrSearchEngine\ResultExtractor}.
+     *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder[] $facetBuilders
      *
      * @return array
@@ -110,7 +113,9 @@ class NativeQueryConverter extends QueryConverter
     private function getFacetParams(array $facetBuilders)
     {
         $facetSets = array_map(
-            array($this->facetBuilderVisitor, 'visit'),
+            function ($facetBuilder) {
+                return $this->facetBuilderVisitor->visitBuilder($facetBuilder, spl_object_hash($facetBuilder));
+            },
             $facetBuilders
         );
 

--- a/lib/Query/FacetBuilderVisitor.php
+++ b/lib/Query/FacetBuilderVisitor.php
@@ -18,26 +18,36 @@ use eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder;
 abstract class FacetBuilderVisitor
 {
     /**
-     * CHeck if visitor is applicable to current facet result.
+     * Check if visitor is applicable to current facet result.
+     *
+     * @deprecated Not needed anymore if visit() correctly used $id param to identify facetBuilder.
      *
      * @param string $field
      *
      * @return bool
      */
-    abstract public function canMap($field);
+    public function canMap($field)
+    {
+        throw new \LogicException('Deprecated in favour of FacetFieldVisitor, and not in use if that is implemented');
+    }
 
     /**
      * Map Solr facet result back to facet objects.
      *
+     * @deprecated Will be removed in 2.0, replaced by {@link FacetFieldVisitor::mapField()}.
+     *
      * @param string $field
      * @param array $data
      *
-     * @return Facet
+     * @return \eZ\Publish\API\Repository\Values\Content\Search\Facet
      */
-    abstract public function map($field, array $data);
+    public function map($field, array $data)
+    {
+        throw new \LogicException('Deprecated in favour of FacetFieldVisitor, and not in use if that is implemented');
+    }
 
     /**
-     * CHeck if visitor is applicable to current facet builder.
+     * Check if visitor is applicable to current facet builder.
      *
      * @param FacetBuilder $facetBuilder
      *
@@ -48,11 +58,16 @@ abstract class FacetBuilderVisitor
     /**
      * Map field value to a proper Solr representation.
      *
+     * @deprecated Will be removed in 2.0, replaced by {@link FacetFieldVisitor::visitBuilder()}.
+     *
      * @param FacetBuilder $facetBuilder
      *
      * @return string
      */
-    abstract public function visit(FacetBuilder $facetBuilder);
+    public function visit(FacetBuilder $facetBuilder)
+    {
+        throw new \LogicException('Deprecated in favour of FacetFieldVisitor, and not in use if that is implemented');
+    }
 
     /**
      * Map Solr return array into a sane hash map.

--- a/lib/Query/FacetBuilderVisitor.php
+++ b/lib/Query/FacetBuilderVisitor.php
@@ -62,7 +62,7 @@ abstract class FacetBuilderVisitor
      *
      * @param FacetBuilder $facetBuilder
      *
-     * @return string
+     * @return string[]
      */
     public function visit(FacetBuilder $facetBuilder)
     {

--- a/lib/Query/FacetFieldVisitor.php
+++ b/lib/Query/FacetFieldVisitor.php
@@ -41,7 +41,7 @@ interface FacetFieldVisitor
      * @param FacetBuilder $facetBuilder
      * @param string $fieldId Id to identify the field in Solr facet.
      *
-     * @return string
+     * @return string[]
      */
     public function visitBuilder(FacetBuilder $facetBuilder, $fieldId);
 }

--- a/lib/Query/FacetFieldVisitor.php
+++ b/lib/Query/FacetFieldVisitor.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * This file is part of the eZ Platform Solr Search Engine package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformSolrSearchEngine\Query;
+
+use eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder;
+
+/**
+ * Visits Solr results into correct facet and facet builder combination.
+ *
+ * NOTE: Will be deprecated in 2.0 and methods will be moved into FacetBuilderVisitor.
+ */
+interface FacetFieldVisitor
+{
+    /**
+     * Map Solr facet result back to facet objects.
+     *
+     * @param string $field
+     * @param array $data
+     * @param FacetBuilder $facetBuilder
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Search\Facet
+     */
+    public function mapField($field, array $data, FacetBuilder $facetBuilder);
+
+    /**
+     * Map field value to a proper Solr representation.
+     *
+     * Example:
+     *        return array(
+     *            'facet.field' => "{!ex=dt key=${fieldId}}content_type_id_id",
+     *            'f.content_type_id_id.facet.limit' => $facetBuilder->limit,
+     *            'f.content_type_id_id.facet.mincount' => $facetBuilder->minCount,
+     *        );
+     *
+     * @param FacetBuilder $facetBuilder
+     * @param string $fieldId Id to identify the field in Solr facet.
+     *
+     * @return string
+     */
+    public function visitBuilder(FacetBuilder $facetBuilder, $fieldId);
+}

--- a/lib/Resources/config/container/solr/facet_builder_visitors.yml
+++ b/lib/Resources/config/container/solr/facet_builder_visitors.yml
@@ -8,13 +8,16 @@ services:
         class: "%ezpublish.search.solr.query.common.facet_builder_visitor.content_type.class%"
         tags:
             - {name: ezpublish.search.solr.query.content.facet_builder_visitor}
+            - {name: ezpublish.search.solr.query.location.facet_builder_visitor}
 
     ezpublish.search.solr.query.common.facet_builder_visitor.section:
         class: "%ezpublish.search.solr.query.common.facet_builder_visitor.section.class%"
         tags:
             - {name: ezpublish.search.solr.query.content.facet_builder_visitor}
+            - {name: ezpublish.search.solr.query.location.facet_builder_visitor}
 
     ezpublish.search.solr.query.common.facet_builder_visitor.user:
         class: "%ezpublish.search.solr.query.common.facet_builder_visitor.user.class%"
         tags:
             - {name: ezpublish.search.solr.query.content.facet_builder_visitor}
+            - {name: ezpublish.search.solr.query.location.facet_builder_visitor}

--- a/tests/lib/Container/Compiler/AggregateFacetBuilderVisitorPassTest.php
+++ b/tests/lib/Container/Compiler/AggregateFacetBuilderVisitorPassTest.php
@@ -25,6 +25,10 @@ class AggregateFacetBuilderVisitorPassTest extends AbstractCompilerPassTestCase
             'ezpublish.search.solr.query.content.facet_builder_visitor.aggregate',
             new Definition()
         );
+        $this->setDefinition(
+            'ezpublish.search.solr.query.location.facet_builder_visitor.aggregate',
+            new Definition()
+        );
     }
 
     /**
@@ -45,12 +49,23 @@ class AggregateFacetBuilderVisitorPassTest extends AbstractCompilerPassTestCase
         $def->addTag('ezpublish.search.solr.query.content.facet_builder_visitor');
         $this->setDefinition($serviceId, $def);
 
+        $serviceId2 = 'service_id2';
+        $def = new Definition();
+        $def->addTag('ezpublish.search.solr.query.location.facet_builder_visitor');
+        $this->setDefinition($serviceId2, $def);
+
         $this->compile();
 
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
             'ezpublish.search.solr.query.content.facet_builder_visitor.aggregate',
             'addVisitor',
             array(new Reference($serviceId))
+        );
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'ezpublish.search.solr.query.location.facet_builder_visitor.aggregate',
+            'addVisitor',
+            array(new Reference($serviceId2))
         );
     }
 }


### PR DESCRIPTION
> Issue: https://jira.ez.no/browse/EZP-27327
> Epic: https://jira.ez.no/browse/EZP-26465
> Alternative to: #91*

Done:
- New logic for facet builder visitors with BC for existing once to be able to identify* which facets belongs to which facet builder, to be able to inject right facet builder when extracting the result from Solr:
  - This makes ContentType and Section facets fully implemented _(for now)_ as we can now use `name` from the user provided value in FacetBuilder.
-  Improve User Facet handling to support all three sub types: `modifier`, `owner` and `group`
- Don't throw when encountering unsupported FacetBuilders, just ignore, user will have to iterate returned facets to generate his UI/app
- Enable the 3 facets _(User, ContentType, Section)_ supported atm also on Location search


\* _The benefit of this approach over the one in #91 is that it  reduces complexity of facet builder visitors by getting them to set id on the facet, which in turn better gurantees we use right facet builder with a given facet during extraction phase, this was proposed by @kore in https://github.com/ezsystems/ezplatform-solr-search-engine/commit/274875f6379da52ea0f8515b6de6412503b924cb#commitcomment-22050214_