### PR TITLE
EZP-26806: Improve fulltext search query syntax

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "~5.6|~7.0",
         "ezsystems/ezpublish-kernel": "~6.7.4@dev|^6.9.1@dev|^7.0@dev",
-        "netgen/query-translator": "~1.0"
+        "netgen/query-translator": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     ],
     "require": {
         "php": "~5.6|~7.0",
-        "ezsystems/ezpublish-kernel": "~6.7.4@dev|^6.9.1@dev|^7.0@dev"
+        "ezsystems/ezpublish-kernel": "~6.7.4@dev|^6.9.1@dev|^7.0@dev",
+        "netgen/query-translator": "~1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",

--- a/lib/Query/Common/QueryTranslator/Generator/WordVisitor.php
+++ b/lib/Query/Common/QueryTranslator/Generator/WordVisitor.php
@@ -8,7 +8,7 @@
  *
  * @version //autogentag//
  */
-namespace EzSystems\EzPlatformSolrSearchEngine\Query\Common\QueryTranslator;
+namespace EzSystems\EzPlatformSolrSearchEngine\Query\Common\QueryTranslator\Generator;
 
 use QueryTranslator\Languages\Galach\Generators\Common\Visitor;
 use QueryTranslator\Languages\Galach\Generators\Lucene\Common\WordBase;

--- a/lib/Query/Common/QueryTranslator/Generator/WordVisitor.php
+++ b/lib/Query/Common/QueryTranslator/Generator/WordVisitor.php
@@ -5,8 +5,6 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- *
- * @version //autogentag//
  */
 namespace EzSystems\EzPlatformSolrSearchEngine\Query\Common\QueryTranslator\Generator;
 

--- a/lib/Query/Common/QueryTranslator/WordVisitor.php
+++ b/lib/Query/Common/QueryTranslator/WordVisitor.php
@@ -32,7 +32,7 @@ class WordVisitor extends WordBase
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      *
      * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html
      *

--- a/lib/Query/Common/QueryTranslator/WordVisitor.php
+++ b/lib/Query/Common/QueryTranslator/WordVisitor.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * This file is part of the eZ Platform Solr Search Engine package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace EzSystems\EzPlatformSolrSearchEngine\Query\Common\QueryTranslator;
+
+use QueryTranslator\Languages\Galach\Generators\Common\Visitor;
+use QueryTranslator\Languages\Galach\Generators\Lucene\Common\WordBase;
+use QueryTranslator\Values\Node;
+
+/**
+ * Word Node Visitor implementation.
+ */
+class WordVisitor extends WordBase
+{
+    public function visit(Node $node, Visitor $subVisitor = null, $options = null)
+    {
+        $word = parent::visit($node, $subVisitor, $options);
+
+        if (isset($options['word_proximity'])) {
+            $fuzziness = sprintf('~%.1f', $options['word_proximity']);
+            $word .= $fuzziness;
+        }
+
+        return $word;
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html
+     *
+     * Note: additionally to what is defined above we also escape blank space,
+     * and we don't escape an asterisk.
+     */
+    protected function escapeWord($string)
+    {
+        return preg_replace(
+            '/(\\+|-|&&|\\|\\||!|\\(|\\)|\\{|}|\\[|]|\\^|"|~|\\?|:|\\/|\\\\| )/',
+            '\\\\$1',
+            $string
+        );
+    }
+}

--- a/lib/Query/Common/QueryTranslator/WordVisitor.php
+++ b/lib/Query/Common/QueryTranslator/WordVisitor.php
@@ -34,7 +34,7 @@ class WordVisitor extends WordBase
     /**
      * {@inheritdoc}
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html
+     * @link http://lucene.apache.org/core/5_0_0/queryparser/org/apache/lucene/queryparser/classic/package-summary.html#Escaping_Special_Characters
      *
      * Note: additionally to what is defined above we also escape blank space,
      * and we don't escape an asterisk.

--- a/lib/Query/Common/QueryTranslator/WordVisitor.php
+++ b/lib/Query/Common/QueryTranslator/WordVisitor.php
@@ -23,8 +23,8 @@ class WordVisitor extends WordBase
     {
         $word = parent::visit($node, $subVisitor, $options);
 
-        if (isset($options['word_proximity'])) {
-            $fuzziness = sprintf('~%.1f', $options['word_proximity']);
+        if (isset($options['fuzziness'])) {
+            $fuzziness = sprintf('~%.1f', $options['fuzziness']);
             $word .= $fuzziness;
         }
 

--- a/lib/Query/Content/CriterionVisitor/FullText.php
+++ b/lib/Query/Content/CriterionVisitor/FullText.php
@@ -106,7 +106,7 @@ class FullText extends CriterionVisitor
 
         $options = [];
         if ($criterion->fuzziness < 1) {
-            $options['word_proximity'] = $criterion->fuzziness;
+            $options['fuzziness'] = $criterion->fuzziness;
         }
 
         $queryString = $this->generator->generate($syntaxTree, $options);

--- a/lib/Resources/config/container/solr.yml
+++ b/lib/Resources/config/container/solr.yml
@@ -2,6 +2,7 @@ imports:
     - {resource: solr/criterion_visitors.yml}
     - {resource: solr/field_mappers.yml}
     - {resource: solr/facet_builder_visitors.yml}
+    - {resource: solr/query_translator.yml}
     - {resource: solr/services.yml}
     - {resource: solr/sort_clause_visitors.yml}
     - {resource: solr/slots.yml}

--- a/lib/Resources/config/container/solr/criterion_visitors.yml
+++ b/lib/Resources/config/container/solr/criterion_visitors.yml
@@ -250,6 +250,9 @@ services:
         class: "%ezpublish.search.solr.query.content.criterion_visitor.full_text.class%"
         arguments:
             - "@ezpublish.search.common.field_name_resolver"
+            - "@ezpublish.search.solr.query.query_translator.galach.tokenizer"
+            - "@ezpublish.search.solr.query.query_translator.galach.parser"
+            - "@ezpublish.search.solr.query.query_translator.galach.generator.edismax"
         tags:
             - {name: ezpublish.search.solr.query.content.criterion_visitor}
 
@@ -318,5 +321,8 @@ services:
         class: "%ezpublish.search.solr.query.location.criterion_visitor.full_text.class%"
         arguments:
             - "@ezpublish.search.common.field_name_resolver"
+            - "@ezpublish.search.solr.query.query_translator.galach.tokenizer"
+            - "@ezpublish.search.solr.query.query_translator.galach.parser"
+            - "@ezpublish.search.solr.query.query_translator.galach.generator.edismax"
         tags:
             - {name: ezpublish.search.solr.query.location.criterion_visitor}

--- a/lib/Resources/config/container/solr/query_translator.yml
+++ b/lib/Resources/config/container/solr/query_translator.yml
@@ -37,7 +37,7 @@ services:
         class: QueryTranslator\Languages\Galach\Generators\Lucene\Common\Query
 
     ezpublish.search.solr.query.query_translator.galach.generator.visitor.word:
-        class: EzSystems\EzPlatformSolrSearchEngine\Query\Common\QueryTranslator\WordVisitor
+        class: EzSystems\EzPlatformSolrSearchEngine\Query\Common\QueryTranslator\Generator\WordVisitor
 
     ezpublish.search.solr.query.query_translator.galach.generator.common.aggregate:
         class: QueryTranslator\Languages\Galach\Generators\Common\Aggregate

--- a/lib/Resources/config/container/solr/query_translator.yml
+++ b/lib/Resources/config/container/solr/query_translator.yml
@@ -7,7 +7,7 @@ services:
     ezpublish.search.solr.query.query_translator.galach.tokenizer:
         class: QueryTranslator\Languages\Galach\Tokenizer
         arguments:
-            - '@ezpublish.search.solr.query.query_translator.galach.token_extractor'
+            - "@ezpublish.search.solr.query.query_translator.galach.token_extractor"
 
     ezpublish.search.solr.query.query_translator.galach.parser:
         class: QueryTranslator\Languages\Galach\Parser
@@ -43,17 +43,17 @@ services:
         class: QueryTranslator\Languages\Galach\Generators\Common\Aggregate
         arguments:
             -
-                - '@ezpublish.search.solr.query.query_translator.galach.generator.visitor.group'
-                - '@ezpublish.search.solr.query.query_translator.galach.generator.visitor.logical_and'
-                - '@ezpublish.search.solr.query.query_translator.galach.generator.visitor.logical_not'
-                - '@ezpublish.search.solr.query.query_translator.galach.generator.visitor.logical_or'
-                - '@ezpublish.search.solr.query.query_translator.galach.generator.visitor.mandatory'
-                - '@ezpublish.search.solr.query.query_translator.galach.generator.visitor.phrase'
-                - '@ezpublish.search.solr.query.query_translator.galach.generator.visitor.prohibited'
-                - '@ezpublish.search.solr.query.query_translator.galach.generator.visitor.query'
-                - '@ezpublish.search.solr.query.query_translator.galach.generator.visitor.word'
+                - "@ezpublish.search.solr.query.query_translator.galach.generator.visitor.group"
+                - "@ezpublish.search.solr.query.query_translator.galach.generator.visitor.logical_and"
+                - "@ezpublish.search.solr.query.query_translator.galach.generator.visitor.logical_not"
+                - "@ezpublish.search.solr.query.query_translator.galach.generator.visitor.logical_or"
+                - "@ezpublish.search.solr.query.query_translator.galach.generator.visitor.mandatory"
+                - "@ezpublish.search.solr.query.query_translator.galach.generator.visitor.phrase"
+                - "@ezpublish.search.solr.query.query_translator.galach.generator.visitor.prohibited"
+                - "@ezpublish.search.solr.query.query_translator.galach.generator.visitor.query"
+                - "@ezpublish.search.solr.query.query_translator.galach.generator.visitor.word"
 
     ezpublish.search.solr.query.query_translator.galach.generator.edismax:
         class: QueryTranslator\Languages\Galach\Generators\ExtendedDisMax
         arguments:
-            - '@ezpublish.search.solr.query.query_translator.galach.generator.common.aggregate'
+            - "@ezpublish.search.solr.query.query_translator.galach.generator.common.aggregate"

--- a/lib/Resources/config/container/solr/query_translator.yml
+++ b/lib/Resources/config/container/solr/query_translator.yml
@@ -1,0 +1,59 @@
+parameters:
+
+services:
+    ezpublish.search.solr.query.query_translator.galach.token_extractor:
+        class: QueryTranslator\Languages\Galach\TokenExtractor\Text
+
+    ezpublish.search.solr.query.query_translator.galach.tokenizer:
+        class: QueryTranslator\Languages\Galach\Tokenizer
+        arguments:
+            - '@ezpublish.search.solr.query.query_translator.galach.token_extractor'
+
+    ezpublish.search.solr.query.query_translator.galach.parser:
+        class: QueryTranslator\Languages\Galach\Parser
+
+    ezpublish.search.solr.query.query_translator.galach.generator.visitor.group:
+        class: QueryTranslator\Languages\Galach\Generators\Lucene\Common\Group
+
+    ezpublish.search.solr.query.query_translator.galach.generator.visitor.logical_and:
+        class: QueryTranslator\Languages\Galach\Generators\Lucene\Common\LogicalAnd
+
+    ezpublish.search.solr.query.query_translator.galach.generator.visitor.logical_not:
+        class: QueryTranslator\Languages\Galach\Generators\Lucene\Common\LogicalNot
+
+    ezpublish.search.solr.query.query_translator.galach.generator.visitor.logical_or:
+        class: QueryTranslator\Languages\Galach\Generators\Lucene\Common\LogicalOr
+
+    ezpublish.search.solr.query.query_translator.galach.generator.visitor.mandatory:
+        class: QueryTranslator\Languages\Galach\Generators\Lucene\Common\Mandatory
+
+    ezpublish.search.solr.query.query_translator.galach.generator.visitor.phrase:
+        class: QueryTranslator\Languages\Galach\Generators\Lucene\Common\Phrase
+
+    ezpublish.search.solr.query.query_translator.galach.generator.visitor.prohibited:
+        class: QueryTranslator\Languages\Galach\Generators\Lucene\Common\Prohibited
+
+    ezpublish.search.solr.query.query_translator.galach.generator.visitor.query:
+        class: QueryTranslator\Languages\Galach\Generators\Lucene\Common\Query
+
+    ezpublish.search.solr.query.query_translator.galach.generator.visitor.word:
+        class: EzSystems\EzPlatformSolrSearchEngine\Query\Common\QueryTranslator\WordVisitor
+
+    ezpublish.search.solr.query.query_translator.galach.generator.common.aggregate:
+        class: QueryTranslator\Languages\Galach\Generators\Common\Aggregate
+        arguments:
+            -
+                - '@ezpublish.search.solr.query.query_translator.galach.generator.visitor.group'
+                - '@ezpublish.search.solr.query.query_translator.galach.generator.visitor.logical_and'
+                - '@ezpublish.search.solr.query.query_translator.galach.generator.visitor.logical_not'
+                - '@ezpublish.search.solr.query.query_translator.galach.generator.visitor.logical_or'
+                - '@ezpublish.search.solr.query.query_translator.galach.generator.visitor.mandatory'
+                - '@ezpublish.search.solr.query.query_translator.galach.generator.visitor.phrase'
+                - '@ezpublish.search.solr.query.query_translator.galach.generator.visitor.prohibited'
+                - '@ezpublish.search.solr.query.query_translator.galach.generator.visitor.query'
+                - '@ezpublish.search.solr.query.query_translator.galach.generator.visitor.word'
+
+    ezpublish.search.solr.query.query_translator.galach.generator.edismax:
+        class: QueryTranslator\Languages\Galach\Generators\ExtendedDisMax
+        arguments:
+            - '@ezpublish.search.solr.query.query_translator.galach.generator.common.aggregate'

--- a/tests/lib/Search/Query/CriterionVisitor/FullTextTest.php
+++ b/tests/lib/Search/Query/CriterionVisitor/FullTextTest.php
@@ -13,7 +13,7 @@ namespace EzSystems\EzPlatformSolrSearchEngine\Tests\Search\Query\CriterionVisit
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\Core\FieldType\TextLine\SearchField;
 use eZ\Publish\SPI\Search\FieldType\StringField;
-use EzSystems\EzPlatformSolrSearchEngine\Query\Common\QueryTranslator\WordVisitor;
+use EzSystems\EzPlatformSolrSearchEngine\Query\Common\QueryTranslator\Generator\WordVisitor;
 use EzSystems\EzPlatformSolrSearchEngine\Query\Content\CriterionVisitor\FullText;
 use EzSystems\EzPlatformSolrSearchEngine\Tests\Search\TestCase;
 use eZ\Publish\Core\Search\Common\FieldNameResolver;

--- a/tests/lib/Search/Query/CriterionVisitor/FullTextTest.php
+++ b/tests/lib/Search/Query/CriterionVisitor/FullTextTest.php
@@ -13,9 +13,14 @@ namespace EzSystems\EzPlatformSolrSearchEngine\Tests\Search\Query\CriterionVisit
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\Core\FieldType\TextLine\SearchField;
 use eZ\Publish\SPI\Search\FieldType\StringField;
+use EzSystems\EzPlatformSolrSearchEngine\Query\Common\QueryTranslator\WordVisitor;
+use EzSystems\EzPlatformSolrSearchEngine\Query\Content\CriterionVisitor\FullText;
 use EzSystems\EzPlatformSolrSearchEngine\Tests\Search\TestCase;
-use EzSystems\EzPlatformSolrSearchEngine\Query;
 use eZ\Publish\Core\Search\Common\FieldNameResolver;
+use QueryTranslator\Languages\Galach\Generators;
+use QueryTranslator\Languages\Galach\Parser;
+use QueryTranslator\Languages\Galach\TokenExtractor\Text;
+use QueryTranslator\Languages\Galach\Tokenizer;
 
 /**
  * Test case for FullText criterion visitor.
@@ -36,7 +41,7 @@ class FullTextTest extends TestCase
             ->expects($this->any())
             ->method('getFieldNames')
             ->with(
-                $this->isInstanceOf('eZ\\Publish\\API\\Repository\\Values\\Content\\Query\\Criterion'),
+                $this->isInstanceOf(Criterion::class),
                 $this->isType('string')
             )
             ->will(
@@ -47,14 +52,62 @@ class FullTextTest extends TestCase
             ->expects($this->any())
             ->method('getFieldTypes')
             ->with(
-                $this->isInstanceOf('eZ\\Publish\\API\\Repository\\Values\\Content\\Query\\Criterion'),
+                $this->isInstanceOf(Criterion::class),
                 $this->isType('string')
             )
             ->will(
                 $this->returnValue($fieldTypes)
             );
 
-        return new Query\Content\CriterionVisitor\FullText($fieldNameResolver);
+        /** @var \eZ\Publish\Core\Search\Common\FieldNameResolver $fieldNameResolver */
+        return new FullText(
+            $fieldNameResolver,
+            $this->getTokenizer(),
+            $this->getParser(),
+            $this->getGenerator()
+        );
+    }
+
+    /**
+     * @return \QueryTranslator\Languages\Galach\Tokenizer
+     */
+    protected function getTokenizer()
+    {
+        return new Tokenizer(
+            new Text()
+        );
+    }
+
+    /**
+     * @return \QueryTranslator\Languages\Galach\Parser
+     */
+    protected function getParser()
+    {
+        return new Parser();
+    }
+
+    /**
+     * @return \QueryTranslator\Languages\Galach\Generators\ExtendedDisMax
+     */
+    protected function getGenerator()
+    {
+        return new Generators\ExtendedDisMax(
+            new Generators\Common\Aggregate(
+                [
+                    new Generators\Lucene\Common\Group(),
+                    new Generators\Lucene\Common\LogicalAnd(),
+                    new Generators\Lucene\Common\LogicalNot(),
+                    new Generators\Lucene\Common\LogicalOr(),
+                    new Generators\Lucene\Common\Mandatory(),
+                    new Generators\Lucene\Common\Prohibited(),
+                    new Generators\Lucene\Common\Phrase(),
+                    new Generators\Lucene\Common\Query(),
+                    new Generators\Lucene\Common\Tag(),
+                    new WordVisitor(),
+                    new Generators\Lucene\Common\User(),
+                ]
+            )
+        );
     }
 
     public function testVisitSimple()
@@ -64,7 +117,7 @@ class FullTextTest extends TestCase
         $criterion = new Criterion\FullText('Hello');
 
         $this->assertEquals(
-            '(meta_content__text_t:(Hello))',
+            "{!edismax v='Hello' qf='meta_content__text_t' uf=-*}",
             $visitor->visit($criterion)
         );
     }
@@ -76,7 +129,7 @@ class FullTextTest extends TestCase
         $criterion = new Criterion\FullText('Hello World');
 
         $this->assertEquals(
-            '(meta_content__text_t:(Hello World))',
+            "{!edismax v='Hello World' qf='meta_content__text_t' uf=-*}",
             $visitor->visit($criterion)
         );
     }
@@ -89,7 +142,7 @@ class FullTextTest extends TestCase
         $criterion->fuzziness = .5;
 
         $this->assertEquals(
-            '(meta_content__text_t:(Hello~0.5))',
+            "{!edismax v='Hello~0.5' qf='meta_content__text_t' uf=-*}",
             $visitor->visit($criterion)
         );
     }
@@ -102,7 +155,7 @@ class FullTextTest extends TestCase
         $criterion->fuzziness = .5;
 
         $this->assertEquals(
-            '(meta_content__text_t:(Hello~0.5 World~0.5))',
+            "{!edismax v='Hello~0.5 World~0.5' qf='meta_content__text_t' uf=-*}",
             $visitor->visit($criterion)
         );
     }
@@ -121,7 +174,7 @@ class FullTextTest extends TestCase
         $criterion->boost = array('title' => 2);
 
         $this->assertEquals(
-            '(meta_content__text_t:(Hello) OR title_1_s:(Hello)^2 OR title_2_s:(Hello)^2)',
+            "{!edismax v='Hello' qf='meta_content__text_t title_1_s^2 title_2_s^2' uf=-*}",
             $visitor->visit($criterion)
         );
     }
@@ -140,7 +193,7 @@ class FullTextTest extends TestCase
         $criterion->boost = array('title' => 2);
 
         $this->assertEquals(
-            '(meta_content__text_t:(Hello World) OR title_1_s:(Hello World)^2 OR title_2_s:(Hello World)^2)',
+            "{!edismax v='Hello World' qf='meta_content__text_t title_1_s^2 title_2_s^2' uf=-*}",
             $visitor->visit($criterion)
         );
     }
@@ -155,7 +208,7 @@ class FullTextTest extends TestCase
         );
 
         $this->assertEquals(
-            '(meta_content__text_t:(Hello))',
+            "{!edismax v='Hello' qf='meta_content__text_t' uf=-*}",
             $visitor->visit($criterion)
         );
     }
@@ -170,7 +223,7 @@ class FullTextTest extends TestCase
         );
 
         $this->assertEquals(
-            '(meta_content__text_t:(Hello World))',
+            "{!edismax v='Hello World' qf='meta_content__text_t' uf=-*}",
             $visitor->visit($criterion)
         );
     }
@@ -189,7 +242,7 @@ class FullTextTest extends TestCase
         $criterion->boost = array('title' => 2);
 
         $this->assertEquals(
-            '(meta_content__text_t:(Hello~0.5) OR title_1_s:(Hello~0.5)^2 OR title_2_s:(Hello~0.5)^2)',
+            "{!edismax v='Hello~0.5' qf='meta_content__text_t title_1_s^2 title_2_s^2' uf=-*}",
             $visitor->visit($criterion)
         );
     }
@@ -208,7 +261,19 @@ class FullTextTest extends TestCase
         $criterion->boost = array('title' => 2);
 
         $this->assertEquals(
-            '(meta_content__text_t:(Hello~0.5 World~0.5) OR title_1_s:(Hello~0.5 World~0.5)^2 OR title_2_s:(Hello~0.5 World~0.5)^2)',
+            "{!edismax v='Hello~0.5 World~0.5' qf='meta_content__text_t title_1_s^2 title_2_s^2' uf=-*}",
+            $visitor->visit($criterion)
+        );
+    }
+
+    public function testVisitErrorCorrection()
+    {
+        $visitor = $this->getFullTextCriterionVisitor();
+
+        $criterion = new Criterion\FullText('OR Hello && (and goodbye)) AND OR AND "as NOT +always');
+
+        $this->assertEquals(
+            "{!edismax v='Hello AND (and goodbye) as +always' qf='meta_content__text_t' uf=-*}",
             $visitor->visit($criterion)
         );
     }


### PR DESCRIPTION
This resolves https://jira.ez.no/browse/EZP-26806
Related PR: https://github.com/ezsystems/ezpublish-kernel/pull/2101

This implements improved query syntax for FullText criterion.
Quick cheat sheet:

`word` `"phrase"` `(group)` `+mandatory` `-prohibited` `AND` `&&` `OR` `||` `NOT` `!`

Examples:

- grouping
   ```
   one AND (two AND (three OR four))
   ```

- phrases
   ```
   "this is a phrase" and these are words
   ```

- mandatory/prohibited operators (`+`, `-`)
   ```
   +one two -three
   ```

And so on.

This is achieved through https://github.com/netgen/query-translator library, using `text` variant of the syntax it provides. The syntax can be customized by adjusting regular expressions used to tokenize the query input, meaning it can be easily adjusted if needed (for example using only the subset of the syntax, changing the operators and so on). The produced query now targets `edismax` query parser.

I would suggest trying the demo of https://github.com/netgen/query-translator to better understand what this is.

### Todos
- [x] API Fulltext documentation
  - Probably need to define a simple and advance format in the doc, and a way for app to capability detect if service engine support advance format _(via search service for instance, pulling that from engine)_
- [x] ~~Elasticsearch implementation~~
- [x] Integration tests