### PR TITLE
Fix-EZP-27724: Unable to run dockerized Solr

### DIFF
--- a/lib/Resources/config/solr/schema.xml
+++ b/lib/Resources/config/solr/schema.xml
@@ -109,5 +109,4 @@ should not remove or drastically change the existing definitions.
     <field name="_version_" type="long" indexed="true" stored="true" multiValued="false" />
 
   <uniqueKey>id</uniqueKey>
-  <defaultSearchField>id</defaultSearchField>
 </schema>


### PR DESCRIPTION
JIRA issue: [https://jira.ez.no/browse/EZP-27724](https://jira.ez.no/browse/EZP-27724)

# Description
As described in issue, run Solr is impossible because in the newest version of Solr ``6.6.0`` field ``defaultSearchField`` is deprecated. 
This PR removes mentioned field from ``schema.xml``.

Second solution proposed here: https://github.com/ezsystems/ezplatform/pull/196