### PR TITLE
EZP-27724: Remove Solr 6.6 deprecated schema field

### DIFF
--- a/lib/Resources/config/solr/schema.xml
+++ b/lib/Resources/config/solr/schema.xml
@@ -109,5 +109,4 @@ should not remove or drastically change the existing definitions.
     <field name="_version_" type="long" indexed="true" stored="true" multiValued="false" />
 
   <uniqueKey>id</uniqueKey>
-  <defaultSearchField>id</defaultSearchField>
 </schema>


### PR DESCRIPTION
JIRA issue: [https://jira.ez.no/browse/EZP-27724](https://jira.ez.no/browse/EZP-27724)

# Description
As described in issue, run Solr is impossible because in the newest version of Solr ``6.6.0`` field ``defaultSearchField`` is deprecated. 
This PR removes mentioned field from ``schema.xml``.

No changes in Solr behavior after deprecated field remove.

Second solution proposed here: https://github.com/ezsystems/ezplatform/pull/196

This PR is the same as https://github.com/ezsystems/ezplatform-solr-search-engine/pull/96 but with changed name and commit message.