### PR TITLE
EZP-27712: Enable RemoveTranslation Search Engine Slot

### DIFF
--- a/lib/Resources/config/container/solr/slots.yml
+++ b/lib/Resources/config/container/solr/slots.yml
@@ -1,3 +1,4 @@
+# @todo decouple Slots from Core (ezpublish-kernel)
 parameters:
     ezpublish.search.solr.slot.class: eZ\Publish\Core\Search\Common\Slot
     ezpublish.search.solr.slot.publish_version.class: eZ\Publish\Core\Search\Common\Slot\PublishVersion
@@ -21,6 +22,7 @@ parameters:
     ezpublish.search.solr.slot.set_content_state.class: eZ\Publish\Core\Search\Common\Slot\SetContentState
     ezpublish.search.solr.slot.swap_location.class: eZ\Publish\Core\Search\Common\Slot\SwapLocation
     ezpublish.search.solr.slot.update_content_metadata.class: eZ\Publish\Core\Search\Common\Slot\UpdateContentMetadata
+    ezpublish.search.solr.slot.remove_translation.class: EzSystems\EzPlatformSolrSearchEngine\Slot\RemoveTranslation
     ezpublish.search.solr.slot.assign_section.class: eZ\Publish\Core\Search\Common\Slot\AssignSection
 
 services:
@@ -157,6 +159,12 @@ services:
         class: "%ezpublish.search.solr.slot.update_content_metadata.class%"
         tags:
             - {name: ezpublish.search.solr.slot, signal: ContentService\UpdateContentMetadataSignal}
+
+    ezpublish.search.solr.slot.remove_translation:
+        parent: ezpublish.search.solr.slot
+        class: "%ezpublish.search.solr.slot.remove_translation.class%"
+        tags:
+            - {name: ezpublish.search.solr.slot, signal: ContentService\RemoveTranslationSignal}
 
     ezpublish.search.solr.slot.assign_section:
         parent: ezpublish.search.solr.slot

--- a/lib/Slot/RemoveTranslation.php
+++ b/lib/Slot/RemoveTranslation.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * This file is part of the eZ Platform Solr Search Engine package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformSolrSearchEngine\Slot;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+use eZ\Publish\Core\Search\Common\Slot;
+
+/**
+ * A Search Engine Slot handling RemoveTranslationSignal.
+ */
+class RemoveTranslation extends Slot
+{
+    /**
+     * Receive the given $signal and react on it.
+     *
+     * @param \eZ\Publish\Core\SignalSlot\Signal $signal
+     */
+    public function receive(Signal $signal)
+    {
+        if (!$signal instanceof Signal\ContentService\RemoveTranslationSignal) {
+            return;
+        }
+
+        $contentInfo = $this->persistenceHandler->contentHandler()->loadContentInfo(
+            $signal->contentId
+        );
+        if (!$contentInfo->isPublished) {
+            return;
+        }
+
+        $this->searchHandler->indexContent(
+            $this->persistenceHandler->contentHandler()->load(
+                $contentInfo->id,
+                $contentInfo->currentVersionNo
+            )
+        );
+    }
+}

--- a/tests/lib/Slot/RemoveTranslationTest.php
+++ b/tests/lib/Slot/RemoveTranslationTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * This file is part of the eZ Platform Solr Search Engine package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformSolrSearchEngine\Tests\Slot;
+
+use eZ\Publish\Core\SignalSlot\Signal\ContentService\RemoveTranslationSignal;
+use eZ\Publish\SPI\Persistence\Content\ContentInfo;
+use eZ\Publish\SPI\Persistence\Content as SPIContent;
+use EzSystems\EzPlatformSolrSearchEngine\Slot\RemoveTranslation;
+
+/**
+ * RemoveTranslation Slot Test.
+ */
+class RemoveTranslationTest extends TestCase
+{
+    /**
+     * @var \EzSystems\EzPlatformSolrSearchEngine\Slot\RemoveTranslation
+     */
+    private $slot;
+
+    /**
+     * Check if required signal exists due to BC.
+     */
+    public static function setUpBeforeClass()
+    {
+        if (!class_exists(RemoveTranslationSignal::class)) {
+            self::markTestSkipped('RemoveTranslationSignal does not exist');
+        }
+    }
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->slot = new RemoveTranslation(
+            $this->getRepositoryMock(),
+            $this->getPersistenceHandlerMock(),
+            $this->getSearchHandlerMock()
+        );
+    }
+
+    /**
+     * Test receiving RemoveTranslationSignal.
+     *
+     * @covers \EzSystems\EzPlatformSolrSearchEngine\Slot\RemoveTranslation::receive
+     */
+    public function testReceive()
+    {
+        $contentHandlerMock = $this->getContentHandlerMock();
+
+        $contentHandlerMock
+            ->expects($this->once())
+            ->method('loadContentInfo')
+            ->willReturn(
+                new ContentInfo(
+                    [
+                        'id' => 2,
+                        'currentVersionNo' => 1,
+                        'isPublished' => true,
+                    ]
+                )
+            )
+        ;
+
+        $content = new SPIContent();
+
+        $contentHandlerMock
+            ->expects($this->once())
+            ->method('load')
+            ->with(2, 1)
+            ->willReturn($content)
+        ;
+
+        $this
+            ->getSearchHandlerMock()
+            ->expects($this->once())
+            ->method('indexContent')
+            ->with($content)
+        ;
+
+        $this->slot->receive(
+            new RemoveTranslationSignal(['contentId' => 2, 'languageCode' => 'eng-US'])
+        );
+    }
+}

--- a/tests/lib/Slot/TestCase.php
+++ b/tests/lib/Slot/TestCase.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * This file is part of the eZ Platform Solr Search Engine package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformSolrSearchEngine\Tests\Slot;
+
+use eZ\Publish\API\Repository\Repository;
+use eZ\Publish\SPI\Persistence\Content\Handler as ContentHandler;
+use eZ\Publish\SPI\Persistence\Handler as PersistenceHandler;
+use eZ\Publish\SPI\Search\Handler as SearchHandler;
+
+/**
+ * Base class for testing Slots.
+ */
+class TestCase extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \eZ\Publish\SPI\Persistence\Content\Handler
+     */
+    private $contentHandlerMock;
+
+    /**
+     * @var \eZ\Publish\SPI\Persistence\Handler
+     */
+    private $persistenceHandlerMock;
+
+    /**
+     * @var \eZ\Publish\SPI\Search\Handler
+     */
+    private $searchHandlerMock;
+
+    /**
+     * @return \eZ\Publish\API\Repository\Repository|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getRepositoryMock()
+    {
+        return $this->getMock(Repository::class);
+    }
+
+    /**
+     * @return \eZ\Publish\SPI\Persistence\Handler|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getPersistenceHandlerMock()
+    {
+        if ($this->persistenceHandlerMock === null) {
+            $this->persistenceHandlerMock = $this->getMock(PersistenceHandler::class);
+            $this->persistenceHandlerMock
+                ->expects($this->any())
+                ->method('contentHandler')
+                ->willReturn($this->getContentHandlerMock())
+            ;
+        }
+
+        return $this->persistenceHandlerMock;
+    }
+
+    /**
+     * @return \eZ\Publish\SPI\Search\Handler|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getSearchHandlerMock()
+    {
+        if ($this->searchHandlerMock === null) {
+            $this->searchHandlerMock = $this->getMock(SearchHandler::class);
+        }
+
+        return $this->searchHandlerMock;
+    }
+
+    /**
+     * @return \eZ\Publish\SPI\Persistence\Content\Handler|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getContentHandlerMock()
+    {
+        if ($this->contentHandlerMock === null) {
+            $this->contentHandlerMock = $this->getMock(ContentHandler::class);
+        }
+
+        return $this->contentHandlerMock;
+    }
+}


### PR DESCRIPTION
Implements [EZP-27712](https://jira.ez.no/browse/EZP-27712) for Solr Bundle
----

This PR adds `RemoveTranslation` Search Engine Slot which reindexes Content on `RemoveTranslationSignal` introduced in ezsystems/ezpublish-kernel#2031

*Note: for ES/SQL Slot see ezsystems/ezpublish-kernel#2060.*

**TODO**:
- [x] Implement and enable `RemoveTranslation` Slot for Solr
- [x] Ensure 1.7 EE LTS BC (see [comment](#issuecomment-319682941)).
- [x] Remove TMP commit before merge