### PR TITLE
EZP-27647: Fix Solr 4 doc instructions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,9 @@ matrix:
         - php: 7.0
           env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="6.4.2"  CORES_SETUP="dedicated"
         - php: 7.1
-          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="6.4.2"  CORES_SETUP="shared" COMPOSER_REQUIRE="ezsystems/ezpublish-kernel:~6.7.4@dev"
+          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="6.5.1"  CORES_SETUP="shared" COMPOSER_REQUIRE="ezsystems/ezpublish-kernel:~6.7.4@dev"
         - php: 5.6
-          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="6.4.2"  CORES_SETUP="single" SOLR_CORES="collection1"
+          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="6.6.0"  CORES_SETUP="single" SOLR_CORES="collection1"
 
 # test only master and stable branches (+ Pull requests against those)
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
         - php: 7.1
           env: TEST_CONFIG="phpunit.xml"
         - php: 5.6
-          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="4.10.4" CORES_SETUP="dedicated"
+          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="4.10.4" CORES_SETUP="dedicated" COMPOSER_REQUIRE="ezsystems/ezpublish-kernel:~6.7.4@dev"
         - php: 7.0
           env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="4.10.4" CORES_SETUP="shared"
         - php: 7.1
@@ -21,7 +21,7 @@ matrix:
         - php: 7.0
           env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="6.4.2"  CORES_SETUP="dedicated"
         - php: 7.1
-          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="6.4.2"  CORES_SETUP="shared"
+          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="6.4.2"  CORES_SETUP="shared" COMPOSER_REQUIRE="ezsystems/ezpublish-kernel:~6.7.4@dev"
         - php: 5.6
           env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="6.4.2"  CORES_SETUP="single" SOLR_CORES="collection1"
 
@@ -37,6 +37,7 @@ before_script:
     - composer config -g github-oauth.github.com "d0285ed5c8644f30547572ead2ed897431c1fc09"
     # Avoid memory issues on composer install
     - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+    - if [ "$COMPOSER_REQUIRE" != "" ] ; then composer require --no-update $COMPOSER_REQUIRE ; fi
     - travis_retry composer update --prefer-dist --no-interaction
     - if [ "$SOLR_VERSION" != "" ] ; then ./bin/.travis/init_solr.sh ; fi
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,15 @@ For Contributing to this Bundle, you should make sure to run both unit and integ
 
     ```bash
     # Solr 4.10
-    cp -R <ezplatform-solr-search-engine>/lib/Resources/config/solr/* solr-4.10.4/example/solr/collection1/conf
+    cd solr-4.10.4/example
+    mkdir -p multicore/collection1/conf
+    cp -R <ezplatform-solr-search-engine>/lib/Resources/config/solr/* multicore/collection1/conf
+    cp solr/collection1/conf/{currency.xml,stopwords.txt,synonyms.txt} multicore/collection1/conf
+    ## Remove default cores configuration and add core configuration
+    sed -i.bak 's/<core name=".*" instanceDir=".*" \/>//g' multicore/solr.xml
+    sed -i.bak "s/<shardHandlerFactory/<core name=\"collection1\" instanceDir=\"collection1\" \/><shardHandlerFactory/g" multicore/solr.xml
+    cp multicore/core0/conf/solrconfig.xml multicore/collection1/conf
+    sed -i.bak s/core0/collection1/g multicore/collection1/conf/solrconfig.xml
 
     # Solr 6
     cd solr-6.4.2
@@ -92,7 +100,7 @@ For Contributing to this Bundle, you should make sure to run both unit and integ
     ```bash
     # Solr 4.10
     cd solr-4.10.4/example
-    java -Djetty.port=8983 -jar start.jar
+    java -Djetty.port=8983 -Dsolr.solr.home=multicore -jar start.jar
 
     # Solr 6
     cd solr-6.4.2

--- a/README.md
+++ b/README.md
@@ -47,10 +47,7 @@ For Contributing to this Bundle, you should make sure to run both unit and integ
 
    One of the following:
    - [Solr 4.10.4](http://archive.apache.org/dist/lucene/solr/4.10.4/solr-4.10.4.tgz)
-   - [Solr 6.4.2](http://archive.apache.org/dist/lucene/solr/6.4.2/solr-6.4.2.tgz)
-
-   _Solr 6 support is currently experimental, but already supports more features then 4.10 (atm: location search scoring)._
-
+   - [Solr 6.6.0](http://archive.apache.org/dist/lucene/solr/6.6.0/solr-6.6.0.tgz)
 
 3. Configure Solr *(single core)*
 
@@ -69,7 +66,7 @@ For Contributing to this Bundle, you should make sure to run both unit and integ
     sed -i.bak s/core0/collection1/g multicore/collection1/conf/solrconfig.xml
 
     # Solr 6
-    cd solr-6.4.2
+    cd solr-6
     mkdir -p server/ez/template
     cp -R <ezplatform-solr-search-engine>/lib/Resources/config/solr/* server/ez/template
     cp server/solr/configsets/basic_configs/conf/{currency.xml,solrconfig.xml,stopwords.txt,synonyms.txt,elevate.xml} server/ez/template
@@ -103,7 +100,7 @@ For Contributing to this Bundle, you should make sure to run both unit and integ
     java -Djetty.port=8983 -Dsolr.solr.home=multicore -jar start.jar
 
     # Solr 6
-    cd solr-6.4.2
+    cd solr-6
     bin/solr -s ez
     ## You'll also need to add cores on Solr 6, this adds single core setup:
     bin/solr create_core -c collection1 -d server/ez/template

--- a/bin/.travis/init_solr.sh
+++ b/bin/.travis/init_solr.sh
@@ -10,7 +10,7 @@ default_cores[2]='core2'
 default_cores[3]='core3'
 
 SOLR_PORT=${SOLR_PORT:-8983}
-SOLR_VERSION=${SOLR_VERSION:-6.4.2}
+SOLR_VERSION=${SOLR_VERSION:-6.6.0}
 SOLR_DEBUG=${SOLR_DEBUG:-false}
 SOLR_HOME=${SOLR_HOME:-ez}
 SOLR_CONFIG=${SOLR_CONFIG:-${default_config_files[*]}}
@@ -21,7 +21,7 @@ SOLR_INSTALL_DIR="${SOLR_DIR}/${SOLR_VERSION}"
 download() {
     case ${SOLR_VERSION} in
         # PS!!: Append versions and don't remove old once, kernel uses this script!
-        4.10.4|6.3.0|6.4.1|6.4.2 )
+        4.10.4|6.3.0|6.4.1|6.4.2|6.5.1|6.6.0 )
             url="http://archive.apache.org/dist/lucene/solr/${SOLR_VERSION}/solr-${SOLR_VERSION}.tgz"
             ;;
         *)


### PR DESCRIPTION
Context: Reports in https://jira.ez.no/browse/EZP-27647 from users that #90 broke solr4 setup with 1.7 release, so:
- Adding testing with kernel 6.7 just in case that might cause issues at some point _(in this case it was not relevant)_
- Add testing for newer version of Solr 6 while at it
- Update instructions for how to configure Solr 4 which seems to have gotten out of date in comparison with what we test as of #90