### PR TITLE
EZP-27774: Basic HTTP Authorisation fix

### DIFF
--- a/lib/Gateway/Endpoint.php
+++ b/lib/Gateway/Endpoint.php
@@ -101,7 +101,9 @@ class Endpoint extends ValueObject
      */
     public function getIdentifier()
     {
-        return "{$this->host}:{$this->port}{$this->path}/{$this->core}";
+        $authorization = (!empty($this->user) ? "{$this->user}:{$this->pass}@" : '');
+
+        return "{$authorization}{$this->host}:{$this->port}{$this->path}/{$this->core}";
     }
 
     /**
@@ -111,8 +113,6 @@ class Endpoint extends ValueObject
      */
     public function getURL()
     {
-        $authorization = (!empty($this->username) ? "{$this->user}:{$this->pass}" : '');
-
-        return "{$this->scheme}://{$authorization}" . $this->getIdentifier();
+        return "{$this->scheme}://" . $this->getIdentifier();
     }
 }


### PR DESCRIPTION
JIRA issue: https://jira.ez.no/browse/EZP-27774

## Description
As described in JIRA, the URL was built incorrectly (missing [at] sign) and `empty($this->username)` statement was wrong as well.

Futhermore, I have moved authorisation URL part `user:pass@` to the `getIdentifier()` method as this also has to be passed in `shards` URL parameter.