### PR TITLE
[WIP] EZP-27761: Translations are not being indexed/found by Solr

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "~5.6|~7.0",
-        "ezsystems/ezpublish-kernel": "~6.7.4@dev|^6.9.1@dev|^7.0@dev"
+        "ezsystems/ezpublish-kernel": "dev-ezp-27761-multilanguage-find-main"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.7",
@@ -29,6 +29,12 @@
     "extra": {
         "branch-alias": {
             "dev-master": "1.4.x-dev"
+        }
+    },
+    "repositories": {
+        "alongosz": {
+            "type": "git",
+            "url": "https://github.com/alongosz/ezpublish-kernel.git"
         }
     }
 }

--- a/lib/CoreFilter/NativeCoreFilter.php
+++ b/lib/CoreFilter/NativeCoreFilter.php
@@ -103,10 +103,10 @@ class NativeCoreFilter extends CoreFilter
             $languageSettings['useAlwaysAvailable'] === true
         );
 
-        $criteria = [
-            new CustomField(self::FIELD_DOCUMENT_TYPE, Operator::EQ, $documentTypeIdentifier),
-            $this->getCoreCriterion($languages, $useAlwaysAvailable),
-        ];
+        $criteria[] = new CustomField(self::FIELD_DOCUMENT_TYPE, Operator::EQ, $documentTypeIdentifier);
+        if (!empty($languages)) {
+            $criteria[] = $this->getLanguageFilterCondition($languages, $useAlwaysAvailable);
+        }
 
         if ($query->filter !== null) {
             $criteria[] = $query->filter;
@@ -126,30 +126,24 @@ class NativeCoreFilter extends CoreFilter
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Query\Criterion
      */
-    private function getCoreCriterion(array $languageCodes, $useAlwaysAvailable)
+    private function getLanguageFilterCondition(array $languageCodes, $useAlwaysAvailable)
     {
-        // Handle languages if given
-        if (!empty($languageCodes)) {
-            // Get condition for prioritized languages fallback
-            $filter = $this->getLanguageFilter($languageCodes);
+        // Get condition for prioritized languages fallback
+        $filter = $this->getLanguageFilter($languageCodes);
 
-            // Handle always available fallback if used
-            if ($useAlwaysAvailable) {
-                // Combine conditions with OR
-                $filter = new LogicalOr(
-                    array(
-                        $filter,
-                        $this->getAlwaysAvailableFilter($languageCodes),
-                    )
-                );
-            }
-
-            // Return languages condition
-            return $filter;
+        // Handle always available fallback if used
+        if ($useAlwaysAvailable) {
+            // Combine conditions with OR
+            $filter = new LogicalOr(
+                array(
+                    $filter,
+                    $this->getAlwaysAvailableFilter($languageCodes),
+                )
+            );
         }
 
-        // Otherwise search only main languages
-        return new CustomField(self::FIELD_IS_MAIN_LANGUAGE, Operator::EQ, true);
+        // Return languages condition
+        return $filter;
     }
 
     /**


### PR DESCRIPTION
# [WiP] Fixes [EZP-27761](https://jira.ez.no/browse/EZP-27761)

This PR attempts to fix inconsistent behavior with respect to SQL search when no languageFilter settings were given when searching for Content.

While this solves the issue at hand, it introduces regression - Content defined in multiple languages is returned multiple times, so it needs to be investigated further.

**TODO**:
- [x] Match all languages (instead of main) when no languages were given
- [ ] Decide how to fix an issue with the same content returned multiple times.
- [ ] Remove TMP commit.
