### PR TITLE
Enables PHPUnit v5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,14 +15,18 @@
         "ezsystems/ezpublish-kernel": "~6.7.4@dev|^6.9.1@dev|^7.0@dev"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.7",
-        "matthiasnoback/symfony-dependency-injection-test": "0.*"
+        "phpunit/phpunit": "^5.7",
+        "matthiasnoback/symfony-dependency-injection-test": "~1.0"
     },
     "autoload": {
         "psr-4": {
             "EzSystems\\EzPlatformSolrSearchEngine\\": "lib",
+            "EzSystems\\EzPlatformSolrSearchEngineBundle\\": "bundle"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
             "EzSystems\\EzPlatformSolrSearchEngine\\Tests\\": "tests/lib",
-            "EzSystems\\EzPlatformSolrSearchEngineBundle\\": "bundle",
             "EzSystems\\EzPlatformSolrSearchEngineBundle\\Tests\\": "tests/bundle"
         }
     },

--- a/tests/lib/Search/Query/CriterionVisitor/FullTextTest.php
+++ b/tests/lib/Search/Query/CriterionVisitor/FullTextTest.php
@@ -15,6 +15,7 @@ use eZ\Publish\Core\FieldType\TextLine\SearchField;
 use eZ\Publish\SPI\Search\FieldType\StringField;
 use EzSystems\EzPlatformSolrSearchEngine\Tests\Search\TestCase;
 use EzSystems\EzPlatformSolrSearchEngine\Query;
+use eZ\Publish\Core\Search\Common\FieldNameResolver;
 
 /**
  * Test case for FullText criterion visitor.
@@ -26,7 +27,7 @@ class FullTextTest extends TestCase
     protected function getFullTextCriterionVisitor(array $fieldTypes = array())
     {
         $fieldNames = array_keys($fieldTypes);
-        $fieldNameResolver = $this->getMockBuilder('\\eZ\\Publish\\Core\\Search\\Common\\FieldNameResolver')
+        $fieldNameResolver = $this->getMockBuilder(FieldNameResolver::class)
             ->disableOriginalConstructor()
             ->setMethods(array('getFieldNames', 'getFieldTypes'))
             ->getMock();

--- a/tests/lib/Search/Query/CriterionVisitor/FullTextTest.php
+++ b/tests/lib/Search/Query/CriterionVisitor/FullTextTest.php
@@ -26,13 +26,10 @@ class FullTextTest extends TestCase
     protected function getFullTextCriterionVisitor(array $fieldTypes = array())
     {
         $fieldNames = array_keys($fieldTypes);
-        $fieldNameResolver = $this->getMock(
-            '\\eZ\\Publish\\Core\\Search\\Common\\FieldNameResolver',
-            array('getFieldNames', 'getFieldTypes'),
-            array(),
-            '',
-            false
-        );
+        $fieldNameResolver = $this->getMockBuilder('\\eZ\\Publish\\Core\\Search\\Common\\FieldNameResolver')
+            ->disableOriginalConstructor()
+            ->setMethods(array('getFieldNames', 'getFieldTypes'))
+            ->getMock();
 
         $fieldNameResolver
             ->expects($this->any())

--- a/tests/lib/Search/Query/CriterionVisitor/FullTextTest.php
+++ b/tests/lib/Search/Query/CriterionVisitor/FullTextTest.php
@@ -29,7 +29,7 @@ class FullTextTest extends TestCase
         $fieldNames = array_keys($fieldTypes);
         $fieldNameResolver = $this->getMockBuilder(FieldNameResolver::class)
             ->disableOriginalConstructor()
-            ->setMethods(array('getFieldNames', 'getFieldTypes'))
+            ->setMethods(['getFieldNames', 'getFieldTypes'])
             ->getMock();
 
         $fieldNameResolver

--- a/tests/lib/Search/TestCase.php
+++ b/tests/lib/Search/TestCase.php
@@ -10,9 +10,11 @@
  */
 namespace EzSystems\EzPlatformSolrSearchEngine\Tests\Search;
 
+use PHPUnit\Framework\TestCase as BaseTestCase;
+
 /**
  * Base test case for Solr related tests.
  */
-abstract class TestCase extends \PHPUnit_Framework_TestCase
+abstract class TestCase extends BaseTestCase
 {
 }

--- a/tests/lib/Slot/TestCase.php
+++ b/tests/lib/Slot/TestCase.php
@@ -12,11 +12,12 @@ use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\SPI\Persistence\Content\Handler as ContentHandler;
 use eZ\Publish\SPI\Persistence\Handler as PersistenceHandler;
 use eZ\Publish\SPI\Search\Handler as SearchHandler;
+use PHPUnit\Framework\TestCase as BaseTestCase;
 
 /**
  * Base class for testing Slots.
  */
-class TestCase extends \PHPUnit_Framework_TestCase
+class TestCase extends BaseTestCase
 {
     /**
      * @var \eZ\Publish\SPI\Persistence\Content\Handler
@@ -38,7 +39,7 @@ class TestCase extends \PHPUnit_Framework_TestCase
      */
     protected function getRepositoryMock()
     {
-        return $this->getMock(Repository::class);
+        return $this->createMock(Repository::class);
     }
 
     /**
@@ -47,7 +48,7 @@ class TestCase extends \PHPUnit_Framework_TestCase
     protected function getPersistenceHandlerMock()
     {
         if ($this->persistenceHandlerMock === null) {
-            $this->persistenceHandlerMock = $this->getMock(PersistenceHandler::class);
+            $this->persistenceHandlerMock = $this->createMock(PersistenceHandler::class);
             $this->persistenceHandlerMock
                 ->expects($this->any())
                 ->method('contentHandler')
@@ -64,7 +65,7 @@ class TestCase extends \PHPUnit_Framework_TestCase
     protected function getSearchHandlerMock()
     {
         if ($this->searchHandlerMock === null) {
-            $this->searchHandlerMock = $this->getMock(SearchHandler::class);
+            $this->searchHandlerMock = $this->createMock(SearchHandler::class);
         }
 
         return $this->searchHandlerMock;
@@ -76,7 +77,7 @@ class TestCase extends \PHPUnit_Framework_TestCase
     protected function getContentHandlerMock()
     {
         if ($this->contentHandlerMock === null) {
-            $this->contentHandlerMock = $this->getMock(ContentHandler::class);
+            $this->contentHandlerMock = $this->createMock(ContentHandler::class);
         }
 
         return $this->contentHandlerMock;


### PR DESCRIPTION
This PR resolves:
* upgrades PHPUnit to version 5.7
* removes deprecated  `getMock()` method
* upgrades `matthiasnoback/symfony-dependency-injection-test` to version 1.0
* adds bundle and lib test to `autoload-dev` section of Composer autoload