### PR TITLE
EZP-27916: [Integration tests] Make SetupFactory autoloaded in root packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     "autoload": {
         "psr-4": {
             "EzSystems\\EzPlatformSolrSearchEngine\\": "lib",
-            "EzSystems\\EzPlatformSolrSearchEngineBundle\\": "bundle"
+            "EzSystems\\EzPlatformSolrSearchEngineBundle\\": "bundle",
+            "EzSystems\\EzPlatformSolrSearchEngine\\Tests\\SetupFactory\\": "tests/lib/SetupFactory"
         }
     },
     "autoload-dev": {


### PR DESCRIPTION
# Fixes [EZP-27916](https://jira.ez.no/browse/EZP-27916)

This PR fixes failures in CI tests for Solr run from `ezpublish-kernel` as a root-package.

Background story: The PR #102 splitted `autoload` settings into `autoload` and `autoload-dev`. 
This is fine when running tests from this package itself, however our `ezpublish-kernel` uses `SetupFactory` that exists in moved namespace prefix.

According to the [composer docs on `autoload-dev`](https://getcomposer.org/doc/04-schema.md#autoload-dev) this is `root-only` setting, so when Solr Bundle is required as a dependency, `composer dump-autoload` won't create proper paths.

**TODO**:
- [x] Discuss possible solutions.
- [x] Move `LegacySetupFactory` to `lib` and change its namespace.
- [x] Discuss the above approach
- [x] Simplify building of container inside `LegacySetupFactory` by reusing container build by the base `SetupFactory`
- [x] Create ezpublish-kernel PR counterpart with alignment of SetupFactory FQCN (ezsystems/ezpublish-kernel#2093)
- [x] Cleanup commits before merge