### PR TITLE
EZP-28005: Use POST request for /select resource

### DIFF
--- a/lib/Gateway/Native.php
+++ b/lib/Gateway/Native.php
@@ -545,11 +545,17 @@ class Native extends Gateway
         $queryString = $this->generateQueryString($parameters);
 
         $response = $this->client->request(
-            'GET',
+            'POST',
             $this->endpointRegistry->getEndpoint(
                 $this->endpointResolver->getEntryEndpoint()
             ),
-            "/select?{$queryString}"
+            '/select',
+            new Message(
+                [
+                    'Content-Type' => 'application/x-www-form-urlencoded',
+                ],
+                $queryString
+            )
         );
 
         // @todo: Error handling?


### PR DESCRIPTION
> issue: https://jira.ez.no/browse/EZP-28005

This switches from `GET` to `POST` when requesting Solr `/select` endpoint.

In some cases very long queries are generated by the engine, hitting the server limit and causing errors. It can happen for example with complex user permissions or having lots of conditions on a field whose name is used in multiple ContentTypes.

While `GET` would be formally correct for `/select` resource, `POST` is more practical since it's size limit is higher. For example with Jetty `GET` is limited to 8k and `POST` to 200k.

Other than that it makes no difference for Solr and multiple projects already did the same for the same reason:

- https://github.com/lucidworks/banana/pull/159
- https://www.drupal.org/node/761990