### PR TITLE
[CS] Aligned php-cs-fixer config with changes introduced by v2.7.1

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -17,6 +17,8 @@ return PhpCsFixer\Config::create()
         'phpdoc_annotation_without_dot' => false,
         'phpdoc_no_alias_tag' => false,
         'space_after_semicolon' => false,
+        'yoda_style' => false,
+        'no_break_comment' => false,
     ])
     ->setRiskyAllowed(true)
     ->setFinder(

--- a/.php_cs
+++ b/.php_cs
@@ -1,37 +1,5 @@
 <?php
 
-if (class_exists('Symfony\CS\Config\Config')) {
-    // PHP-CS-Fixer 1.x syntax (deprecated)
-    return Symfony\CS\Config\Config::create()
-        ->setUsingLinter(false)
-        ->setUsingCache(true)
-        ->level(Symfony\CS\FixerInterface::SYMFONY_LEVEL)
-        ->fixers([
-            'concat_with_spaces',
-            '-concat_without_spaces',
-            '-empty_return',
-            '-phpdoc_params',
-            '-phpdoc_separation',
-            '-phpdoc_to_comment',
-            '-spaces_cast',
-            '-blankline_after_open_tag',
-            '-single_blank_line_before_namespace',
-            // psr0 has weird issues with our PSR-4 layout, so deactivating it.
-            '-psr0',
-            '-phpdoc_annotation_without_dot',
-        ])
-        ->finder(
-            Symfony\CS\Finder\DefaultFinder::create()
-                ->in(__DIR__)
-                ->notPath('phpunit.xml')
-                ->exclude([
-                    'vendor',
-                ])
-                ->files()->name('*.php')
-        )
-    ;
-}
-
 // PHP-CS-Fixer 2.x syntax
 return PhpCsFixer\Config::create()
     ->setRules([


### PR DESCRIPTION
This PR aligns php-cs-fixer config with changes introduced by its recent update to `v2.7.1`.

Backporting to **1.0** as this branch is still supported by eZ Publish `5.x`.

**TODO**:
- [x] Remove obsolete php-cs-fixer `v1.x` configuration.
- [x] Set CS rule `yoda_style` and `no_break_comment` to false.
- [ ] Apply `modernize_types_casting` on merge into `1.4` for `lib/Indexer.php`