### PR TITLE
EZP-28088: Re-try connections when trying to reach Solr

### DIFF
--- a/lib/Gateway/HttpClient/Stream.php
+++ b/lib/Gateway/HttpClient/Stream.php
@@ -38,7 +38,7 @@ class Stream implements HttpClient
         // We'll try to reach backend 5 times before throwing exception.
         $i = 0;
         do {
-            $i++;
+            ++$i;
             if ($responseMessage = $this->requestStream($method, $endpoint, $path, $message)) {
                 return $responseMessage;
             }

--- a/lib/Gateway/HttpClient/Stream.php
+++ b/lib/Gateway/HttpClient/Stream.php
@@ -46,7 +46,6 @@ class Stream implements HttpClient
         $this->connectionTimeout = $connectionTimeout;
         $this->connectionRetry = $connectionRetry;
         $this->retryWaitMs = $retryWaitMs;
-
     }
 
     /**

--- a/lib/Gateway/HttpClient/Stream.php
+++ b/lib/Gateway/HttpClient/Stream.php
@@ -47,7 +47,7 @@ class Stream implements HttpClient
      * @param int $retry Number of times to re-try connection.
      * @param int $retryWaitMs Time in milli seconds.
      */
-    public function __construct(LoggerInterface $logger, $timeout = 20, $retry = 3, $retryWaitMs = 100)
+    public function __construct(LoggerInterface $logger, $timeout = 10, $retry = 5, $retryWaitMs = 100)
     {
         $this->logger = $logger;
         $this->connectionTimeout = $timeout;

--- a/lib/Gateway/HttpClient/Stream.php
+++ b/lib/Gateway/HttpClient/Stream.php
@@ -74,7 +74,7 @@ class Stream implements HttpClient
 
             // Wait for 100ms before we retry
             // Timeout is 10s, so time spent in worst case is 50.5s, which is less then default_socket_timeout (60s)
-            usleep($this->retryWaitMs*1000);
+            usleep($this->retryWaitMs * 1000);
         } while ($i < $this->connectionRetry);
 
         throw new ConnectionException($endpoint->getURL(), $path, $method);

--- a/lib/Gateway/HttpClient/Stream.php
+++ b/lib/Gateway/HttpClient/Stream.php
@@ -43,6 +43,7 @@ class Stream implements HttpClient
     /**
      * Stream constructor.
      *
+     * @param \Psr\Log\LoggerInterface $logger
      * @param int $timeout Timeout for connection in seconds.
      * @param int $retry Number of times to re-try connection.
      * @param int $retryWaitMs Time in milli seconds.

--- a/lib/Resources/config/container/solr/services.yml
+++ b/lib/Resources/config/container/solr/services.yml
@@ -14,6 +14,7 @@ parameters:
 services:
     ezpublish.search.solr.gateway.client.http.stream:
         class: "%ezpublish.search.solr.gateway.client.http.stream.class%"
+        arguments: ["@logger"]
 
     # Note: services tagged with 'ezpublish.search.solr.query.content.criterion_visitor'
     # are registered to this one using compilation pass


### PR DESCRIPTION
> issue: https://jira.ez.no/browse/EZP-28088


Note: This does not handle HTTP error codes returned, as code uses `ignore_errors`, however afaik what is relevant here is cases where we don't reach Solr _(network errors/dns/..)_. But if anyone see any other cases that would be relevant here please share :)

Also open question is if Solr would sometimes needs more time than 10s for handling calls, so might be timeout is too low here.


Todo:
- [x] Logger