### PR TITLE
EZP-28176: Support for parallel and selective indexing command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "~5.6|~7.0",
-        "ezsystems/ezpublish-kernel": "~6.7.6@dev|^6.11.4@dev|^7.0@dev",
+        "ezsystems/ezpublish-kernel": "~6.7.7@dev|^6.12.1@dev|^7.0@dev",
         "netgen/query-translator": "^1.0"
     },
     "require-dev": {

--- a/lib/Indexer.php
+++ b/lib/Indexer.php
@@ -9,83 +9,62 @@
 namespace EzSystems\EzPlatformSolrSearchEngine;
 
 use eZ\Publish\API\Repository\Exceptions\NotFoundException;
-use eZ\Publish\Core\Search\Common\Indexer as SearchIndexer;
-use EzSystems\EzPlatformSolrSearchEngine\Handler as SearchHandler;
-use Symfony\Component\Console\Helper\ProgressBar;
-use Symfony\Component\Console\Output\OutputInterface;
-use PDO;
-use RuntimeException;
+use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
+use eZ\Publish\Core\Search\Common\IncrementalIndexer;
+use EzSystems\EzPlatformSolrSearchEngine\Handler as SolrSearchHandler;
+use eZ\Publish\SPI\Persistence\Handler as PersistenceHandler;
+use Psr\Log\LoggerInterface;
 
-class Indexer extends SearchIndexer
+class Indexer extends IncrementalIndexer
 {
     /**
      * @var \EzSystems\EzPlatformSolrSearchEngine\Handler
      */
     protected $searchHandler;
 
-    /**
-     * Create search engine index.
-     *
-     * @param \Symfony\Component\Console\Output\OutputInterface $output
-     * @param int $iterationCount
-     * @param bool $commit
-     */
-    public function createSearchIndex(OutputInterface $output, $iterationCount, $commit)
-    {
-        $output->writeln('Creating Solr Search Engine Index...');
+    public function __construct(
+        LoggerInterface $logger,
+        PersistenceHandler $persistenceHandler,
+        DatabaseHandler $databaseHandler,
+        SolrSearchHandler $searchHandler
+    ) {
+        parent::__construct($logger, $persistenceHandler, $databaseHandler, $searchHandler);
+    }
 
-        if (!$this->searchHandler instanceof SearchHandler) {
-            throw new RuntimeException(sprintf('Expected to find an instance of %s, but found %s', SearchHandler::class, get_class($this->searchHandler)));
+    public function getName()
+    {
+        return 'eZ Platform Solr Search Engine';
+    }
+
+    public function purge()
+    {
+        $this->searchHandler->purgeIndex();
+    }
+
+    public function updateSearchIndex(array $contentIds, $commit)
+    {
+        $documents = [];
+        $contentHandler = $this->persistenceHandler->contentHandler();
+        foreach ($contentIds as $contentId) {
+            try {
+                $info = $contentHandler->loadContentInfo($contentId);
+                if ($info->isPublished) {
+                    $content = $contentHandler->load($contentId, $info->currentVersionNo);
+                    $documents[] = $this->searchHandler->generateDocument($content);
+                } else {
+                    $this->searchHandler->deleteContent($contentId);
+                }
+            } catch (NotFoundException $e) {
+                $this->searchHandler->deleteContent($contentId);
+            }
         }
 
-        $stmt = $this->getContentDbFieldsStmt(['count(id)']);
-        $totalCount = (int) $stmt->fetchColumn();
-        $stmt = $this->getContentDbFieldsStmt(['id', 'current_version']);
+        if (!empty($documents)) {
+            $this->searchHandler->bulkIndexDocuments($documents);
+        }
 
-        $this->searchHandler->purgeIndex();
-
-        $progress = new ProgressBar($output);
-        $progress->start($totalCount);
-
-        $i = 0;
-        do {
-            $contentObjects = [];
-            for ($k = 0; $k <= $iterationCount; ++$k) {
-                if (!$row = $stmt->fetch(PDO::FETCH_ASSOC)) {
-                    break;
-                }
-                try {
-                    $contentObjects[] = $this->persistenceHandler->contentHandler()->load(
-                        $row['id'],
-                        $row['current_version']
-                    );
-                } catch (NotFoundException $e) {
-                    $this->logWarning($progress, "Could not load current version of Content with id ${row['id']}, so skipped for indexing. Full exception: " . $e->getMessage());
-                }
-            }
-
-            $documents = [];
-            foreach ($contentObjects as $content) {
-                try {
-                    $documents[] = $this->searchHandler->generateDocument($content);
-                } catch (NotFoundException $e) {
-                    // Ignore content objects that have some sort of missing data on it
-                    $this->logWarning($progress, 'Content with id ' . $content->versionInfo->id . ' has missing data, so skipped for indexing. Full exception: ' . $e->getMessage());
-                }
-            }
-            if (!empty($documents)) {
-                $this->searchHandler->bulkIndexDocuments($documents);
-            }
-
-            if ($commit) {
-                $this->searchHandler->commit();
-            }
-
-            $progress->advance($k);
-        } while (($i += $iterationCount) < $totalCount);
-        $progress->finish();
-        $output->writeln('');
-
-        $output->writeln('Finished creating Solr Search Engine Index');
+        if ($commit) {
+            $this->searchHandler->commit(true);
+        }
     }
 }


### PR DESCRIPTION
> issue: https://jira.ez.no/browse/EZP-28176
> Depends on https://github.com/ezsystems/ezpublish-kernel/pull/2139

As a Developer I want a indexing command which is:
- faster at indexing (parallel indexing)
- able to refresh parts of index (by date or content id)
- able to omit purging so index is gradually refreshed on running prod setup
- able to remove index items if no longer existing (when I provide content id's to index)

Todo:
- [x] Split out SolrCreateIndexCommand.php changes into own PR and improvement for 1.0 and up
- [x] Re start travis once kernel PR has been merged