### PR TITLE
EZP-28814: Make single core Solr work on platform.sh

### DIFF
--- a/lib/Gateway/EndpointRegistry.php
+++ b/lib/Gateway/EndpointRegistry.php
@@ -62,4 +62,18 @@ class EndpointRegistry
 
         return $this->endpoint[$name];
     }
+
+    /**
+     * Get first Endpoint, for usecases where there is only one.
+     *
+     * @return \EzSystems\EzPlatformSolrSearchEngine\Gateway\Endpoint
+     */
+    public function getFirstEndpoint()
+    {
+        if (empty($this->endpoint)) {
+            throw new OutOfBoundsException("No Endpoint registered at all'.");
+        }
+
+        return reset($this->endpoint);
+    }
 }

--- a/lib/Gateway/EndpointResolver.php
+++ b/lib/Gateway/EndpointResolver.php
@@ -5,8 +5,6 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- *
- * @version //autogentag//
  */
 namespace EzSystems\EzPlatformSolrSearchEngine\Gateway;
 

--- a/lib/Gateway/EndpointResolver/NativeEndpointResolver.php
+++ b/lib/Gateway/EndpointResolver/NativeEndpointResolver.php
@@ -11,12 +11,13 @@
 namespace EzSystems\EzPlatformSolrSearchEngine\Gateway\EndpointResolver;
 
 use EzSystems\EzPlatformSolrSearchEngine\Gateway\EndpointResolver;
+use EzSystems\EzPlatformSolrSearchEngine\Gateway\SingleEndpointResolver;
 use RuntimeException;
 
 /**
  * NativeEndpointResolver provides Solr endpoints for a Content translations.
  */
-class NativeEndpointResolver implements EndpointResolver
+class NativeEndpointResolver implements EndpointResolver, SingleEndpointResolver
 {
     /**
      * Holds an array of Solr entry endpoint names.
@@ -53,6 +54,13 @@ class NativeEndpointResolver implements EndpointResolver
      * @var null|string
      */
     private $mainLanguagesEndpoint;
+
+    /**
+     * Result of hasMultipleEndpoints() once called the first time.
+     *
+     * @var bool|null
+     */
+    protected $hasMultiple = null;
 
     /**
      * Create from Endpoint names.
@@ -161,5 +169,29 @@ class NativeEndpointResolver implements EndpointResolver
         }
 
         return array_keys($endpointSet);
+    }
+
+    /**
+     * Returns true if current configurations has several endpoints.
+     *
+     * @return bool
+     */
+    public function hasMultipleEndpoints()
+    {
+        if ($this->hasMultiple !== null) {
+            return $this->hasMultiple;
+        }
+
+        $endpointSet = array_flip($this->endpointMap);
+
+        if (isset($this->defaultEndpoint)) {
+            $endpointSet[$this->defaultEndpoint] = true;
+        }
+
+        if (isset($this->mainLanguagesEndpoint)) {
+            $endpointSet[$this->mainLanguagesEndpoint] = true;
+        }
+
+        return $this->hasMultiple = count($endpointSet) > 1;
     }
 }

--- a/lib/Gateway/Native.php
+++ b/lib/Gateway/Native.php
@@ -175,12 +175,18 @@ class Native extends Gateway
     /**
      * Returns search targets for given language settings.
      *
+     * Only return endpoints if there are more then one configured, as this is meant for use on shard parameter.
+     *
      * @param array $languageSettings
      *
      * @return string
      */
     protected function getSearchTargets($languageSettings)
     {
+        if ($this->endpointResolver instanceof SingleEndpointResolver && !$this->endpointResolver->hasMultipleEndpoints()) {
+            return '';
+        }
+
         $shards = array();
         $endpoints = $this->endpointResolver->getSearchTargets($languageSettings);
 
@@ -196,10 +202,16 @@ class Native extends Gateway
     /**
      * Returns all search targets without language constraint.
      *
+     * Only return endpoints if there are more then one configured, as this is meant for use on shard parameter.
+     *
      * @return string
      */
     protected function getAllSearchTargets()
     {
+        if ($this->endpointResolver instanceof SingleEndpointResolver && !$this->endpointResolver->hasMultipleEndpoints()) {
+            return '';
+        }
+
         $shards = [];
         $searchTargets = $this->endpointResolver->getEndpoints();
         if (!empty($searchTargets)) {

--- a/lib/Gateway/SingleEndpointResolver.php
+++ b/lib/Gateway/SingleEndpointResolver.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * This file is part of the eZ Platform Solr Search Engine package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformSolrSearchEngine\Gateway;
+
+/**
+ * Additional interface for Endpoint resolvers which resolves Solr backend endpoints.
+ */
+interface SingleEndpointResolver
+{
+    /**
+     * Returns true if current configurations has several endpoints.
+     *
+     * @return bool
+     */
+    public function hasMultipleEndpoints();
+}

--- a/lib/Resources/config/container/solr.yml
+++ b/lib/Resources/config/container/solr.yml
@@ -66,6 +66,7 @@ services:
         class: "%ezpublish.search.solr.result_extractor.native.class%"
         arguments:
             - "@ezpublish.search.solr.query.content.facet_builder_visitor.aggregate"
+            - "@ezpublish.search.solr.gateway.endpoint_registry"
 
     ezpublish.search.solr.result_extractor:
         alias: ezpublish.search.solr.result_extractor.native

--- a/lib/ResultExtractor/LoadingResultExtractor.php
+++ b/lib/ResultExtractor/LoadingResultExtractor.php
@@ -10,6 +10,7 @@
  */
 namespace EzSystems\EzPlatformSolrSearchEngine\ResultExtractor;
 
+use EzSystems\EzPlatformSolrSearchEngine\Gateway\EndpointRegistry;
 use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor;
 use eZ\Publish\SPI\Persistence\Content\Handler as ContentHandler;
 use eZ\Publish\SPI\Persistence\Content\Location\Handler as LocationHandler;
@@ -39,12 +40,13 @@ class LoadingResultExtractor extends ResultExtractor
     public function __construct(
         ContentHandler $contentHandler,
         LocationHandler $locationHandler,
-        FacetBuilderVisitor $facetBuilderVisitor
+        FacetBuilderVisitor $facetBuilderVisitor,
+        EndpointRegistry $endpointRegistry
     ) {
         $this->contentHandler = $contentHandler;
         $this->locationHandler = $locationHandler;
 
-        parent::__construct($facetBuilderVisitor);
+        parent::__construct($facetBuilderVisitor, $endpointRegistry);
     }
 
     /**

--- a/tests/lib/Search/Gateway/EndpointResolver/NativeEndpointResolverTest.php
+++ b/tests/lib/Search/Gateway/EndpointResolver/NativeEndpointResolverTest.php
@@ -11,6 +11,7 @@
 namespace EzSystems\EzPlatformSolrSearchEngine\Tests\Search\Gateway\EndpointResolver;
 
 use EzSystems\EzPlatformSolrSearchEngine\Gateway\EndpointResolver\NativeEndpointResolver;
+use EzSystems\EzPlatformSolrSearchEngine\Gateway\SingleEndpointResolver;
 use EzSystems\EzPlatformSolrSearchEngine\Tests\Search\TestCase;
 use RuntimeException;
 
@@ -158,6 +159,7 @@ class NativeEndpointResolverTest extends TestCase
                 array(
                     'endpoint_en_GB',
                 ),
+                false,
             ),
             // Will return all endpoints (for always available fallback without main languages endpoint)
             3 => array(
@@ -689,6 +691,7 @@ class NativeEndpointResolverTest extends TestCase
                 array(
                     'default_endpoint',
                 ),
+                false,
             ),
             // Will return main languages endpoint (search on main languages with main languages endpoint)
             34 => array(
@@ -699,6 +702,7 @@ class NativeEndpointResolverTest extends TestCase
                 array(
                     'main_languages_endpoint',
                 ),
+                false,
             ),
             // Will return main languages endpoint (search on main languages with main languages endpoint)
             35 => array(
@@ -722,6 +726,7 @@ class NativeEndpointResolverTest extends TestCase
                 array(
                     'default_endpoint',
                 ),
+                false,
             ),
             // Will return main languages endpoint (search on main languages with main languages endpoint)
             37 => array(
@@ -748,6 +753,7 @@ class NativeEndpointResolverTest extends TestCase
                 array(
                     'main_languages_endpoint',
                 ),
+                false,
             ),
             // Will return all endpoints (search on main languages without main languages endpoint)
             39 => array(
@@ -763,6 +769,7 @@ class NativeEndpointResolverTest extends TestCase
                 array(
                     'default_endpoint',
                 ),
+                false,
             ),
             // Will return main languages endpoint (search on main languages with main languages endpoint)
             40 => array(
@@ -789,6 +796,7 @@ class NativeEndpointResolverTest extends TestCase
                 array(
                     'main_languages_endpoint',
                 ),
+                false,
             ),
         );
     }
@@ -801,13 +809,15 @@ class NativeEndpointResolverTest extends TestCase
      * @param null|string $mainLanguagesEndpoint
      * @param array $languageSettings
      * @param string[] $expected
+     * @param bool $expectedIsMultiple
      */
     public function testGetSearchTargets(
         $endpointMap,
         $defaultEndpoint,
         $mainLanguagesEndpoint,
         $languageSettings,
-        $expected
+        $expected,
+        $expectedIsMultiple = true
     ) {
         $endpointResolver = $this->getEndpointResolver(
             array(),
@@ -819,6 +829,11 @@ class NativeEndpointResolverTest extends TestCase
         $actual = $endpointResolver->getSearchTargets($languageSettings);
 
         $this->assertEquals($expected, $actual);
+
+        if ($endpointResolver instanceof SingleEndpointResolver) {
+            $this->assertEquals($expectedIsMultiple, $endpointResolver->hasMultipleEndpoints());
+        }
+
     }
 
     public function providerForTestGetSearchTargetsThrowsRuntimeException()

--- a/tests/lib/Search/Gateway/EndpointResolver/NativeEndpointResolverTest.php
+++ b/tests/lib/Search/Gateway/EndpointResolver/NativeEndpointResolverTest.php
@@ -833,7 +833,6 @@ class NativeEndpointResolverTest extends TestCase
         if ($endpointResolver instanceof SingleEndpointResolver) {
             $this->assertEquals($expectedIsMultiple, $endpointResolver->hasMultipleEndpoints());
         }
-
     }
 
     public function providerForTestGetSearchTargetsThrowsRuntimeException()


### PR DESCRIPTION
> Replaces #110 
> Attempt to fix usage on platform.sh where Solr does not know about dns of itself causing it to break

This is kind of working around the platform.sh dns issue _(solr service does not known about it's own dns)_, and it's only able to do it on single core, multi core is still broken on Platform.sh which means any serious multi language setup _(where you want to configure different language stemming rules and so on per core)_ will be blocked from using that.

####  The real solution to this
- Platform.sh needs to fix their self discovery of their Solr setup, they anyway need that if people are to use multi / shared core setup.
- Far stretch, but might also be that this problem goes away if we enable solr cloud features, see pr on that.

/cc @vidarl 