### PR TITLE
EZP-28898: Implemented SortClause visitor for Random sort

### DIFF
--- a/lib/Query/Common/SortClauseVisitor/Random.php
+++ b/lib/Query/Common/SortClauseVisitor/Random.php
@@ -37,6 +37,7 @@ class Random extends SortClauseVisitor
      */
     public function visit(SortClause $sortClause)
     {
-        return 'random_' . $sortClause->targetData->seed . $this->getDirection($sortClause);
+        $seed = $sortClause->targetData->seed ?? mt_rand();
+        return 'random_' . (string)$seed . ' ' . $this->getDirection($sortClause);
     }
 }

--- a/lib/Query/Common/SortClauseVisitor/Random.php
+++ b/lib/Query/Common/SortClauseVisitor/Random.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * This file is part of the eZ Platform Solr Search Engine package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformSolrSearchEngine\Query\Common\SortClauseVisitor;
+
+use EzSystems\EzPlatformSolrSearchEngine\Query\SortClauseVisitor;
+use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
+
+/**
+ * Visits the sortClause tree into a Solr query.
+ */
+class Random extends SortClauseVisitor
+{
+    /**
+     * Check if visitor is applicable to current sortClause.
+     *
+     * @param SortClause $sortClause
+     *
+     * @return bool
+     */
+    public function canVisit(SortClause $sortClause)
+    {
+        return $sortClause instanceof SortClause\Random;
+    }
+
+    /**
+     * Map field value to a proper Solr representation.
+     *
+     * @param SortClause $sortClause
+     *
+     * @return string
+     */
+    public function visit(SortClause $sortClause)
+    {
+        return 'random_' . $sortClause->targetData->seed . $this->getDirection($sortClause);
+    }
+}

--- a/lib/Resources/config/container/solr/sort_clause_visitors.yml
+++ b/lib/Resources/config/container/solr/sort_clause_visitors.yml
@@ -8,6 +8,7 @@ parameters:
     ezpublish.search.solr.query.common.sort_clause_visitor.date_published.class: EzSystems\EzPlatformSolrSearchEngine\Query\Common\SortClauseVisitor\DatePublished
     ezpublish.search.solr.query.common.sort_clause_visitor.date_modified.class: EzSystems\EzPlatformSolrSearchEngine\Query\Common\SortClauseVisitor\DateModified
     ezpublish.search.solr.query.common.sort_clause_visitor.map_location_distance.class: EzSystems\EzPlatformSolrSearchEngine\Query\Common\SortClauseVisitor\MapLocationDistance
+    ezpublish.search.solr.query.common.sort_clause_visitor.random.class: EzSystems\EzPlatformSolrSearchEngine\Query\Common\SortClauseVisitor\Random
     # Location search
     ezpublish.search.solr.query.location.sort_clause_visitor.depth.class: EzSystems\EzPlatformSolrSearchEngine\Query\Location\SortClauseVisitor\Location\Depth
     ezpublish.search.solr.query.location.sort_clause_visitor.id.class: EzSystems\EzPlatformSolrSearchEngine\Query\Location\SortClauseVisitor\Location\Id
@@ -67,6 +68,12 @@ services:
         arguments:
             - "@ezpublish.search.common.field_name_resolver"
             - 'value_location'
+        tags:
+            - {name: ezpublish.search.solr.query.content.sort_clause_visitor}
+            - {name: ezpublish.search.solr.query.location.sort_clause_visitor}
+
+    ezpublish.search.solr.query.common.sort_clause_visitor.random:
+        class: "%ezpublish.search.solr.query.common.sort_clause_visitor.random.class%"
         tags:
             - {name: ezpublish.search.solr.query.content.sort_clause_visitor}
             - {name: ezpublish.search.solr.query.location.sort_clause_visitor}

--- a/lib/Resources/config/solr/schema.xml
+++ b/lib/Resources/config/solr/schema.xml
@@ -56,8 +56,10 @@ should not remove or drastically change the existing definitions.
 
     <fieldType name="currency" class="solr.CurrencyField" precisionStep="8" defaultCurrency="USD" currencyConfig="currency.xml" />
 
-
-
+    <!--
+        This fieldtype is required to allow random sorting
+    -->
+    <fieldType name="random" class="solr.RandomSortField" />
 
     <!--
       Required ID field.
@@ -102,6 +104,11 @@ should not remove or drastically change the existing definitions.
     <dynamicField name="*_gl_0_coordinate" type="double" indexed="true" stored="true"/>
     <dynamicField name="*_gl_1_coordinate" type="double" indexed="true" stored="true"/>
     <dynamicField name="*_c" type="currency" indexed="true" stored="true"/>
+
+    <!--
+        This field is required to allow random sorting
+    -->
+    <dynamicField name="random*" type="random" indexed="true" stored="false"/>
 
     <!--
       This field is required since Solr 4


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-28898](https://jira.ez.no/browse/EZP-28898)
| **Requires** | ezsystems/ezpublish-kernel#2605
| **Bug/Improvement**| no
| **New feature**    | yes
| **Target version** | Solr Bundle `2.0` for eZ Platform `3.0`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes

This allows random sorting based on a seed.  Using the same seed will result in same order of random results.

Example:

This example rotates the used seed based on time so the returned results have a new order every 360 seconds.

```
$query = new Query();
$query->sortClauses = [
    new Random((int)(time() / 360)),
];

```