### PR TITLE
EZP-28739: Add --continue-on-error option & display corrupted content IDs in the search indexer

### DIFF
--- a/lib/Indexer.php
+++ b/lib/Indexer.php
@@ -23,11 +23,6 @@ class Indexer extends IncrementalIndexer
      */
     protected $searchHandler;
 
-    /**
-     * @var \Psr\Log\LoggerInterface
-     */
-    protected $logger;
-
     public function __construct(
         LoggerInterface $logger,
         PersistenceHandler $persistenceHandler,
@@ -35,7 +30,6 @@ class Indexer extends IncrementalIndexer
         SolrSearchHandler $searchHandler
     ) {
         parent::__construct($logger, $persistenceHandler, $databaseHandler, $searchHandler);
-        $this->logger = $logger;
     }
 
     public function getName()


### PR DESCRIPTION
…t IDs in the search indexer

JIRA issue: https://jira.ez.no/browse/EZP-28739

This PR contains changed required for changes introduced in: https://github.com/ezsystems/ezpublish-kernel/pull/2221