### PR TITLE
EZP-29396: Remove unnecessary test cache decorator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,11 @@ matrix:
           env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="4.10.4" CORES_SETUP="shared"
         - php: 7.1
           env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="4.10.4" CORES_SETUP="single" SOLR_CORES="collection1"
-        - php: 7.0
-          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="6.4.2"  CORES_SETUP="dedicated"
-        - php: 7.1
-          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="6.5.1"  CORES_SETUP="shared" COMPOSER_REQUIRE="ezsystems/ezpublish-kernel:~6.7.4@dev"
         - php: 5.6
+          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="6.6.0"  CORES_SETUP="single" SOLR_CORES="collection1"
+        - php: 7.0
+          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="6.4.2"  CORES_SETUP="dedicated" COMPOSER_REQUIRE="ezsystems/ezpublish-kernel:~6.7.4@dev"
+        - php: 7.1
           env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="6.6.0"  CORES_SETUP="single" SOLR_CORES="collection1"
 
 # test only master and stable branches (+ Pull requests against those)

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,11 @@ matrix:
           env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="4.10.4" CORES_SETUP="shared"
         - php: 7.1
           env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="4.10.4" CORES_SETUP="single" SOLR_CORES="collection1"
-        - php: 5.6
-          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="6.6.0"  CORES_SETUP="single" SOLR_CORES="collection1"
         - php: 7.0
           env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="6.4.2"  CORES_SETUP="dedicated" COMPOSER_REQUIRE="ezsystems/ezpublish-kernel:~6.7.4@dev"
         - php: 7.1
+          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="6.5.1"  CORES_SETUP="shared"
+        - php: 5.6
           env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="6.6.0"  CORES_SETUP="single" SOLR_CORES="collection1"
 
 # test only master and stable branches (+ Pull requests against those)

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
         "netgen/query-translator": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7",
-        "matthiasnoback/symfony-dependency-injection-test": "~1.0"
+        "phpunit/phpunit": "^5.6||^7.0",
+        "matthiasnoback/symfony-dependency-injection-test": "~1.0||~3.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "netgen/query-translator": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.6||^7.0",
+        "phpunit/phpunit": "^5.7||^7.0",
         "matthiasnoback/symfony-dependency-injection-test": "~1.0||~3.0"
     },
     "autoload": {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -23,3 +23,8 @@ if (!file_exists($file)) {
 }
 
 $autoload = require_once $file;
+
+// Polyfill PHPUnit 6.0
+if (!class_exists('PHPUnit_Framework_Constraint', true)) {
+    class_alias('PHPUnit\Framework\Constraint\Constraint', 'PHPUnit_Framework_Constraint');
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -24,7 +24,7 @@ if (!file_exists($file)) {
 
 $autoload = require_once $file;
 
-// Polyfill PHPUnit 6.0
+// Polyfill for PHPUnit 6.0 and up
 if (!class_exists('PHPUnit_Framework_Constraint', true)) {
     class_alias('PHPUnit\Framework\Constraint\Constraint', 'PHPUnit_Framework_Constraint');
 }

--- a/tests/lib/Resources/config/multicore_dedicated.yml
+++ b/tests/lib/Resources/config/multicore_dedicated.yml
@@ -11,7 +11,6 @@ parameters:
     languages:
         - eng-US
         - eng-GB
-    ezpublish.cache_pool.spi.cache.decorator.class: eZ\Publish\Core\Persistence\Cache\Tests\Helpers\IntegrationTestCacheServiceDecorator
     ignored_storage_files:
         -
             var/ezdemo_site/storage/images/design/plain-site/172-2-eng-US/eZ-Publish-Demo-Design-without-demo-content1.png
@@ -28,9 +27,6 @@ parameters:
     ezpublish.search.solr.main_translations_endpoint: null
 
 services:
-    ezpublish.cache_pool.spi.cache.decorator:
-        class: "%ezpublish.cache_pool.spi.cache.decorator.class%"
-
     ezpublish.spi.search_engine:
         alias: ezpublish.spi.search.solr
 

--- a/tests/lib/Resources/config/multicore_shared.yml
+++ b/tests/lib/Resources/config/multicore_shared.yml
@@ -11,7 +11,6 @@ parameters:
     languages:
         - eng-US
         - eng-GB
-    ezpublish.cache_pool.spi.cache.decorator.class: eZ\Publish\Core\Persistence\Cache\Tests\Helpers\IntegrationTestCacheServiceDecorator
     ignored_storage_files:
         -
             var/ezdemo_site/storage/images/design/plain-site/172-2-eng-US/eZ-Publish-Demo-Design-without-demo-content1.png
@@ -25,9 +24,6 @@ parameters:
     ezpublish.search.solr.main_translations_endpoint: endpoint0
 
 services:
-    ezpublish.cache_pool.spi.cache.decorator:
-        class: "%ezpublish.cache_pool.spi.cache.decorator.class%"
-
     ezpublish.spi.search_engine:
         alias: ezpublish.spi.search.solr
 

--- a/tests/lib/Resources/config/single_core.yml
+++ b/tests/lib/Resources/config/single_core.yml
@@ -11,7 +11,6 @@ parameters:
     languages:
         - eng-US
         - eng-GB
-    ezpublish.cache_pool.spi.cache.decorator.class: eZ\Publish\Core\Persistence\Cache\Tests\Helpers\IntegrationTestCacheServiceDecorator
     ignored_storage_files:
         -
             var/ezdemo_site/storage/images/design/plain-site/172-2-eng-US/eZ-Publish-Demo-Design-without-demo-content1.png
@@ -24,9 +23,6 @@ parameters:
     ezpublish.search.solr.main_translations_endpoint: null
 
 services:
-    ezpublish.cache_pool.spi.cache.decorator:
-        class: "%ezpublish.cache_pool.spi.cache.decorator.class%"
-
     ezpublish.spi.search_engine:
         alias: ezpublish.spi.search.solr
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29396](https://jira.ez.no/browse/EZP-29396)
| **Bug**| yes
| **Target version** | `1.5` and `master`

This change is required regarding changes done in kernel in: https://github.com/ezsystems/ezpublish-kernel/pull/2387.
Since test should be working properly with Redis, using of the `eZ\Publish\Core\Persistence\Cache\Tests\Helpers\IntegrationTestCacheServiceDecorator` is no longer necessary. 