### PR TITLE
Test regressions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,22 +10,8 @@ cache:
 
 matrix:
     include:
-        - php: 5.6
-          env: TEST_CONFIG="phpunit.xml"
         - php: 7.2
-          env: TEST_CONFIG="phpunit.xml"
-        - php: 5.6
-          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="4.10.4" CORES_SETUP="dedicated" COMPOSER_REQUIRE="ezsystems/ezpublish-kernel:~6.7.4@dev"
-        - php: 7.0
-          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="4.10.4" CORES_SETUP="shared"
-        - php: 7.1
-          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="4.10.4" CORES_SETUP="single" SOLR_CORES="collection1"
-        - php: 7.0
-          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="6.4.2"  CORES_SETUP="dedicated" COMPOSER_REQUIRE="ezsystems/ezpublish-kernel:~6.7.4@dev"
-        - php: 7.2
-          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="6.5.1"  CORES_SETUP="shared"
-        - php: 5.6
-          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="6.6.5"  CORES_SETUP="single" SOLR_CORES="collection1"
+          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="6.6.0"  CORES_SETUP="shared"
 
 # test only master and stable branches (+ Pull requests against those)
 branches:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Solr Search Engine Bundle for eZ Platform
+# Solr Search Engine Bundle for eZ Platform 
 
 [![Build Status](https://img.shields.io/travis/ezsystems/ezplatform-solr-search-engine.svg?style=flat-square)](https://travis-ci.org/ezsystems/ezplatform-solr-search-engine)
 [![Downloads](https://img.shields.io/packagist/dt/ezsystems/ezplatform-solr-search-engine.svg?style=flat-square)](https://packagist.org/packages/ezsystems/ezplatform-solr-search-engine)

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "~5.6|~7.0",
-        "ezsystems/ezpublish-kernel": "~6.7.7@dev|^6.12.1@dev|^7.0@dev",
+        "ezsystems/ezpublish-kernel": "7.2.2",
         "netgen/query-translator": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
Testing change in fulltext scoring probably caused by https://github.com/ezsystems/ezplatform-solr-search-engine/pull/120 (not sure why it didn't show initially).

Discovered on https://github.com/netgen/ezplatform-search-extra/pull/7, see the change in regression tests between last two commits (last build in the list), installing `1.5.4` and `1.5.2.1` respectively:

- https://travis-ci.org/netgen/ezplatform-search-extra/jobs/415284876
- https://travis-ci.org/netgen/ezplatform-search-extra/jobs/415293559