### PR TITLE
EZP-30169: Bump to 1.6 bundle version & drop Solr 4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,15 +10,13 @@ cache:
 
 matrix:
     include:
-        - php: 5.6
-          env: TEST_CONFIG="phpunit.xml"
         - php: 7.2
           env: TEST_CONFIG="phpunit.xml"
-        - php: 7.0
-          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="6.4.2"  CORES_SETUP="dedicated" COMPOSER_REQUIRE="ezsystems/ezpublish-kernel:~6.7.8@dev"
+        - php: 7.1
+          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="6.4.2"  CORES_SETUP="dedicated"
         - php: 7.2
           env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="6.5.1"  CORES_SETUP="shared"
-        - php: 5.6
+        - php: 7.2
           env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="6.6.5"  CORES_SETUP="single" SOLR_CORES="collection1"
 
 # test only master and stable branches (+ Pull requests against those)

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,14 +14,8 @@ matrix:
           env: TEST_CONFIG="phpunit.xml"
         - php: 7.2
           env: TEST_CONFIG="phpunit.xml"
-        - php: 5.6
-          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="4.10.4" CORES_SETUP="dedicated" COMPOSER_REQUIRE="ezsystems/ezpublish-kernel:~6.7.4@dev"
         - php: 7.0
-          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="4.10.4" CORES_SETUP="shared" COMPOSER_REQUIRE="ezsystems/ezpublish-kernel:~6.13.5@dev"
-        - php: 7.1
-          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="4.10.4" CORES_SETUP="single" SOLR_CORES="collection1"
-        - php: 7.1
-          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="6.4.2"  CORES_SETUP="dedicated"
+          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="6.4.2"  CORES_SETUP="dedicated" COMPOSER_REQUIRE="ezsystems/ezpublish-kernel:~6.7.8@dev"
         - php: 7.2
           env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="6.5.1"  CORES_SETUP="shared"
         - php: 5.6

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License](https://img.shields.io/github/license/ezsystems/ezplatform-solr-search-engine.svg?style=flat-square)](LICENSE)
 
 Solr Search Engine Bundle for use with:
-- v1.5+: eZ Platform 1.7+ *(bundled out of the box)* with Solr 4.10.4 _or_ 6.x _(recommended: 6.x)_
+- v1.5+: eZ Platform 1.7+ *(bundled out of the box)* with Solr 6.x _(recommended: 6.6 which is an LTS)_
 - v1.0.x: eZ Publish Platform Enterprise 5.4.5+ *(optional, not as feature rich but helpful for scaling filtering queries)* with Solr 4.10.4
 
 #####  Overview of features
@@ -56,7 +56,6 @@ For Contributing to this Bundle, you should make sure to run both unit and integ
 2. Get & extract Solr
 
    E.g. one of the following:
-   - [Solr 4.10.4](http://archive.apache.org/dist/lucene/solr/4.10.4/solr-4.10.4.tgz)
    - [Solr 6.6.5](http://archive.apache.org/dist/lucene/solr/6.6.0/solr-6.6.5.tgz)
 
 3. Configure Solr *(single core)*
@@ -64,17 +63,6 @@ For Contributing to this Bundle, you should make sure to run both unit and integ
     *Note: See .travis.yml and bin/.travis/init_solr.sh for multi core setups*
 
     ```bash
-    # Solr 4.10
-    cd solr-4.10.4/example
-    mkdir -p multicore/collection1/conf
-    cp -R <ezplatform-solr-search-engine>/lib/Resources/config/solr/* multicore/collection1/conf
-    cp solr/collection1/conf/{currency.xml,stopwords.txt,synonyms.txt} multicore/collection1/conf
-    ## Remove default cores configuration and add core configuration
-    sed -i.bak 's/<core name=".*" instanceDir=".*" \/>//g' multicore/solr.xml
-    sed -i.bak "s/<shardHandlerFactory/<core name=\"collection1\" instanceDir=\"collection1\" \/><shardHandlerFactory/g" multicore/solr.xml
-    cp multicore/core0/conf/solrconfig.xml multicore/collection1/conf
-    sed -i.bak s/core0/collection1/g multicore/collection1/conf/solrconfig.xml
-
     # Solr 6
     cd solr-6.6.5
     mkdir -p server/ez/template
@@ -115,10 +103,6 @@ For Contributing to this Bundle, you should make sure to run both unit and integ
 4. Start Solr
 
     ```bash
-    # Solr 4.10
-    cd solr-4.10.4/example
-    java -Djetty.port=8983 -Dsolr.solr.home=multicore -jar start.jar
-
     # Solr 6
     cd solr-6.6.5
     bin/solr -s ez

--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,11 @@
     "require": {
         "php": "~5.6|~7.0",
         "ezsystems/ezpublish-kernel": "~6.7.10@dev|^6.13.6@dev|~7.3.5@dev|^7.4.3@dev",
-        "netgen/query-translator": "^1.0"
+        "netgen/query-translator": "^1.0.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7||^7.0",
-        "matthiasnoback/symfony-dependency-injection-test": "~1.0||~3.0"
+        "phpunit/phpunit": "^5.7||^7.5",
+        "matthiasnoback/symfony-dependency-injection-test": "~1.0||~3.1"
     },
     "autoload": {
         "psr-4": {
@@ -34,7 +34,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.5.x-dev"
+            "dev-master": "1.6.x-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "ezsystems/ezplatform-solr-search-engine",
     "description": "Solr search engine implementation for eZ Platform",
-    "license": "GPL-2.0",
+    "license": "GPL-2.0-only",
     "type": "ezplatform-bundle",
     "homepage": "https://github.com/ezsystems/ezplatform-solr-search-engine",
     "authors": [
@@ -11,8 +11,8 @@
         }
     ],
     "require": {
-        "php": "~5.6|~7.0",
-        "ezsystems/ezpublish-kernel": "~6.7.10@dev|^6.13.6@dev|~7.3.5@dev|^7.4.3@dev",
+        "php": "^7.1",
+        "ezsystems/ezpublish-kernel": "^7.5@dev",
         "netgen/query-translator": "^1.0.2"
     },
     "require-dev": {


### PR DESCRIPTION
Story: https://jira.ez.no/browse/EZP-30169

Preparations for the 2.5LTS, to reduce test/support matrix to get rid of irrelevant versions _(by now)_.

Given location search scoring can never be supported on Solr 4 and given how old it is, it makes sense to stop using time on it for QA and others.