### PR TITLE
Required kernel for eZ Platform 1.7 should be 6.7.10+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "~5.6|~7.0",
-        "ezsystems/ezpublish-kernel": "~6.7.8@dev|^6.13.5@dev|~7.3.5@dev|^7.4.3@dev",
+        "ezsystems/ezpublish-kernel": "~6.7.10@dev|^6.13.6@dev|~7.3.5@dev|^7.4.3@dev",
         "netgen/query-translator": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
Current tagged kernel 6.7 is [6.7.9.1](https://github.com/ezsystems/ezpublish-kernel/releases/tag/v6.7.9.1) which does not contain changes required by https://github.com/ezsystems/ezplatform-solr-search-engine/commit/55558b70649a1c2a64be534c5c5e14dae8271c70

same for 6.13

This PR changes the requirement for kernel 6.7 to version 6.7.10 and kernel 6.13 to 6.13.6