### PR TITLE
[Travis] Fixed test matrix to cover more Kernel versions when testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
         - php: 5.6
           env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="4.10.4" CORES_SETUP="dedicated" COMPOSER_REQUIRE="ezsystems/ezpublish-kernel:~6.7.4@dev"
         - php: 7.0
-          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="4.10.4" CORES_SETUP="shared"
+          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="4.10.4" CORES_SETUP="shared" COMPOSER_REQUIRE="ezsystems/ezpublish-kernel:~6.13.5@dev"
         - php: 7.1
           env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="4.10.4" CORES_SETUP="single" SOLR_CORES="collection1"
         - php: 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ matrix:
           env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="4.10.4" CORES_SETUP="shared"
         - php: 7.1
           env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="4.10.4" CORES_SETUP="single" SOLR_CORES="collection1"
-        - php: 7.0
-          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="6.4.2"  CORES_SETUP="dedicated" COMPOSER_REQUIRE="ezsystems/ezpublish-kernel:~6.7.4@dev"
+        - php: 7.1
+          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="6.4.2"  CORES_SETUP="dedicated"
         - php: 7.2
           env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="6.5.1"  CORES_SETUP="shared"
         - php: 5.6

--- a/bin/.travis/init_solr.sh
+++ b/bin/.travis/init_solr.sh
@@ -8,6 +8,7 @@ default_cores[0]='core0'
 default_cores[1]='core1'
 default_cores[2]='core2'
 default_cores[3]='core3'
+default_cores[4]='core4'
 
 SOLR_PORT=${SOLR_PORT:-8983}
 SOLR_VERSION=${SOLR_VERSION:-6.6.5}

--- a/tests/lib/Resources/config/multicore_dedicated.yml
+++ b/tests/lib/Resources/config/multicore_dedicated.yml
@@ -23,6 +23,7 @@ parameters:
           eng-US: endpoint1
           por-PT: endpoint2
           ger-DE: endpoint3
+          nor-NO: endpoint4
     ezpublish.search.solr.default_endpoint: null
     ezpublish.search.solr.main_translations_endpoint: null
 
@@ -77,3 +78,15 @@ services:
                 core: core3
         tags:
             - {name: ezpublish.search.solr.endpoint, alias: endpoint3}
+
+    ezpublish.search.solr.endpoint.endpoint4:
+        class: "%ezpublish.solr.endpoint.class%"
+        arguments:
+            -
+                scheme: http
+                host: localhost
+                port: 8983
+                path: /solr
+                core: core4
+        tags:
+            - {name: ezpublish.search.solr.endpoint, alias: endpoint4}


### PR DESCRIPTION
Target version: **1.5.x** for eZ Platform `1.7.x LTS`, `1.13.x LTS` and `7.x` FT.

This PR enables testing of:
- [x] `dedicated` multicore setup against the latest version of `ezpublish-kernel`
- [x] `shared` multicore setup against `ezpublish-kernel` 6.13.x LTS.

This way we can cover all supported LTS versions and also test dedicated setup against the latest changes.

Note: dedicated multicore setup is about using single Solr core for single language.

TODO:
- [x] Add new core for Norwegian language so the tests on Kernel 7.x pass
