### PR TITLE
EZP-30282: Impl. indexing of related objects for the full text search

### DIFF
--- a/bundle/ApiLoader/IndexingDepthProviderFactory.php
+++ b/bundle/ApiLoader/IndexingDepthProviderFactory.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngineBundle\ApiLoader;
+
+use eZ\Bundle\EzPublishCoreBundle\ApiLoader\RepositoryConfigurationProvider;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+
+class IndexingDepthProviderFactory implements ContainerAwareInterface
+{
+    use ContainerAwareTrait;
+
+    /**
+     * @var \eZ\Bundle\EzPublishCoreBundle\ApiLoader\RepositoryConfigurationProvider
+     */
+    private $repositoryConfigurationProvider;
+
+    /**
+     * @var string
+     */
+    private $defaultConnection;
+
+    /**
+     * @var string
+     */
+    private $indexingDepthProviderClass;
+
+    /**
+     * @param \eZ\Bundle\EzPublishCoreBundle\ApiLoader\RepositoryConfigurationProvider $repositoryConfigurationProvider
+     * @param string $defaultConnection
+     * @param string $indexingDepthProviderClass
+     */
+    public function __construct(
+        RepositoryConfigurationProvider $repositoryConfigurationProvider,
+        string $defaultConnection,
+        string $indexingDepthProviderClass
+    ) {
+        $this->repositoryConfigurationProvider = $repositoryConfigurationProvider;
+        $this->defaultConnection = $defaultConnection;
+        $this->indexingDepthProviderClass = $indexingDepthProviderClass;
+    }
+
+    public function buildService()
+    {
+        $repositoryConfig = $this->repositoryConfigurationProvider->getRepositoryConfig();
+
+        $connection = $this->defaultConnection;
+        if (isset($repositoryConfig['search']['connection'])) {
+            $connection = $repositoryConfig['search']['connection'];
+        }
+
+        return new $this->indexingDepthProviderClass(
+            $this->container->getParameter(
+                "ez_search_engine_solr.connection.{$connection}.indexing_depth.map"
+            ),
+            $this->container->getParameter(
+                "ez_search_engine_solr.connection.{$connection}.indexing_depth.default"
+            )
+        );
+    }
+}

--- a/bundle/DependencyInjection/Configuration.php
+++ b/bundle/DependencyInjection/Configuration.php
@@ -248,6 +248,33 @@ class Configuration implements ConfigurationInterface
                             ->end()
                         ->end()
                     ->end()
+                    ->arrayNode('indexing_depth')
+                        ->info('Maximum level of the related content which is included while indexing content item.')
+                        ->addDefaultsIfNotSet()
+                        ->children()
+                            ->integerNode('default')
+                                ->defaultValue(0)
+                                ->min(0)
+                                ->max(3)
+                                ->info('Default value indexing depth')
+                            ->end()
+                            ->arrayNode('content_type')
+                                ->info('A map of ContentType identifiers and indexing depth')
+                                ->example(
+                                    [
+                                        'article' => 3,
+                                        'image' => 1,
+                                    ]
+                                )
+                                ->normalizeKeys(false)
+                                ->useAttributeAsKey('content_type_identifier')
+                                ->prototype('integer')
+                                    ->min(0)
+                                    ->max(3)
+                                ->end()
+                            ->end()
+                        ->end()
+                    ->end()
                     ->arrayNode('boost_factors')
                         ->addDefaultsIfNotSet()
                         ->info(

--- a/bundle/DependencyInjection/EzSystemsEzPlatformSolrSearchEngineExtension.php
+++ b/bundle/DependencyInjection/EzSystemsEzPlatformSolrSearchEngineExtension.php
@@ -137,6 +137,8 @@ class EzSystemsEzPlatformSolrSearchEngineExtension extends Extension
         foreach ($config['connections'] as $name => $params) {
             $this->configureSearchServices($container, $name, $params);
             $this->configureBoostMap($container, $name, $params);
+            $this->configureIndexingDepth($container, $name, $params);
+
             $container->setParameter("$alias.connection.$name", $params);
         }
 
@@ -200,6 +202,24 @@ class EzSystemsEzPlatformSolrSearchEngineExtension extends Extension
         $boostFactorMapId = "{$alias}.connection.{$connectionName}.boost_factor_map_id";
 
         $container->setParameter($boostFactorMapId, $boostFactorMap);
+    }
+
+    /**
+     * Creates indexing depth map parameter for a given $connectionName.
+     *
+     * @param ContainerBuilder $container
+     * @param string $connectionName
+     * @param array $connectionParams
+     */
+    private function configureIndexingDepth(ContainerBuilder $container, $connectionName, $connectionParams)
+    {
+        $alias = $this->getAlias();
+
+        $defaultIndexingDepthId = "{$alias}.connection.{$connectionName}.indexing_depth.default";
+        $contentTypeIndexingDepthMapId = "{$alias}.connection.{$connectionName}.indexing_depth.map";
+
+        $container->setParameter($defaultIndexingDepthId, $connectionParams['indexing_depth']['default']);
+        $container->setParameter($contentTypeIndexingDepthMapId, $connectionParams['indexing_depth']['content_type']);
     }
 
     /**

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -1,6 +1,7 @@
 parameters:
     ezpublish.solr.engine_factory.class: EzSystems\EzPlatformSolrSearchEngineBundle\ApiLoader\SolrEngineFactory
     ezpublish.solr.boost_factor_provider_factory.class: EzSystems\EzPlatformSolrSearchEngineBundle\ApiLoader\BoostFactorProviderFactory
+    ezpublish.solr.indexing_depth_provider_factory.class: EzSystems\EzPlatformSolrSearchEngineBundle\ApiLoader\IndexingDepthProviderFactory
     ez_search_engine_solr.default_connection: ~
 
 services:
@@ -21,3 +22,16 @@ services:
             - "%ezpublish.search.solr.boost_factor_provider.class%"
         calls:
             - [setContainer, ["@service_container"]]
+
+    ezpublish.search.solr.field_mapper.indexing_depth_provider_factory:
+        class: "%ezpublish.solr.indexing_depth_provider_factory.class%"
+        arguments:
+            - "@ezpublish.api.repository_configuration_provider"
+            - "%ez_search_engine_solr.default_connection%"
+            - "%ezpublish.search.solr.indexing_depth_provider.class%"
+        calls:
+            - [setContainer, ["@service_container"]]
+
+    ezpublish.search.solr.field_mapper.indexing_depth_provider:
+        class: "%ezpublish.search.solr.field_mapper.indexing_depth_provider.class%"
+        factory: 'ezpublish.search.solr.field_mapper.indexing_depth_provider_factory:buildService'

--- a/lib/FieldMapper/IndexingDepthProvider.php
+++ b/lib/FieldMapper/IndexingDepthProvider.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\FieldMapper;
+
+use eZ\Publish\SPI\Persistence\Content\Type as ContentType;
+
+class IndexingDepthProvider
+{
+    /**
+     * @var array
+     */
+    private $contentTypeMap;
+
+    /**
+     * @var int
+     */
+    private $defaultIndexingDepth;
+
+    /**
+     * @param array $contentTypeMap
+     * @param int $defaultIndexingDepth
+     */
+    public function __construct(array $contentTypeMap = [], $defaultIndexingDepth = 1)
+    {
+        $this->contentTypeMap = $contentTypeMap;
+        $this->defaultIndexingDepth = $defaultIndexingDepth;
+    }
+
+    /**
+     * Returns max depth of indexing for given content type.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content\Type $contentType
+     *
+     * @return int
+     */
+    public function getMaxDepthForContent(ContentType $contentType): int
+    {
+        if (isset($this->contentTypeMap[$contentType->identifier])) {
+            return $this->contentTypeMap[$contentType->identifier];
+        }
+
+        return $this->defaultIndexingDepth;
+    }
+
+    /**
+     * @return int
+     */
+    public function getMaxDepth(): int
+    {
+        if (!empty($this->contentTypeMap)) {
+            return max($this->defaultIndexingDepth, ...array_values($this->contentTypeMap));
+        }
+
+        return $this->defaultIndexingDepth;
+    }
+}

--- a/lib/Query/CriterionVisitor.php
+++ b/lib/Query/CriterionVisitor.php
@@ -35,7 +35,7 @@ abstract class CriterionVisitor
      *
      * @return string
      */
-    abstract public function visit(Criterion $criterion, CriterionVisitor $subVisitor = null);
+    abstract public function visit(Criterion $criterion, self $subVisitor = null);
 
     /**
      * Get Solr range.

--- a/lib/Resources/config/container/solr.yml
+++ b/lib/Resources/config/container/solr.yml
@@ -20,6 +20,7 @@ parameters:
     ezpublish.search.solr.result_extractor.native.class: EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\NativeResultExtractor
     ezpublish.search.solr.query_converter.class: EzSystems\EzPlatformSolrSearchEngine\Query\Common\QueryConverter\NativeQueryConverter
     ezpublish.search.solr.boost_factor_provider.class: EzSystems\EzPlatformSolrSearchEngine\FieldMapper\BoostFactorProvider
+    ezpublish.search.solr.indexing_depth_provider.class: EzSystems\EzPlatformSolrSearchEngine\FieldMapper\IndexingDepthProvider
     # Endpoint resolver arguments must be set in order to be overrideable
     ezpublish.search.solr.entry_endpoints: []
     ezpublish.search.solr.cluster_endpoints: []

--- a/lib/Resources/config/container/solr/criterion_visitors.yml
+++ b/lib/Resources/config/container/solr/criterion_visitors.yml
@@ -263,6 +263,7 @@ services:
             - "@ezpublish.search.solr.query.query_translator.galach.tokenizer"
             - "@ezpublish.search.solr.query.query_translator.galach.parser"
             - "@ezpublish.search.solr.query.query_translator.galach.generator.edismax"
+            - "@=service('ezpublish.search.solr.field_mapper.indexing_depth_provider').getMaxDepth()"
         tags:
             - {name: ezpublish.search.solr.query.content.criterion_visitor}
 

--- a/lib/Resources/config/container/solr/field_mappers.yml
+++ b/lib/Resources/config/container/solr/field_mappers.yml
@@ -50,9 +50,11 @@ services:
         class: '%ezpublish.search.solr.field_mapper.content_translation.content_document_fulltext_fields.class%'
         arguments:
             - '@ezpublish.spi.persistence.content_type_handler'
+            - '@ezpublish.spi.persistence.content_handler'
             - '@ezpublish.search.common.field_registry'
             - '@ezpublish.search.common.field_name_generator'
             - '@ezpublish.search.solr.field_mapper.boost_factor_provider'
+            - '@ezpublish.search.solr.field_mapper.indexing_depth_provider'
         tags:
             - {name: ezpublish.search.solr.field_mapper.content_translation}
 

--- a/lib/Resources/config/container/solr/services.yml
+++ b/lib/Resources/config/container/solr/services.yml
@@ -10,6 +10,9 @@ parameters:
     ezpublish.search.solr.field_mapper.location.class: EzSystems\EzPlatformSolrSearchEngine\FieldMapper\LocationFieldMapper\Aggregate
     ezpublish.search.solr.field_mapper.boost_factor_provider.class: EzSystems\EzPlatformSolrSearchEngine\FieldMapper\BoostFactorProvider
     ezpublish.search.solr.field_mapper.boost_factor_provider.map: []
+    ezpublish.search.solr.field_mapper.indexing_depth_provider.class: \EzSystems\EzPlatformSolrSearchEngine\FieldMapper\IndexingDepthProvider
+    ezpublish.search.solr.field_mapper.indexing_depth_provider.map: []
+    ezpublish.search.solr.field_mapper.indexing_depth_provider.default: 0
 
 services:
     ezpublish.search.solr.gateway.client.http.stream:
@@ -75,3 +78,9 @@ services:
         class: "%ezpublish.search.solr.field_mapper.boost_factor_provider.class%"
         arguments:
             - "%ezpublish.search.solr.field_mapper.boost_factor_provider.map%"
+
+    ezpublish.search.solr.field_mapper.indexing_depth_provider:
+        class: "%ezpublish.search.solr.field_mapper.indexing_depth_provider.class%"
+        arguments:
+            - "%ezpublish.search.solr.field_mapper.indexing_depth_provider.map%"
+            - "%ezpublish.search.solr.field_mapper.indexing_depth_provider.default%"

--- a/tests/lib/Search/FieldMapper/IndexingDepthProviderTest.php
+++ b/tests/lib/Search/FieldMapper/IndexingDepthProviderTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\Tests\Search\FieldMapper;
+
+use EzSystems\EzPlatformSolrSearchEngine\FieldMapper\IndexingDepthProvider;
+use PHPUnit\Framework\TestCase;
+use eZ\Publish\SPI\Persistence\Content\Type as SPIContentType;
+
+class IndexingDepthProviderTest extends TestCase
+{
+    public function testGetMaxDepthForContentType()
+    {
+        $indexingDepthProvider = $this->createIndexingDepthProvider();
+
+        $this->assertEquals(2, $indexingDepthProvider->getMaxDepthForContent(
+            $this->getContentTypeStub('article')
+        ));
+
+        $this->assertEquals(1, $indexingDepthProvider->getMaxDepthForContent(
+            $this->getContentTypeStub('blog_post')
+        ));
+    }
+
+    public function testGetMaxDepthForContentTypeReturnsDefaultValue()
+    {
+        $indexingDepthProvider = $this->createIndexingDepthProvider();
+
+        $this->assertEquals(0, $indexingDepthProvider->getMaxDepthForContent(
+            $this->getContentTypeStub('folder')
+        ));
+    }
+
+    public function testGetMaxDepth()
+    {
+        $this->assertEquals(2, $this->createIndexingDepthProvider()->getMaxDepth());
+    }
+
+    private function createIndexingDepthProvider(): IndexingDepthProvider
+    {
+        return new IndexingDepthProvider([
+            'article' => 2,
+            'blog_post' => 1,
+        ], 0);
+    }
+
+    private function getContentTypeStub($identifier): SPIContentType
+    {
+        return new SPIContentType([
+            'identifier' => $identifier,
+        ]);
+    }
+}

--- a/tests/lib/Search/Query/CriterionVisitor/FullTextTest.php
+++ b/tests/lib/Search/Query/CriterionVisitor/FullTextTest.php
@@ -29,7 +29,7 @@ use QueryTranslator\Languages\Galach\Tokenizer;
  */
 class FullTextTest extends TestCase
 {
-    protected function getFullTextCriterionVisitor(array $fieldTypes = array())
+    protected function getFullTextCriterionVisitor(array $fieldTypes = array(), int $maxDepth = 0)
     {
         $fieldNames = array_keys($fieldTypes);
         $fieldNameResolver = $this->getMockBuilder(FieldNameResolver::class)
@@ -64,7 +64,8 @@ class FullTextTest extends TestCase
             $fieldNameResolver,
             $this->getTokenizer(),
             $this->getParser(),
-            $this->getGenerator()
+            $this->getGenerator(),
+            $maxDepth
         );
     }
 
@@ -274,6 +275,18 @@ class FullTextTest extends TestCase
 
         $this->assertEquals(
             "{!edismax v='Hello AND (and goodbye) as +always' qf='meta_content__text_t' uf=-*}",
+            $visitor->visit($criterion)
+        );
+    }
+
+    public function testVisitWithRelated()
+    {
+        $visitor = $this->getFullTextCriterionVisitor([], 3);
+
+        $criterion = new Criterion\FullText('Hello');
+
+        $this->assertEquals(
+            "{!edismax v='Hello' qf='meta_content__text_t meta_related_content_1__text_t^0.5 meta_related_content_2__text_t^0.25 meta_related_content_3__text_t^0.125' uf=-*}",
             $visitor->visit($criterion)
         );
     }


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-30282

## Description 

Impl. indexation of related objects for the full text search. 

### Indexing related content

Text of related content is stored in the `meta_related_content_X__text_t ` index fields where `X` is relation level e.g. `meta_related_content_1__text_t`, `meta_related_content_2__text_t ` 

### Boost factor for related content

As an User, I expect the following order of search results for query "Content A": `Content A`, `Content B`  when content repository contains `Content A` and  `Content B` with embedded `Content A`.
 
This is implemented by adding boost factor based on the following formula:

![image](https://user-images.githubusercontent.com/211967/54682981-c2b96280-4b10-11e9-8b98-b3430e0bff69.png)

to the index fields with related content. Ref. 
https://github.com/ezsystems/ezplatform-solr-search-engine/blob/1238c57777b936c63a7b2d31a73032f8fee9e3c5/lib/Query/Content/CriterionVisitor/FullText.php#L154-L157
 
### Indexing depth configuration

As a Developer, you are able to define the maximum indexing depth using the following YAML configuration:

```yml
ez_search_engine_solr:
    # ...
    connections:
        default:
            # ...
            indexing_depth:
                default: 1          # Default value: 0 - no relation indexing, 1 - direct relations, 2nd level  relations, 3rd level  relations (maximum value).
                content_type:
                    article: 2      # Index depth defined for specyfic content type
``` 

Indexing of the related content is disabled by default, however, this might change in eZ Platform 3.X. 

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Impl. feature / bugifx
- [x] Impl. tests 
- [x] Ready for Code Review
