### PR TITLE
EZP-30835: Added support for Solr 7.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,14 @@ matrix:
         - php: 7.2
           env: TEST_CONFIG="phpunit.xml"
         - php: 7.1
-          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="6.4.2"  CORES_SETUP="dedicated"
-        - php: 7.2
-          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="6.5.1"  CORES_SETUP="shared"
-        - php: 7.2
-          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="6.6.5"  CORES_SETUP="single" SOLR_CORES="collection1"
-        - php: 7.2
-          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="6.6.5"  CORES_SETUP="cloud" SOLR_CLOUD="yes"
+          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="7.7.2"  CORES_SETUP="dedicated"
+        - php: 7.1
+          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="7.7.2"  CORES_SETUP="shared"
+        - php: 7.1
+          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="7.7.2"  CORES_SETUP="single" SOLR_CORES="collection1"
+        - php: 7.1
+          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="7.7.2"  CORES_SETUP="cloud" SOLR_CLOUD="yes"
+
 # test only master and stable branches (+ Pull requests against those)
 branches:
     only:

--- a/bin/generate-solr-config.sh
+++ b/bin/generate-solr-config.sh
@@ -4,7 +4,7 @@ set -e
 
 # Default paramters, if not overloaded by user arguments
 DESTINATION_DIR=.platform/configsets/solr6/conf
-SOLR_VERSION=6.6.5
+SOLR_VERSION=7.7.2
 FORCE=false
 SOLR_INSTALL_DIR=""
 
@@ -20,7 +20,7 @@ Help (this text):
 Usage with eZ Platform Cloud (arguments here can be skipped as they have default values):
 ./vendor/ezsystems/ezplatform-solr-search-engine/bin/generate-solr-config.sh \\
   --destination-dir=.platform/configsets/solr6/conf \\
-  --solr-version=6.6.5
+  --solr-version=7.7.2
 
 Usage with on-premise version of Solr:
 ./vendor/ezsystems/ezplatform-solr-search-engine/bin/generate-solr-config.sh \\
@@ -28,7 +28,7 @@ Usage with on-premise version of Solr:
   --solr-install-dir=/opt/solr
 
 Warning:
- This script only supports Solr 6 and higher !!
+ This script only supports Solr 7 and higher !!
 
 
 Arguments:
@@ -94,7 +94,7 @@ if [ -e $DESTINATION_DIR ]; then
 fi
 
 if [ "$SOLR_INSTALL_DIR" == "" ]; then
-    # If we where not provided existing install directory we'll temporary download version of solr 6 to generate config.
+    # If we where not provided existing install directory we'll temporary download version of solr 7 to generate config.
     GENERATE_SOLR_TMPDIR=`mktemp -d`
     echo "Downloading solr bundle:"
     curl http://archive.apache.org/dist/lucene/solr/${SOLR_VERSION}/solr-${SOLR_VERSION}.tgz > $GENERATE_SOLR_TMPDIR/solr-${SOLR_VERSION}.tgz
@@ -109,7 +109,7 @@ fi
 
 mkdir -p $DESTINATION_DIR
 cp -a ${EZ_BUNDLE_PATH}/lib/Resources/config/solr/* $DESTINATION_DIR
-cp ${SOLR_INSTALL_DIR}/server/solr/configsets/basic_configs/conf/{currency.xml,solrconfig.xml,stopwords.txt,synonyms.txt,elevate.xml} $DESTINATION_DIR
+cp ${SOLR_INSTALL_DIR}/server/solr/configsets/_default/conf/{solrconfig.xml,stopwords.txt,synonyms.txt} $DESTINATION_DIR
 
 if [[ ! $DESTINATION_DIR =~ ^\.platform ]]; then
     # If we are not targeting .platform(.sh) config, we also output default solr.xml
@@ -119,7 +119,7 @@ else
 fi
 
 # Adapt autoSoftCommit to have a recommended value, and remove add-unknown-fields-to-the-schema
-sed -i.bak '/<updateRequestProcessorChain name="add-unknown-fields-to-the-schema">/,/<\/updateRequestProcessorChain>/d' $DESTINATION_DIR/solrconfig.xml
+sed -i.bak '/<updateRequestProcessorChain name="add-unknown-fields-to-the-schema".*/,/<\/updateRequestProcessorChain>/d' $DESTINATION_DIR/solrconfig.xml
 sed -i.bak2 's/${solr.autoSoftCommit.maxTime:-1}/${solr.autoSoftCommit.maxTime:20}/' $DESTINATION_DIR/solrconfig.xml
 
 if [ "$GENERATE_SOLR_TMPDIR" != "" ]; then

--- a/lib/Query/Common/QueryConverter/NativeQueryConverter.php
+++ b/lib/Query/Common/QueryConverter/NativeQueryConverter.php
@@ -62,7 +62,6 @@ class NativeQueryConverter extends QueryConverter
     public function convert(Query $query)
     {
         $params = array(
-            'defType' => 'edismax',
             'q' => '{!lucene}' . $this->criterionVisitor->visit($query->query),
             'fq' => '{!lucene}' . $this->criterionVisitor->visit($query->filter),
             'sort' => $this->getSortClauses($query->sortClauses),

--- a/lib/Resources/config/solr/schema.xml
+++ b/lib/Resources/config/solr/schema.xml
@@ -41,23 +41,48 @@ should not remove or drastically change the existing definitions.
         <filter class="solr.LowerCaseFilterFactory"/>
       </analyzer>
     </fieldType>
+
+    <fieldType name="text_general" class="solr.TextField" positionIncrementGap="100" multiValued="true" sortMissingLast="true">
+        <analyzer type="index">
+            <tokenizer class="solr.KeywordTokenizerFactory"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+        </analyzer>
+        <analyzer type="query">
+            <tokenizer class="solr.KeywordTokenizerFactory"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+        </analyzer>
+    </fieldType>
+
+    <fieldType name="pdate" class="solr.DatePointField" docValues="true"/>
+    <fieldType name="pdates" class="solr.DatePointField" docValues="true" multiValued="true"/>
+    <!--
+      Numeric field types that index values using KD-trees.
+      Point fields don't support FieldCache, so they must have docValues="true" if needed for sorting, faceting, functions, etc.
+    -->
+    <fieldType name="pint" class="solr.IntPointField" docValues="true"/>
+    <fieldType name="pfloat" class="solr.FloatPointField" docValues="true"/>
+    <fieldType name="plong" class="solr.LongPointField" docValues="true"/>
+    <fieldType name="pdouble" class="solr.DoublePointField" docValues="true"/>
+
+    <fieldType name="pints" class="solr.IntPointField" docValues="true" multiValued="true"/>
+    <fieldType name="pfloats" class="solr.FloatPointField" docValues="true" multiValued="true"/>
+    <fieldType name="plongs" class="solr.LongPointField" docValues="true" multiValued="true"/>
+    <fieldType name="pdoubles" class="solr.DoublePointField" docValues="true" multiValued="true"/>
+    <fieldType name="random" class="solr.RandomSortField" indexed="true"/>
+
     <fieldType name="identifier" class="solr.StrField" sortMissingLast="true" />
-    <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true"/>
+    <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true" multiValued="false"/>
+    <fieldType name="booleans" class="solr.BoolField" sortMissingLast="true" multiValued="true"/>
     <fieldtype name="binary" class="solr.BinaryField"/>
-    <fieldType name="int" class="solr.TrieIntField" precisionStep="0" positionIncrementGap="0"/>
-    <fieldType name="float" class="solr.TrieFloatField" precisionStep="0" positionIncrementGap="0"/>
-    <fieldType name="long" class="solr.TrieLongField" precisionStep="0" positionIncrementGap="0"/>
-    <fieldType name="double" class="solr.TrieDoubleField" precisionStep="0" positionIncrementGap="0"/>
-    <fieldType name="date" class="solr.TrieDateField" precisionStep="0" positionIncrementGap="0"/>
+    <fieldType name="int" class="solr.IntPointField" docValues="true"/>
+    <fieldType name="float" class="solr.FloatPointField" docValues="true"/>
+    <fieldType name="long" class="solr.LongPointField" docValues="true"/>
+    <fieldType name="double" class="solr.DoublePointField" docValues="true"/>
+    <fieldType name="date" class="solr.DatePointField" docValues="true"/>
 
     <fieldtype name="ignored" stored="false" indexed="false" multiValued="true" class="solr.StrField" />
     <fieldType name="point" class="solr.PointType" dimension="2" subFieldSuffix="_d"/>
     <fieldType name="location" class="solr.LatLonType" subFieldSuffix="_coordinate"/>
-
-    <fieldType name="currency" class="solr.CurrencyField" precisionStep="8" defaultCurrency="USD" currencyConfig="currency.xml" />
-
-
-
 
     <!--
       Required ID field.
@@ -101,7 +126,11 @@ should not remove or drastically change the existing definitions.
     <dynamicField name="*_gl" type="location" indexed="true" stored="true"/>
     <dynamicField name="*_gl_0_coordinate" type="double" indexed="true" stored="true"/>
     <dynamicField name="*_gl_1_coordinate" type="double" indexed="true" stored="true"/>
-    <dynamicField name="*_c" type="currency" indexed="true" stored="true"/>
+
+   <!--
+        This field is required to allow random sorting
+    -->
+    <dynamicField name="random*" type="random" indexed="true" stored="false"/>
 
     <!--
       This field is required since Solr 4


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-30835

### Related SOLR issues

https://issues.apache.org/jira/browse/SOLR-11501:

> Starting a query string with local-params {!myparser ...} is used to switch the
query parser to another, and is intended for use by Solr system developers, not end users doing searches. To reduce negative side-effects of unintended hack-ability, we've limited the cases that local-params will be parsed to only contexts in which the default parser is "lucene" or "func". So if defType=edismax then q={!myparser ...} won't work. In that example, put the desired query parser into defType. Another example is if deftype=edismax then hl.q={!myparser ...} won't work for the same reason. In that example, either put the desired query parser into hl.qparser or set hl.qparser=lucene. Most users won't run into these cases but some will and must change. If you must have full backwards compatibility, use luceneMatchVersion=7.1.0 or something earlier.

Ref. https://github.com/ezsystems/ezplatform-solr-search-engine/pull/136/files#diff-d75c9ba9fe393b04edf2db8762aa77b7L65

https://issues.apache.org/jira/browse/SOLR-10503:

> CurrencyField has been deprecated in favor of new CurrencyFieldType

_Dropped as is not used by eZ Platform_

https://issues.apache.org/jira/browse/SOLR-10729:

> Deprecated LatLonType, GeoHashField, SpatialPointVectorFieldType, and SpatialTermQueryPrefixTreeFieldType. Instead, switch to LatLonPointSpatialField or SpatialRecursivePrefixTreeFieldType or RptWithGeometrySpatialField.

_Will be processed as a separate task: https://jira.ez.no/browse/EZP-30977_

https://issues.apache.org/jira/browse/SOLR-?????:

> Deprecated: All Trie* numeric and date field types have been deprecated in favor of *Point field types.

_Replaced according to suggestion_

https://issues.apache.org/jira/browse/SOLR-12770:

> The 'shards' parameter handling logic changes to use a new config element to determine what hosts can be requested.

_This is CI only related issue_

https://issues.apache.org/jira/browse/SOLR-?????:

> Index-time boosts have been removed from Lucene, and are no longer available from Solr. If any boosts are provided, they will be ignored by the indexing chain. As a replacement, index-time scoring factors should be indexed in a separate field and combined with the query score using a function query. See the section Function Queries for more information.

Ref. https://lucene.apache.org/solr/guide/7_2/major-changes-in-solr-7.html

### Release 

Due to the major changes in Solr, support for 7.X will be part of the `ezplatform-solr-search-engine` 2.0 release which will be compatible with eZ Platform 2.5 release. Solr 6.X will be dropped in this release. 

Solr 7.X and Solr 8.X will be officialy supported in `ezplatform-solr-search-engine` 3.0 release which will be compatible with eZ Platform 3.X.

##### TODO
- [X] Add entries to the test matrix
- [X] Adjust `bin/generate-solr-config.sh`
- [x] Adjust `schema.xml`