### PR TITLE
[SF4] Implemented factory for IndexingDepthProvider

### DIFF
--- a/lib/Query/Content/CriterionVisitor/Factory/FullTextFactory.php
+++ b/lib/Query/Content/CriterionVisitor/Factory/FullTextFactory.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\Query\Content\CriterionVisitor\Factory;
+
+use eZ\Publish\Core\Search\Common\FieldNameResolver;
+use EzSystems\EzPlatformSolrSearchEngine\FieldMapper\IndexingDepthProvider;
+use EzSystems\EzPlatformSolrSearchEngine\Query\Content\CriterionVisitor\FullText;
+use QueryTranslator\Languages\Galach\Generators\ExtendedDisMax;
+use QueryTranslator\Languages\Galach\Parser;
+use QueryTranslator\Languages\Galach\Tokenizer;
+
+/**
+ * Factory for FullText Criterion Visitor.
+ *
+ * @see \EzSystems\EzPlatformSolrSearchEngine\Query\Content\CriterionVisitor\FullText
+ *
+ * @internal
+ */
+final class FullTextFactory
+{
+    /**
+     * Field map.
+     *
+     * @var \eZ\Publish\Core\Search\Common\FieldNameResolver
+     */
+    private $fieldNameResolver;
+
+    /**
+     * @var \QueryTranslator\Languages\Galach\Tokenizer
+     */
+    private $tokenizer;
+
+    /**
+     * @var \QueryTranslator\Languages\Galach\Parser
+     */
+    private $parser;
+
+    /**
+     * @var \QueryTranslator\Languages\Galach\Generators\ExtendedDisMax
+     */
+    private $generator;
+
+    /**
+     * @var \EzSystems\EzPlatformSolrSearchEngine\FieldMapper\IndexingDepthProvider
+     */
+    private $indexingDepthProvider;
+
+    /**
+     * Create from content type handler and field registry.
+     *
+     * @param \eZ\Publish\Core\Search\Common\FieldNameResolver $fieldNameResolver
+     * @param \QueryTranslator\Languages\Galach\Tokenizer $tokenizer
+     * @param \QueryTranslator\Languages\Galach\Parser $parser
+     * @param \QueryTranslator\Languages\Galach\Generators\ExtendedDisMax $generator
+     * @param \EzSystems\EzPlatformSolrSearchEngine\FieldMapper\IndexingDepthProvider $indexingDepthProvider
+     */
+    public function __construct(
+        FieldNameResolver $fieldNameResolver,
+        Tokenizer $tokenizer,
+        Parser $parser,
+        ExtendedDisMax $generator,
+        IndexingDepthProvider $indexingDepthProvider
+    ) {
+        $this->fieldNameResolver = $fieldNameResolver;
+        $this->tokenizer = $tokenizer;
+        $this->parser = $parser;
+        $this->generator = $generator;
+        $this->indexingDepthProvider = $indexingDepthProvider;
+    }
+
+    /**
+     * Create FullText Criterion Visitor.
+     *
+     * @return \EzSystems\EzPlatformSolrSearchEngine\Query\Content\CriterionVisitor\FullText
+     */
+    public function createCriterionVisitor(): FullText
+    {
+        return new FullText(
+            $this->fieldNameResolver,
+            $this->tokenizer,
+            $this->parser,
+            $this->generator,
+            $this->indexingDepthProvider->getMaxDepth()
+        );
+    }
+}

--- a/lib/Resources/config/container/solr/criterion_visitors.yml
+++ b/lib/Resources/config/container/solr/criterion_visitors.yml
@@ -258,14 +258,17 @@ services:
 
     ezpublish.search.solr.query.content.criterion_visitor.full_text:
         class: "%ezpublish.search.solr.query.content.criterion_visitor.full_text.class%"
+        factory: ['@EzSystems\EzPlatformSolrSearchEngine\Query\Content\CriterionVisitor\Factory\FullTextFactory', 'createCriterionVisitor']
+        tags:
+            - {name: ezpublish.search.solr.query.content.criterion_visitor}
+
+    EzSystems\EzPlatformSolrSearchEngine\Query\Content\CriterionVisitor\Factory\FullTextFactory:
         arguments:
             - "@ezpublish.search.common.field_name_resolver"
             - "@ezpublish.search.solr.query.query_translator.galach.tokenizer"
             - "@ezpublish.search.solr.query.query_translator.galach.parser"
             - "@ezpublish.search.solr.query.query_translator.galach.generator.edismax"
-            - "@=service('ezpublish.search.solr.field_mapper.indexing_depth_provider').getMaxDepth()"
-        tags:
-            - {name: ezpublish.search.solr.query.content.criterion_visitor}
+            - "@ezpublish.search.solr.field_mapper.indexing_depth_provider"
 
     ezpublish.search.solr.query.content.criterion_visitor.visibility:
         class: "%ezpublish.search.solr.query.content.criterion_visitor.visibility.class%"


### PR DESCRIPTION
|     |      |
| --- | --- |
| Bug | yes
| Target version | `v2.0 (master)` for eZ Platform `v3.0`
| Required by | ezpublish-kernel, ezplatform-richtext to unblock failing Solr integration tests.

Symfony 4 no longer allows using private services in DIC `@=service` expressions so we need to provide
factory instead.

**TODO:**
- [x] Confirm Travis agrees
- [x] Check code style