### PR TITLE
EZP-30296: Large API subtree delete leads to serious Solr index inconsistencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "~5.6|~7.0",
-        "ezsystems/ezpublish-kernel": "~6.7.10@dev|^6.13.6@dev|~7.3.5@dev|^7.4.3@dev",
+        "ezsystems/ezpublish-kernel": "~6.7.10@dev|^6.13.6@dev|~7.3.5@dev|~7.4.3@dev",
         "netgen/query-translator": "^1.0"
     },
     "require-dev": {

--- a/lib/Handler.php
+++ b/lib/Handler.php
@@ -47,8 +47,8 @@ class Handler implements SearchHandlerInterface, Capable
 {
     /* Solr's maxBooleanClauses config value is 1024 */
     const SOLR_BULK_REMOVE_LIMIT = 1000;
-    /* 32b max integer value due to Solr (JVM) limitations */
-    const SOLR_MAX_QUERY_LIMIT = PHP_INT_MAX >> 32;
+    /* 16b max unsigned integer value due to Solr (JVM) limitations */
+    const SOLR_MAX_QUERY_LIMIT = 65535;
     const DEFAULT_QUERY_LIMIT = 1000;
 
     /**

--- a/lib/Handler.php
+++ b/lib/Handler.php
@@ -45,7 +45,11 @@ use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
  */
 class Handler implements SearchHandlerInterface, Capable
 {
+    /* Solr's maxBooleanClauses config value is 1024 */
     const SOLR_BULK_REMOVE_LIMIT = 1000;
+    /* 32b max integer value due to Solr (JVM) limitations */
+    const SOLR_MAX_QUERY_LIMIT = PHP_INT_MAX >> 32;
+    const DEFAULT_QUERY_LIMIT = 1000;
 
     /**
      * Content locator gateway.
@@ -330,7 +334,7 @@ class Handler implements SearchHandlerInterface, Capable
      */
     protected function deleteAllItemsWithoutAdditionalLocation($locationId)
     {
-        $query = $this->prepareQuery();
+        $query = $this->prepareQuery(self::SOLR_MAX_QUERY_LIMIT);
         $query->filter = new Criterion\LogicalAnd(
             [
                 $this->allItemsWithinLocation($locationId),
@@ -348,7 +352,7 @@ class Handler implements SearchHandlerInterface, Capable
             $contentDocumentIds[] = $this->mapper->generateContentDocumentId($hit->valueObject->id) . '*';
         }
 
-        foreach (\array_chunk($contentDocumentIds, self::SOLR_BULK_REMOVE_LIMIT) as $ids) {
+        foreach (\array_chunk(\array_unique($contentDocumentIds), self::SOLR_BULK_REMOVE_LIMIT) as $ids) {
             $query = '_root_:(' . implode(' OR ', $ids) . ')';
             $this->gateway->deleteByQuery($query);
         }
@@ -359,7 +363,7 @@ class Handler implements SearchHandlerInterface, Capable
      */
     protected function updateAllElementsWithAdditionalLocation($locationId)
     {
-        $query = $this->prepareQuery();
+        $query = $this->prepareQuery(self::SOLR_MAX_QUERY_LIMIT);
         $query->filter = new Criterion\LogicalAnd(
             [
                 $this->allItemsWithinLocation($locationId),
@@ -388,14 +392,16 @@ class Handler implements SearchHandlerInterface, Capable
     /**
      * Prepare standard query for delete purpose.
      *
+     * @param int $limit
+     *
      * @return Query
      */
-    protected function prepareQuery()
+    protected function prepareQuery($limit = self::DEFAULT_QUERY_LIMIT)
     {
         return new Query(
             [
                 'query' => new Criterion\MatchAll(),
-                'limit' => 1000,
+                'limit' => $limit,
                 'offset' => 0,
             ]
         );


### PR DESCRIPTION
JIRA ticket: https://jira.ez.no/browse/EZP-30296

Bulk deleting using `deleteByQuery` has been introduced. I couldn't find particular information about Solr's bulk operation size limit, at least not in their documentation, but I think it's good to have some limit to prevent exceeding GET length limit for instance.

After a talk with @andrerom and @alongosz I decided to move further work on slots to a separated PR. Therefore, this one covers only bulk deleting. 