### PR TITLE
[Travis] Bumped minimum required ezpublish-kernel versions for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ matrix:
         - php: 7.2
           env: TEST_CONFIG="phpunit.xml"
         - php: 5.6
-          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="4.10.4" CORES_SETUP="dedicated" COMPOSER_REQUIRE="ezsystems/ezpublish-kernel:~6.7.4@dev"
+          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="4.10.4" CORES_SETUP="dedicated" COMPOSER_REQUIRE="ezsystems/ezpublish-kernel:~6.7.10@dev"
         - php: 7.0
-          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="4.10.4" CORES_SETUP="shared" COMPOSER_REQUIRE="ezsystems/ezpublish-kernel:~6.13.5@dev"
+          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="4.10.4" CORES_SETUP="shared" COMPOSER_REQUIRE="ezsystems/ezpublish-kernel:~6.13.6@dev"
         - php: 7.1
           env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="4.10.4" CORES_SETUP="single" SOLR_CORES="collection1"
         - php: 7.1


### PR DESCRIPTION
Adjusted the minimum requirements for ezpublish-kernel on Travis to the values present in composer.json (https://github.com/ezsystems/ezplatform-solr-search-engine/blob/1.5/composer.json#L15) to avoid memory errors like this one: https://travis-ci.org/ezsystems/ezplatform-solr-search-engine/jobs/588966737