### PR TITLE
[composer] Set branch alias to 3.0.x-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.0.x-dev"
+            "dev-master": "3.0.x-dev"
         }
     }
 }


### PR DESCRIPTION
Updated branch-alias for dev-master to `3.0.x` in `composer.json` according to https://github.com/ezsystems/ezplatform-solr-search-engine/pull/136:

> Due to the major changes in Solr, support for 7.X will be part of the ezplatform-solr-search-engine 2.0 release which will be compatible with eZ Platform 2.5 release. Solr 6.X will be dropped in this release.
>
> Solr 7.X and Solr 8.X will be officialy supported in ezplatform-solr-search-engine 3.0 release which will be compatible with eZ Platform 3.X.