### PR TITLE
Fixed duplicated random field type definition in schema.xml

### DIFF
--- a/lib/Resources/config/solr/schema.xml
+++ b/lib/Resources/config/solr/schema.xml
@@ -84,13 +84,6 @@ should not remove or drastically change the existing definitions.
     <fieldType name="point" class="solr.PointType" dimension="2" subFieldSuffix="_d"/>
     <fieldType name="location" class="solr.LatLonType" subFieldSuffix="_coordinate"/>
 
-    <fieldType name="currency" class="solr.CurrencyField" precisionStep="8" defaultCurrency="USD" currencyConfig="currency.xml" />
-
-    <!--
-        This fieldtype is required to allow random sorting
-    -->
-    <fieldType name="random" class="solr.RandomSortField" />
-
     <!--
       Required ID field.
     -->


### PR DESCRIPTION
> JIRA: -

## Description 

Fixed resolved conflicts in `schema.xml` during https://github.com/ezsystems/ezplatform-solr-search-engine/pull/136 merge up.  

* duplicated definition of the `random` field type. The second occurrence is here: 
https://github.com/ezsystems/ezplatform-solr-search-engine/blob/8587f3e3b261fd3dcc9269d6de84eda862798540/lib/Resources/config/solr/schema.xml#L133

* leftover currency field type definition (dropped in https://github.com/ezsystems/ezplatform-solr-search-engine/commit/da9056d5a31ff7d4ecb01690ed53b2981854e2b8#diff-2ef3da3ce7e2d13c93a0e1a4742c06c5L57)