### PR TITLE
EZP-30759: Creating content with terminal escape codes chars inside Searchable field will return 500 error when using Solr

### DIFF
--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -2,6 +2,7 @@ parameters:
     ezpublish.solr.engine_factory.class: EzSystems\EzPlatformSolrSearchEngineBundle\ApiLoader\SolrEngineFactory
     ezpublish.solr.boost_factor_provider_factory.class: EzSystems\EzPlatformSolrSearchEngineBundle\ApiLoader\BoostFactorProviderFactory
     ez_search_engine_solr.default_connection: ~
+    ez_search_engine_solr.invalid_characters_pattern: "#\\x1b[[][^A-Za-z]*[A-Za-z]#"
 
 services:
     ezpublish.solr.engine_factory:

--- a/lib/FieldMapper/ContentFieldMapper/BlockDocumentsBaseContentFields.php
+++ b/lib/FieldMapper/ContentFieldMapper/BlockDocumentsBaseContentFields.php
@@ -43,21 +43,29 @@ class BlockDocumentsBaseContentFields extends ContentFieldMapper
     protected $sectionHandler;
 
     /**
+     * @var string
+     */
+    private $invalidCharactersPattern;
+
+    /**
      * @param \eZ\Publish\SPI\Persistence\Content\Location\Handler $locationHandler
      * @param \eZ\Publish\SPI\Persistence\Content\Type\Handler $contentTypeHandler
      * @param \eZ\Publish\SPI\Persistence\Content\ObjectState\Handler $objectStateHandler
      * @param \eZ\Publish\SPI\Persistence\Content\Section\Handler $sectionHandler
+     * @param string $invalidCharactersPattern
      */
     public function __construct(
         LocationHandler $locationHandler,
         ContentTypeHandler $contentTypeHandler,
         ObjectStateHandler $objectStateHandler,
-        SectionHandler $sectionHandler
+        SectionHandler $sectionHandler,
+        $invalidCharactersPattern
     ) {
         $this->locationHandler = $locationHandler;
         $this->contentTypeHandler = $contentTypeHandler;
         $this->objectStateHandler = $objectStateHandler;
         $this->sectionHandler = $sectionHandler;
+        $this->invalidCharactersPattern = $invalidCharactersPattern;
     }
 
     public function accept(Content $content)
@@ -104,7 +112,7 @@ class BlockDocumentsBaseContentFields extends ContentFieldMapper
             ),
             new Field(
                 'content_name',
-                $contentInfo->name,
+                preg_replace($this->invalidCharactersPattern, '', $contentInfo->name),
                 new FieldType\StringField()
             ),
             new Field(

--- a/lib/FieldMapper/ContentTranslationFieldMapper/BlockDocumentsContentFields.php
+++ b/lib/FieldMapper/ContentTranslationFieldMapper/BlockDocumentsContentFields.php
@@ -45,21 +45,29 @@ class BlockDocumentsContentFields extends ContentTranslationFieldMapper
     protected $boostFactorProvider;
 
     /**
+     * @var string
+     */
+    private $invalidCharactersPattern;
+
+    /**
      * @param \eZ\Publish\SPI\Persistence\Content\Type\Handler $contentTypeHandler
      * @param \eZ\Publish\Core\Search\Common\FieldRegistry $fieldRegistry
      * @param \eZ\Publish\Core\Search\Common\FieldNameGenerator $fieldNameGenerator
      * @param \EzSystems\EzPlatformSolrSearchEngine\FieldMapper\BoostFactorProvider $boostFactorProvider
+     * @param string $invalidCharactersPattern
      */
     public function __construct(
         ContentTypeHandler $contentTypeHandler,
         FieldRegistry $fieldRegistry,
         FieldNameGenerator $fieldNameGenerator,
-        BoostFactorProvider $boostFactorProvider
+        BoostFactorProvider $boostFactorProvider,
+        $invalidCharactersPattern
     ) {
         $this->contentTypeHandler = $contentTypeHandler;
         $this->fieldRegistry = $fieldRegistry;
         $this->fieldNameGenerator = $fieldNameGenerator;
         $this->boostFactorProvider = $boostFactorProvider;
+        $this->invalidCharactersPattern = $invalidCharactersPattern;
     }
 
     public function accept(Content $content, $languageCode)
@@ -102,7 +110,7 @@ class BlockDocumentsContentFields extends ContentTranslationFieldMapper
                             $fieldDefinition->identifier,
                             $contentType->identifier
                         ),
-                        $indexField->value,
+                        preg_replace($this->invalidCharactersPattern, '', $indexField->value),
                         $this->getIndexFieldType($contentType, $fieldDefinition, $indexField->type)
                     );
                 }

--- a/lib/FieldMapper/ContentTranslationFieldMapper/ContentDocumentFulltextFields.php
+++ b/lib/FieldMapper/ContentTranslationFieldMapper/ContentDocumentFulltextFields.php
@@ -51,21 +51,29 @@ class ContentDocumentFulltextFields extends ContentTranslationFieldMapper
     protected $boostFactorProvider;
 
     /**
+     * @var string
+     */
+    private $invalidCharactersPattern;
+
+    /**
      * @param \eZ\Publish\SPI\Persistence\Content\Type\Handler $contentTypeHandler
      * @param \eZ\Publish\Core\Search\Common\FieldRegistry $fieldRegistry
      * @param \eZ\Publish\Core\Search\Common\FieldNameGenerator $fieldNameGenerator
      * @param \EzSystems\EzPlatformSolrSearchEngine\FieldMapper\BoostFactorProvider $boostFactorProvider
+     * @param $invalidCharactersPattern
      */
     public function __construct(
         ContentTypeHandler $contentTypeHandler,
         FieldRegistry $fieldRegistry,
         FieldNameGenerator $fieldNameGenerator,
-        BoostFactorProvider $boostFactorProvider
+        BoostFactorProvider $boostFactorProvider,
+        $invalidCharactersPattern
     ) {
         $this->contentTypeHandler = $contentTypeHandler;
         $this->fieldRegistry = $fieldRegistry;
         $this->fieldNameGenerator = $fieldNameGenerator;
         $this->boostFactorProvider = $boostFactorProvider;
+        $this->invalidCharactersPattern = $invalidCharactersPattern;
     }
 
     public function accept(Content $content, $languageCode)
@@ -104,7 +112,7 @@ class ContentDocumentFulltextFields extends ContentTranslationFieldMapper
 
                     $fields[] = new Field(
                         self::$fieldName,
-                        $indexField->value,
+                        preg_replace($this->invalidCharactersPattern, '', $indexField->value),
                         $this->getIndexFieldType($contentType)
                     );
                 }

--- a/lib/FieldMapper/ContentTranslationFieldMapper/ContentDocumentTranslatedContentNameField.php
+++ b/lib/FieldMapper/ContentTranslationFieldMapper/ContentDocumentTranslatedContentNameField.php
@@ -38,15 +38,23 @@ class ContentDocumentTranslatedContentNameField extends ContentTranslationFieldM
     protected $boostFactorProvider;
 
     /**
+     * @var string
+     */
+    private $invalidCharactersPattern;
+
+    /**
      * @param \eZ\Publish\SPI\Persistence\Content\Type\Handler $contentTypeHandler
      * @param \EzSystems\EzPlatformSolrSearchEngine\FieldMapper\BoostFactorProvider $boostFactorProvider
+     * @param $invalidCharactersPattern
      */
     public function __construct(
         ContentTypeHandler $contentTypeHandler,
-        BoostFactorProvider $boostFactorProvider
+        BoostFactorProvider $boostFactorProvider,
+        $invalidCharactersPattern
     ) {
         $this->contentTypeHandler = $contentTypeHandler;
         $this->boostFactorProvider = $boostFactorProvider;
+        $this->invalidCharactersPattern = $invalidCharactersPattern;
     }
 
     public function accept(Content $content, $languageCode)
@@ -60,7 +68,7 @@ class ContentDocumentTranslatedContentNameField extends ContentTranslationFieldM
             return [];
         }
 
-        $contentName = $content->versionInfo->names[$languageCode];
+        $contentName = preg_replace($this->invalidCharactersPattern, '', $content->versionInfo->names[$languageCode]);
         $contentType = $this->contentTypeHandler->load(
             $content->versionInfo->contentInfo->contentTypeId
         );

--- a/lib/Resources/config/container/solr/field_mappers.yml
+++ b/lib/Resources/config/container/solr/field_mappers.yml
@@ -16,6 +16,7 @@ services:
             - '@ezpublish.spi.persistence.content_type_handler'
             - '@ezpublish.spi.persistence.object_state_handler'
             - '@ezpublish.spi.persistence.section_handler'
+            - '%ez_search_engine_solr.invalid_characters_pattern%'
         tags:
             - {name: ezpublish.search.solr.field_mapper.block}
 
@@ -26,6 +27,7 @@ services:
             - '@ezpublish.search.common.field_registry'
             - '@ezpublish.search.common.field_name_generator'
             - '@ezpublish.search.solr.field_mapper.boost_factor_provider'
+            - '%ez_search_engine_solr.invalid_characters_pattern%'
         tags:
             - {name: ezpublish.search.solr.field_mapper.block_translation}
 
@@ -53,6 +55,7 @@ services:
             - '@ezpublish.search.common.field_registry'
             - '@ezpublish.search.common.field_name_generator'
             - '@ezpublish.search.solr.field_mapper.boost_factor_provider'
+            - '%ez_search_engine_solr.invalid_characters_pattern%'
         tags:
             - {name: ezpublish.search.solr.field_mapper.content_translation}
 
@@ -61,6 +64,7 @@ services:
         arguments:
             - '@ezpublish.spi.persistence.content_type_handler'
             - '@ezpublish.search.solr.field_mapper.boost_factor_provider'
+            - '%ez_search_engine_solr.invalid_characters_pattern%'
         tags:
             - {name: ezpublish.search.solr.field_mapper.content_translation}
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30759](https://jira.ez.no/browse/EZP-30759)
| **Bug**| yes
| **New feature**    | no
| **Target version** | `1.5` and higher

This PR fixes the issue described in the mentioned JIRA ticket. The simple solution is to filter out all the terminal escape characters but just for Solr as Legacy storage handles it without any issue. 

I'll add type hints on merge up, as `1.5` can be used with eZ Platform v1.x on PHP 5.x.

I'm about to create an issue in Solr's JIRA tracker, but as for now, I'm waiting for their devs to confirm that from their perspective this can be considered as a bug. I'll update the PR and add a comment in the code once the issue is created. 