### PR TITLE
Fixed wrong kernel version in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^7.1",
-        "ezsystems/ezpublish-kernel": "^7.5.7@dev",
+        "ezsystems/ezpublish-kernel": "^7.5.6@dev",
         "netgen/query-translator": "^1.0.2"
     },
     "require-dev": {


### PR DESCRIPTION
The requirement for `ezpublish-kernel` in `composer.json` is wrongly set for `7.5.7@dev`, as the next kernel released required will be `7.5.6` (eZ Platform 2.5.6 was released with kernel `7.5.5`).

This PR changes requirement to `^7.5.6@dev`