### PR TITLE
EZP-31275: Fixed wrong tag for ContentDocumentEmptyFields

### DIFF
--- a/lib/Resources/config/container/solr/field_mappers.yml
+++ b/lib/Resources/config/container/solr/field_mappers.yml
@@ -80,4 +80,4 @@ services:
             - '@ezpublish.search.common.field_name_generator'
             - '@ezpublish.persistence.field_type_registry'
         tags:
-            - {name: ezpublish.search.solr.field_mapper.content_translation}
+            - {name: ezpublish.search.solr.field_mapper.block_translation}


### PR DESCRIPTION
The empty field was indexed only for Contents (not Locations), therefore it was impossible to use IsEmpty Criterion when searching for locations.

This PR changes tag for `EzSystems\EzPlatformSolrSearchEngine\FieldMapper\ContentTranslationFieldMapper\ContentDocumentEmptyFields` to `ezpublish.search.solr.field_mapper.block_translation` so empty fields will be indexed also for Locations.

After applying the fix `php bin/console ezplatform:reindex` has to be executed to create indexes containing empty fields for locations.

More in JIRA ticket: https://jira.ez.no/browse/EZP-31275