### PR TITLE
EZP-31420: Deleted translation from Solr when deleted from Version

### DIFF
--- a/lib/Handler.php
+++ b/lib/Handler.php
@@ -478,11 +478,8 @@ class Handler implements SearchHandlerInterface, Capable, ContentTranslationHand
 
     /**
      * Deletes a translation content object from the index.
-     *
-     * @param int $contentId
-     * @param string $languageCode
      */
-    public function deleteTranslation($contentId, $languageCode)
+    public function deleteTranslation(int $contentId, string $languageCode): void
     {
         $languageCode = preg_replace('([^A-Za-z0-9/]+)', '', $languageCode);
         $idPrefix = $this->mapper->generateContentDocumentId($contentId, $languageCode);

--- a/lib/Handler.php
+++ b/lib/Handler.php
@@ -14,6 +14,7 @@ use eZ\Publish\API\Repository\SearchService;
 use eZ\Publish\SPI\Persistence\Content;
 use eZ\Publish\SPI\Persistence\Content\Location;
 use eZ\Publish\SPI\Persistence\Content\Handler as ContentHandler;
+use eZ\Publish\SPI\Search\ContentTranslationHandler;
 use eZ\Publish\SPI\Search\Handler as SearchHandlerInterface;
 use eZ\Publish\SPI\Search\Capable;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
@@ -43,7 +44,7 @@ use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
  * content objects based on criteria, which could not be converted in to
  * database statements.
  */
-class Handler implements SearchHandlerInterface, Capable
+class Handler implements SearchHandlerInterface, Capable, ContentTranslationHandler
 {
     /* Solr's maxBooleanClauses config value is 1024 */
     const SOLR_BULK_REMOVE_LIMIT = 1000;
@@ -474,4 +475,19 @@ class Handler implements SearchHandlerInterface, Capable
                return false;
         }
     }
+
+    /**
+     * Deletes a translation content object from the index.
+     *
+     * @param int $contentId
+     * @param string $languageCode
+     */
+    public function deleteTranslation($contentId, $languageCode)
+    {
+        $languageCode = preg_replace('([^A-Za-z0-9/]+)', '', $languageCode);
+        $idPrefix = $this->mapper->generateContentDocumentId($contentId, $languageCode);
+
+        $this->gateway->deleteByQuery("_root_:{$idPrefix}*");
+    }
+
 }

--- a/lib/Handler.php
+++ b/lib/Handler.php
@@ -481,10 +481,16 @@ class Handler implements SearchHandlerInterface, Capable, ContentTranslationHand
      */
     public function deleteTranslation(int $contentId, string $languageCode): void
     {
-        $languageCode = preg_replace('([^A-Za-z0-9/]+)', '', $languageCode);
-        $idPrefix = $this->mapper->generateContentDocumentId($contentId, $languageCode);
+        $idPrefix = $this->mapper->generateContentDocumentId($contentId, $this->sanitizeInput($languageCode));
 
         $this->gateway->deleteByQuery("_root_:{$idPrefix}*");
     }
 
+    /**
+     * Sanitize string before injecting into Search Engine query
+     */
+    protected function sanitizeInput(string $input): string
+    {
+        return preg_replace('([^A-Za-z0-9/]+)', '', $input);
+    }
 }

--- a/lib/Slot/RemoveTranslation.php
+++ b/lib/Slot/RemoveTranslation.php
@@ -10,6 +10,7 @@ namespace EzSystems\EzPlatformSolrSearchEngine\Slot;
 
 use eZ\Publish\Core\SignalSlot\Signal;
 use eZ\Publish\Core\Search\Common\Slot;
+use eZ\Publish\SPI\Search\ContentTranslationHandler;
 
 /**
  * A Search Engine Slot handling RemoveTranslationSignal.
@@ -34,10 +35,12 @@ class RemoveTranslation extends Slot
             return;
         }
 
-        $this->searchHandler->deleteContent(
-            $contentInfo->id,
-            $contentInfo->currentVersionNo
-        );
+        if ($this->searchHandler instanceof ContentTranslationHandler) {
+            $this->searchHandler->deleteTranslation(
+                $contentInfo->id,
+                $signal->languageCode
+            );
+        }
 
         $this->searchHandler->indexContent(
             $this->persistenceHandler->contentHandler()->load(

--- a/lib/Slot/RemoveTranslation.php
+++ b/lib/Slot/RemoveTranslation.php
@@ -34,6 +34,11 @@ class RemoveTranslation extends Slot
             return;
         }
 
+        $this->searchHandler->deleteContent(
+            $contentInfo->id,
+            $contentInfo->currentVersionNo
+        );
+
         $this->searchHandler->indexContent(
             $this->persistenceHandler->contentHandler()->load(
                 $contentInfo->id,

--- a/tests/lib/Slot/RemoveTranslationTest.php
+++ b/tests/lib/Slot/RemoveTranslationTest.php
@@ -67,6 +67,13 @@ class RemoveTranslationTest extends TestCase
             )
         ;
 
+        $this
+            ->getSearchHandlerMock()
+            ->expects($this->once())
+            ->method('deleteContent')
+            ->with(2, 1)
+        ;
+
         $content = new SPIContent();
 
         $contentHandlerMock
@@ -74,13 +81,6 @@ class RemoveTranslationTest extends TestCase
             ->method('load')
             ->with(2, 1)
             ->willReturn($content)
-        ;
-
-        $this
-            ->getSearchHandlerMock()
-            ->expects($this->once())
-            ->method('deleteContent')
-            ->with(2, 1)
         ;
 
         $this

--- a/tests/lib/Slot/RemoveTranslationTest.php
+++ b/tests/lib/Slot/RemoveTranslationTest.php
@@ -67,13 +67,6 @@ class RemoveTranslationTest extends TestCase
             )
         ;
 
-        $this
-            ->getSearchHandlerMock()
-            ->expects($this->once())
-            ->method('deleteContent')
-            ->with(2, 1)
-        ;
-
         $content = new SPIContent();
 
         $contentHandlerMock

--- a/tests/lib/Slot/RemoveTranslationTest.php
+++ b/tests/lib/Slot/RemoveTranslationTest.php
@@ -79,6 +79,13 @@ class RemoveTranslationTest extends TestCase
         $this
             ->getSearchHandlerMock()
             ->expects($this->once())
+            ->method('deleteContent')
+            ->with(2, 1)
+        ;
+
+        $this
+            ->getSearchHandlerMock()
+            ->expects($this->once())
             ->method('indexContent')
             ->with($content)
         ;


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31420](https://jira.ez.no/browse/EZP-31420)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `1,7`
| **BC breaks**      | no
| **Tests pass**     | [yes](https://travis-ci.org/github/ezsystems/ezpublish-kernel/builds/675704022)
| **Doc needed**     | no

## Description 
Depends on: https://github.com/ezsystems/ezpublish-kernel/pull/3013

Removing a content translation does not remove the associated SolR documents

**TODO**:
- [X] Implement feature / fix a bug.
- [x] Ask for Code Review.
