### PR TITLE
EZP-31080: Fixed SectionIdentifier criterion to handle strings

### DIFF
--- a/lib/Query/Common/CriterionVisitor/SectionIdentifierIn.php
+++ b/lib/Query/Common/CriterionVisitor/SectionIdentifierIn.php
@@ -34,7 +34,7 @@ class SectionIdentifierIn extends CriterionVisitor
                     static function (string $value) {
                         return 'content_section_identifier_id:"'.$value.'"';
                     },
-                    $criterion->value
+                    (array) $criterion->value
                 )
             )
         );


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-31080

`SectionIdentifier` criterion can accept a string or an array of strings. It was passing strings directly to `array_map` which resulted in error. This casts strings to single element array which solves the problem.