### PR TITLE
EZP-31007: Replaced ezpublish-kernel with ezplatform-kernel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ before_script:
 
 script:
     - if [ "$SOLR_VERSION" = "" ] ; then php vendor/bin/phpunit --bootstrap tests/bootstrap.php -c $TEST_CONFIG ; fi
-    - if [ "$SOLR_VERSION" != "" ] ; then php -d memory_limit=-1 vendor/bin/phpunit --bootstrap tests/bootstrap.php -c vendor/ezsystems/ezpublish-kernel/$TEST_CONFIG ; fi
+    - if [ "$SOLR_VERSION" != "" ] ; then php -d memory_limit=-1 vendor/bin/phpunit --bootstrap tests/bootstrap.php -c vendor/ezsystems/ezplatform-kernel/$TEST_CONFIG ; fi
 
 notifications:
     email: false

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ For how to install and configure see:
 
 ### Testing locally
 
-For Contributing to this Bundle, you should make sure to run both unit and integration tests *(from ezpublish-kernel repo)*.
+For Contributing to this Bundle, you should make sure to run both unit and integration tests *(from ezplatform-kernel repo)*.
 
 1. Setup this repository locally
 
@@ -120,7 +120,7 @@ For Contributing to this Bundle, you should make sure to run both unit and integ
 
     ```bash
     export CORES_SETUP="single"
-    php -d memory_limit=-1 vendor/bin/phpunit --bootstrap tests/bootstrap.php -vc vendor/ezsystems/ezpublish-kernel/phpunit-integration-legacy-solr.xml
+    php -d memory_limit=-1 vendor/bin/phpunit --bootstrap tests/bootstrap.php -vc vendor/ezsystems/ezplatform-kernel/phpunit-integration-legacy-solr.xml
     ```
 
 ## Copyright & license

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "symfony/framework-bundle": "^5.0"
     },
     "require-dev": {
+        "ezsystems/doctrine-dbal-schema": "^1.0@dev",
         "phpunit/phpunit": "^8.2",
         "matthiasnoback/symfony-dependency-injection-test": "^4.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^7.3",
-        "ezsystems/ezpublish-kernel": "^8.0@dev",
+        "ezsystems/ezplatform-kernel": "^1.0@dev",
         "netgen/query-translator": "^1.0.2",
         "symfony/http-kernel": "^5.0",
         "symfony/dependency-injection": "^5.0",

--- a/lib/Query/Common/FacetBuilderVisitor/Aggregate.php
+++ b/lib/Query/Common/FacetBuilderVisitor/Aggregate.php
@@ -89,7 +89,7 @@ class Aggregate extends FacetBuilderVisitor implements FacetFieldVisitor
         }
 
         // Ignore unsupported FacetBuilders, don't block the query for it
-        // ref: https://github.com/ezsystems/ezpublish-kernel/commit/435624d6fb8aa03ec219818ff7cb6755944b8d7b
+        // ref: https://github.com/ezsystems/ezplatform-kernel/commit/435624d6fb8aa03ec219818ff7cb6755944b8d7b
         return [];
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,16 +1,12 @@
 <?php
 
 /**
- * This file is part of the eZ Platform Solr Search Engine package.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- *
- * @version //autogentag//
  */
 
-// Setup config file for running integration tests from ezpublish-kernel dependency
-$file = __DIR__ . '/../vendor/ezsystems/ezpublish-kernel/config.php';
+// Setup config file for running integration tests from ezplatform-kernel dependency
+$file = __DIR__ . '/../vendor/ezsystems/ezplatform-kernel/config.php';
 if (!file_exists($file)) {
     if (!symlink($file . '-DEVELOPMENT', $file)) {
         throw new RuntimeException('Could not symlink config.php-DEVELOPMENT to config.php');


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-31007](https://jira.ez.no/browse/EZP-31007)
| **Type**                                   | improvement
| **Target eZ Platform version** | `v3.0.0`
| **BC breaks**                          | no
| **Tests pass**                          | yes
| **Doc needed**                       | no

This PR replaces `ezpublish-kernel` references with `ezplatform-kernel` in `composer.json` and other places and fixes dependency issues blocking package installation (due to Composer minimum stability requirements):

- `ezsystems/doctrine-dbal-schema:^1.0@dev` is required  by `ezplatform-kernel:^1.0@dev`.

#### TODO
- [x] Wait for Travis