### PR TITLE
EZP-31517: Refactored Indexer to rely on Doctrine\DBAL

### DIFF
--- a/lib/Indexer.php
+++ b/lib/Indexer.php
@@ -1,16 +1,15 @@
 <?php
 
 /**
- * This file is part of the eZ Platform Solr Search Engine package.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace EzSystems\EzPlatformSolrSearchEngine;
 
+use Doctrine\DBAL\Connection;
 use eZ\Publish\API\Repository\Exceptions\NotFoundException;
-use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
 use eZ\Publish\Core\Search\Common\IncrementalIndexer;
+use eZ\Publish\SPI\Persistence\Content\ContentInfo;
 use EzSystems\EzPlatformSolrSearchEngine\Handler as SolrSearchHandler;
 use eZ\Publish\SPI\Persistence\Handler as PersistenceHandler;
 use Psr\Log\LoggerInterface;
@@ -26,10 +25,10 @@ class Indexer extends IncrementalIndexer
     public function __construct(
         LoggerInterface $logger,
         PersistenceHandler $persistenceHandler,
-        DatabaseHandler $databaseHandler,
+        Connection $connection,
         SolrSearchHandler $searchHandler
     ) {
-        parent::__construct($logger, $persistenceHandler, $databaseHandler, $searchHandler);
+        parent::__construct($logger, $persistenceHandler, $connection, $searchHandler);
     }
 
     public function getName()

--- a/lib/Indexer.php
+++ b/lib/Indexer.php
@@ -48,7 +48,7 @@ class Indexer extends IncrementalIndexer
         foreach ($contentIds as $contentId) {
             try {
                 $info = $contentHandler->loadContentInfo($contentId);
-                if ($info->isPublished) {
+                if ($info->status === ContentInfo::STATUS_PUBLISHED) {
                     $content = $contentHandler->load($contentId, $info->currentVersionNo);
                     $documents[] = $this->searchHandler->generateDocument($content);
                 } else {

--- a/lib/Resources/config/container/solr.yml
+++ b/lib/Resources/config/container/solr.yml
@@ -9,7 +9,6 @@ imports:
 parameters:
     ezpublish.search.solr.connection.server: http://localhost:8983/solr/core0
     ezpublish.spi.search.solr.class: EzSystems\EzPlatformSolrSearchEngine\Handler
-    ezpublish.spi.search.solr.indexer.class: EzSystems\EzPlatformSolrSearchEngine\Indexer
     ezpublish.search.solr.gateway.native.class: EzSystems\EzPlatformSolrSearchEngine\Gateway\Native
     ezpublish.search.solr.gateway.endpoint_registry.class: EzSystems\EzPlatformSolrSearchEngine\Gateway\EndpointRegistry
     ezpublish.search.solr.gateway.endpoint_resolver.native.class: EzSystems\EzPlatformSolrSearchEngine\Gateway\EndpointResolver\NativeEndpointResolver
@@ -128,12 +127,12 @@ services:
         lazy: true
 
     ezpublish.spi.search.solr.indexer:
-        class: "%ezpublish.spi.search.solr.indexer.class%"
+        class: EzSystems\EzPlatformSolrSearchEngine\Indexer
         arguments:
-            - "@logger"
-            - "@ezpublish.api.storage_engine"
-            - "@ezpublish.api.storage_engine.legacy.dbhandler"
-            - "@ezpublish.spi.search.solr"
+            $logger: "@logger"
+            $persistenceHandler: "@ezpublish.api.storage_engine"
+            $connection: "@ezpublish.persistence.connection"
+            $searchHandler: "@ezpublish.spi.search.solr"
         tags:
             - {name: ezpublish.searchEngineIndexer, alias: solr}
         lazy: true


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-31517](https://jira.ez.no/browse/EZP-31517) blocking [EZP-30921](https://jira.ez.no/browse/EZP-30921)
| **Requires**                        | ezsystems/ezplatform-kernel#10
| **Type**                                   | improvement
| **Target eZ Platform version** | `v3.0`
| **BC breaks**                          | yes
| **Tests pass**                          | yes
| **Doc needed**                       | yes

#### Summary

This PR refactors Solr Search Indexer to rely on Doctrine Connection instead of Database Handler from Zeta Components (see ezsystems/ezplatform-kernel#10 for more details).

Additionally this Indexer code also relied on deprecated SPI `ContentInfo::$isPublished` property, which was fixed as well during refactoring.

#### Doc

The service container parameter `ezpublish.spi.search.solr.indexer.class` has been dropped (no other BC promises here were broken).

#### QA

- [ ] Sanity for `ezplatform:reindex` on Solr 7.7.2.

#### Checklist:
- [x] PR description is updated.
- ~Tests are implemented~ missing test coverage, indexing itself covered on API.
- [x] Added code follows Coding Standards (use `$ composer fix-cs`).
- [x] PR is ready for a review.
