### PR TITLE
EZP-31423: Refactored SetupFactory to rely on Doctrine Connection

### DIFF
--- a/tests/lib/SetupFactory/LegacySetupFactory.php
+++ b/tests/lib/SetupFactory/LegacySetupFactory.php
@@ -27,6 +27,13 @@ use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
  */
 class LegacySetupFactory extends CoreLegacySetupFactory
 {
+    public const CONFIGURATION_FILES_MAP = [
+        SearchServiceTranslationLanguageFallbackTest::SETUP_DEDICATED => 'multicore_dedicated.yml',
+        SearchServiceTranslationLanguageFallbackTest::SETUP_SHARED => 'multicore_shared.yml',
+        SearchServiceTranslationLanguageFallbackTest::SETUP_SINGLE => 'single_core.yml',
+        SearchServiceTranslationLanguageFallbackTest::SETUP_CLOUD => 'cloud.yml',
+    ];
+
     /**
      * Returns a configured repository for testing.
      *
@@ -119,23 +126,17 @@ class LegacySetupFactory extends CoreLegacySetupFactory
         $searchHandler->commit();
     }
 
-    protected function getTestConfigurationFile()
+    protected function getTestConfigurationFile(): string
     {
-        $isSolrCloud = getenv('SOLR_CLOUD');
-        if ($isSolrCloud) {
-            return 'cloud.yml';
+        $isSolrCloud = getenv('SOLR_CLOUD') === 'yes';
+        $coresSetup = $isSolrCloud
+            ? SearchServiceTranslationLanguageFallbackTest::SETUP_CLOUD
+            : getenv('CORES_SETUP');
+
+        if (!isset(self::CONFIGURATION_FILES_MAP[$coresSetup])) {
+            throw new RuntimeException("Backend cores setup '{$coresSetup}' is not handled");
         }
 
-        $coresSetup = getenv('CORES_SETUP');
-        switch ($coresSetup) {
-            case SearchServiceTranslationLanguageFallbackTest::SETUP_DEDICATED:
-                return 'multicore_dedicated.yml';
-            case SearchServiceTranslationLanguageFallbackTest::SETUP_SHARED:
-                return 'multicore_shared.yml';
-            case SearchServiceTranslationLanguageFallbackTest::SETUP_SINGLE:
-                return 'single_core.yml';
-        }
-
-        throw new RuntimeException("Backend cores setup '{$coresSetup}' is not handled");
+        return self::CONFIGURATION_FILES_MAP[$coresSetup];
     }
 }

--- a/tests/lib/SetupFactory/LegacySetupFactory.php
+++ b/tests/lib/SetupFactory/LegacySetupFactory.php
@@ -107,18 +107,12 @@ class LegacySetupFactory extends CoreLegacySetupFactory
 
         $query = $connection->createQueryBuilder();
         $query
-            ->select('id', 'current_version')
+            ->select('id')
             ->from(ContentGateway::CONTENT_ITEM_TABLE);
 
-        $stmt = $query->execute();
+        $contentIds = array_map('intval', $query->execute()->fetchAll(FetchMode::COLUMN));
 
-        $contentItems = [];
-        while ($row = $stmt->fetch(FetchMode::ASSOCIATIVE)) {
-            $contentItems[] = $contentHandler->load(
-                $row['id'],
-                $row['current_version']
-            );
-        }
+        $contentItems = $contentHandler->loadContentList($contentIds);
 
         $searchHandler->purgeIndex();
         $searchHandler->bulkIndexContent($contentItems);


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-31423](https://jira.ez.no/browse/EZP-31423) blocking [EZP-30921](https://jira.ez.no/browse/EZP-30921)
| **Type**                                   | improvement
| **Target eZ Platform version** | `v3.0`
| **BC breaks**                          | no
| **Tests pass**                          | yes
| **Doc needed**                       | no

This PR refactors test SetupFactory to stop relying on Database Handler from Zeta Components in favor of Doctrine Connection.
I've optimized loading a list of Content items to be indexed.
I've also refactored `getTestConfigurationFile` method simply because I couldn't look at it.

#### Checklist:
- [x] PR description is updated.
- [x] Tests are refactored.
- [x] new code follows Coding Standards.
- [x] Travis passes.
- [x] PR is ready for a review.