### PR TITLE
Specify port in solr_create_core for the tests

### DIFF
--- a/bin/.travis/init_solr.sh
+++ b/bin/.travis/init_solr.sh
@@ -161,7 +161,7 @@ solr_create_core() {
     core_name=$1
     config_dir=$2
 
-    ./${SOLR_INSTALL_DIR}/bin/solr create_core -c ${core_name} -d ${config_dir} || exit_on_error "Can't create core"
+    ./${SOLR_INSTALL_DIR}/bin/solr create_core -p ${SOLR_PORT} -c ${core_name} -d ${config_dir} || exit_on_error "Can't create core"
 }
 
 solr_cloud_configure_nodes() {


### PR DESCRIPTION
I was running tests for https://github.com/ezsystems/ezplatform-xmltext-fieldtype on my local, where I have multiple Solr instances. After executing `./vendor/ezsystems/ezplatform-solr-search-engine/bin/.travis/init_solr.sh` cores were created in wrong Solr instance.
This PR fixes it.