### PR TITLE
EZP-31325: Fixed sorting by Content & Location ID

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "~5.6|~7.0",
-        "ezsystems/ezpublish-kernel": "~6.13.6@dev",
+        "ezsystems/ezpublish-kernel": "~6.13.7@dev",
         "netgen/query-translator": "^1.0"
     },
     "require-dev": {

--- a/lib/FieldMapper/ContentFieldMapper/BlockDocumentsBaseContentFields.php
+++ b/lib/FieldMapper/ContentFieldMapper/BlockDocumentsBaseContentFields.php
@@ -87,6 +87,12 @@ class BlockDocumentsBaseContentFields extends ContentFieldMapper
                 $contentInfo->id,
                 new FieldType\IdentifierField()
             ),
+            // explicit integer representation to allow sorting
+            new Field(
+                'content_id_normalized',
+                $contentInfo->id,
+                new FieldType\IntegerField()
+            ),
             new Field(
                 'content_type_id',
                 $contentInfo->contentTypeId,

--- a/lib/FieldMapper/LocationFieldMapper/LocationDocumentBaseFields.php
+++ b/lib/FieldMapper/LocationFieldMapper/LocationDocumentBaseFields.php
@@ -48,6 +48,12 @@ class LocationDocumentBaseFields extends LocationFieldMapper
                 $location->id,
                 new FieldType\IdentifierField()
             ),
+            // explicit integer representation to allow sorting
+            new Field(
+                'location_id_normalized',
+                $location->id,
+                new FieldType\IntegerField()
+            ),
             new Field(
                 'document_type',
                 DocumentMapper::DOCUMENT_TYPE_IDENTIFIER_LOCATION,

--- a/lib/Query/Common/SortClauseVisitor/ContentId.php
+++ b/lib/Query/Common/SortClauseVisitor/ContentId.php
@@ -39,6 +39,6 @@ class ContentId extends SortClauseVisitor
      */
     public function visit(SortClause $sortClause)
     {
-        return 'content_id_id' . $this->getDirection($sortClause);
+        return 'content_id_normalized_i' . $this->getDirection($sortClause);
     }
 }

--- a/lib/Query/Location/SortClauseVisitor/Location/Id.php
+++ b/lib/Query/Location/SortClauseVisitor/Location/Id.php
@@ -39,6 +39,6 @@ class Id extends SortClauseVisitor
      */
     public function visit(SortClause $sortClause)
     {
-        return 'location_id' . $this->getDirection($sortClause);
+        return 'location_id_normalized_i' . $this->getDirection($sortClause);
     }
 }


### PR DESCRIPTION
| | |
| --- | --- |
| **JIRA issue** | [EZP-31325](https://jira.ez.no/browse/EZP-31325)
| **Requires for tests** | ezsystems/ezpublish-kernel#3029
| **Type** | bug
| **Solr version** | 4.10+
| **Solr Bundle version** | `1.5`, `1.7`, `2.0`, 3.0+`
| **eZ Platform version** | `v1.13+`
| **Tests** | [passing](https://travis-ci.org/github/ezsystems/ezplatform-solr-search-engine/builds/692518141) with ezsystems/ezpublish-kernel#3029
| **Doc needed** | no

### Summary

Solr Fields `location_id` and `content_id` are indexed as `identifier`s which are strings by default. This causes dictionary (alphabetical) ordering of IDs when sorting. Those IDs, in fact, are numbers and numerical sorting should be applied.

The bug exists for an edge case when the IDs have different string length, e.g. "9" and "10". For the detailed steps to reproduce see [EZP-31325](https://jira.ez.no/browse/EZP-31325). See also [failing test case](https://travis-ci.org/github/ezsystems/ezpublish-kernel/builds/683847958).

### Solution

There were several approaches considered, the current one has been choosen due to BC.

When mapping for indexing, new Solr Fields are indroduced: `"content_id_normalized"` and `"location_id_normalized"` for Content ID and Location ID respectively. They're mapped as integers (so get the `_i` suffix in the Solr index).

`SortClause\ContentId` and `SortClause\Location\Id` now rely on those fields instead.

### QA

See that sorting by Content ID and Location ID fails if IDs are of different lengths. Probably possible via PHP API only. See integration test (ezsystems/ezpublish-kernel#3029) and JIRA issue for the code snippets.

### TODO
- [x] **Drop TMP commit**
- [x] Wait for Travis.
- [x] Create Kernel PR with integration test coverage (ezsystems/ezpublish-kernel#3029).
- [x] Ask for a code review.