### PR TITLE
[Fast-forward merge] Improved indexing of Identifiers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^7.1",
-        "ezsystems/ezpublish-kernel": "^7.5.6@dev",
+        "ezsystems/ezpublish-kernel": "^7.5.8@dev",
         "netgen/query-translator": "^1.0.2"
     },
     "require-dev": {

--- a/lib/FieldMapper/ContentFieldMapper/BlockDocumentsBaseContentFields.php
+++ b/lib/FieldMapper/ContentFieldMapper/BlockDocumentsBaseContentFields.php
@@ -125,7 +125,7 @@ class BlockDocumentsBaseContentFields extends ContentFieldMapper
             new Field(
                 'content_remote_id',
                 $contentInfo->remoteId,
-                new FieldType\IdentifierField()
+                new FieldType\RemoteIdentifierField()
             ),
             new Field(
                 'content_modification_date',

--- a/lib/FieldMapper/ContentFieldMapper/ContentDocumentLocationFields.php
+++ b/lib/FieldMapper/ContentFieldMapper/ContentDocumentLocationFields.php
@@ -74,7 +74,7 @@ class ContentDocumentLocationFields extends ContentFieldMapper
             $fields[] = new Field(
                 'location_remote_id',
                 $locationData['remote_ids'],
-                new FieldType\MultipleIdentifierField()
+                new FieldType\MultipleRemoteIdentifierField()
             );
             $fields[] = new Field(
                 'location_path_string',
@@ -97,7 +97,7 @@ class ContentDocumentLocationFields extends ContentFieldMapper
             $fields[] = new Field(
                 'main_location_remote_id',
                 $mainLocation->remoteId,
-                new FieldType\IdentifierField()
+                new FieldType\RemoteIdentifierField()
             );
             $fields[] = new Field(
                 'main_location_visible',

--- a/lib/FieldMapper/LocationFieldMapper/LocationDocumentBaseFields.php
+++ b/lib/FieldMapper/LocationFieldMapper/LocationDocumentBaseFields.php
@@ -71,7 +71,7 @@ class LocationDocumentBaseFields extends LocationFieldMapper
             new Field(
                 'remote_id',
                 $location->remoteId,
-                new FieldType\IdentifierField()
+                new FieldType\RemoteIdentifierField()
             ),
             new Field(
                 'parent_id',

--- a/lib/Handler.php
+++ b/lib/Handler.php
@@ -5,8 +5,6 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- *
- * @version //autogentag//
  */
 namespace EzSystems\EzPlatformSolrSearchEngine;
 
@@ -481,16 +479,8 @@ class Handler implements SearchHandlerInterface, Capable, ContentTranslationHand
      */
     public function deleteTranslation(int $contentId, string $languageCode): void
     {
-        $idPrefix = $this->mapper->generateContentDocumentId($contentId, $this->sanitizeInput($languageCode));
-
-        $this->gateway->deleteByQuery("_root_:{$idPrefix}*");
-    }
-
-    /**
-     * Sanitize string before injecting into Search Engine query
-     */
-    protected function sanitizeInput(string $input): string
-    {
-        return preg_replace('([^A-Za-z0-9/]+)', '', $input);
+        $this->gateway->deleteByQuery(
+            "content_id_id:{$contentId} AND meta_indexed_language_code_s:{$languageCode}"
+        );
     }
 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-25484](https://jira.ez.no/browse/EZP-25484), follow up to [EZP-31420](https://jira.ez.no/browse/EZP-31420) (#173)
| **Required by** | ezsystems/ezpublish-kernel#3034
| **Bug/Improvement**| yes
| **Target eZ Platform version** | 2.5.x, 3.x
| **BC breaks**      | yes, on indexed remote ID values
| **Tests pass**     | [yes](https://travis-ci.org/github/ezsystems/ezplatform-solr-search-engine/builds/689259741)
| **Doc needed**     | yes, but due to Kernel changes (see Kernel PR)

### TL;DR;

This PR changes the way Content & Location remote IDs are indexed by allowing almost all possible input which is consistent with Content/Location API.

So now you're able to index in Solr Content items with such remote IDs:
![image](https://user-images.githubusercontent.com/7099219/82466369-9c020d80-9ac0-11ea-95dd-8727d173527b.png)
Enjoy!

As a follow up, accidentally discovered issue with deleting translations which rely on Document IDs is fixed.

### Description

~Generated value of Solr Document ID changed via ezsystems/ezpublish-kernel#3034~
The first version of this PR relied on changed Document ID. This is no longer the case, but I still believe the fix is valid. Till now only `content` Document types were removed (based on Document ID). The change makes `location` documents being removed as well because we now rely on specific fields rather than Document ID.

The essence here however is a distinction between remote identifiers and other identifiers (e.g. used to generate mentioned Document ID). It relies on just introduced (ezsystems/ezpublish-kernel#3034) `RemoteIdentifierField` and `MultipleRemoteIdentifierField` (remote ID list) search field types, which are mapped by Kernel using the same strategy as `StringField`. This makes values indexed by Solr provided to the search index almost as-is, excluding non-printables and control sequences only which are known to crash Solr. This fixes [EZP-25484](https://jira.ez.no/browse/EZP-25484) as required.

### QA

- [x] Sanity for translation-specific searches (actually what AdminUI->Search does is language specific now, so should be fine,
- [x] Sanity for translation removal, especially sanity on [EZP-31420](https://jira.ez.no/browse/EZP-31420), ideally for `findContent` & `findLocations`.

**TODO**:
- [x] **Remove TMP commit before merging**
- [x] Align Solr implementation with ezsystems/ezpublish-kernel#3034
- [x] See if Travis is passing just with those changes (should be BC-safe change)
- [x] See if Travis is passing with changes from ezsystems/ezpublish-kernel#3034 [build](https://travis-ci.org/github/ezsystems/ezplatform-solr-search-engine/builds/688268880?utm_source=github_status&utm_medium=notification)
- [x] Ask for Code Review.