### PR TITLE
[Solr Bundle 1.5] Forced Kernel 6.13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,11 @@
     ],
     "require": {
         "php": "~5.6|~7.0",
-        "ezsystems/ezpublish-kernel": "~6.7.10@dev|^6.13.6@dev|~7.3.5@dev|~7.4.3@dev",
+        "ezsystems/ezpublish-kernel": "~6.13.6@dev",
         "netgen/query-translator": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7||^7.0",
+        "phpunit/phpunit": "^5.7",
         "matthiasnoback/symfony-dependency-injection-test": "~1.0||~3.0"
     },
     "autoload": {


### PR DESCRIPTION
Looks like we're running tests using unmaintained Kernel 7.4.4 instead of 6.13.x intended for eZ Platform 1.13. 

Solr Bundle v1.5 was intended to [support eZ Platform 1.7, 1.13 and anything older than 2.5](https://github.com/ezsystems/ezplatform-solr-search-engine/blob/v1.7.3/README.md).  Currently we still maintain eZ Platform 1.13 LTS only, so other versions constraint can be dropped.

**TODO**
- [x] See if Travis passes.