### PR TITLE
[Travis] Dropped testing using Kernel 6.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ matrix:
         - php: 7.2
           env: TEST_CONFIG="phpunit.xml"
         - php: 5.6
-          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="4.10.4" CORES_SETUP="dedicated" COMPOSER_REQUIRE="ezsystems/ezpublish-kernel:~6.7.10@dev"
+          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="4.10.4" CORES_SETUP="dedicated"
         - php: 7.0
-          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="4.10.4" CORES_SETUP="shared" COMPOSER_REQUIRE="ezsystems/ezpublish-kernel:~6.13.6@dev"
+          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="4.10.4" CORES_SETUP="shared"
         - php: 7.1
           env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="4.10.4" CORES_SETUP="single" SOLR_CORES="collection1"
         - php: 7.1


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | Follow-up to #185, blocking [EZP-31325](https://jira.ez.no/browse/EZP-31325)
| **Type**                                   | bug
| **Solr Bundle version**            | `1.5` only

When resolving #185 I missed the fact that `.travis.yml` enforced `ezpublish-kernel:6.7` (which is past EOM) for some jobs. The jobs are still valid as they test different setups, but should be executed with a Kernel version from composer.

#### Checklist:
- [x] PR description is updated.
- [x] Travis is passing.
- [x] PR is ready for a review.
