### PR TITLE
EZEE-3208: Visibility SortClause ignores content visibility

### DIFF
--- a/lib/Query/Location/SortClauseVisitor/Location/Visibility.php
+++ b/lib/Query/Location/SortClauseVisitor/Location/Visibility.php
@@ -39,6 +39,6 @@ class Visibility extends SortClauseVisitor
      */
     public function visit(SortClause $sortClause)
     {
-        return 'hidden_b' . $this->getDirection($sortClause);
+        return 'invisible_b' . $this->getDirection($sortClause);
     }
 }


### PR DESCRIPTION
\> JIRA: \[EZEE-3208\](https://jira.ez.no/browse/EZEE-3208)

\### Description

Aligned \`\\eZ\\Publish\\API\\Repository\\Values\\Content\\Query\\SortClause\\Location\\Visibility\` behaviour to legacy search engine. See https://github.com/ezsystems/ezplatform-kernel/blob/9f59de2eb64de9cf447f07edca43ed1f91dea065/eZ/Publish/Core/Persistence/Legacy/Filter/SortClauseQueryBuilder/Location/VisibilityQueryBuilder.php#L23

\## Checklist

\- \[X\] Code follows the code style of this project (use \`$ composer fix-cs\`).  
\- \[ \] Change requires a change to the documentation.  
\- \[X\] Code is ready for a review.