### PR TITLE
EZP-31588: Replaced deprecated ezpublish.searchEngine and ezpublish.searchEngineIndexer tags

### DIFF
--- a/lib/Resources/config/container/solr.yml
+++ b/lib/Resources/config/container/solr.yml
@@ -123,7 +123,7 @@ services:
             - "@ezpublish.search.solr.result_extractor"
             - "@ezpublish.search.solr.core_filter"
         tags:
-            - {name: ezpublish.searchEngine, alias: solr}
+            - {name: ezplatform.search_engine, alias: solr}
         lazy: true
 
     ezpublish.spi.search.solr.indexer:
@@ -134,6 +134,6 @@ services:
             $connection: "@ezpublish.persistence.connection"
             $searchHandler: "@ezpublish.spi.search.solr"
         tags:
-            - {name: ezpublish.searchEngineIndexer, alias: solr}
+            - {name: ezplatform.search_engine.indexer, alias: solr}
         lazy: true
 


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-31588

### Description

Replaced deprecated `ezpublish.searchEngine` and `ezpublish.searchEngineIndexer` tags in favour of `ezplatform.search_engine` and `ezplatform.search_engine.indexer`

:exclamation: **Requires ezsystems/ezplatform-kernel#51** :exclamation: