### PR TITLE
EZP-27458: Aggregation API

### DIFF
--- a/bundle/ApiLoader/SolrEngineFactory.php
+++ b/bundle/ApiLoader/SolrEngineFactory.php
@@ -41,7 +41,10 @@ class SolrEngineFactory
     private $documentMapper;
 
     /** @var \EzSystems\EzPlatformSolrSearchEngine\ResultExtractor */
-    private $resultExtractor;
+    private $contentResultExtractor;
+
+    /** @var \EzSystems\EzPlatformSolrSearchEngine\ResultExtractor */
+    private $locationResultExtractor;
 
     public function __construct(
         RepositoryConfigurationProvider $repositoryConfigurationProvider,
@@ -51,7 +54,8 @@ class SolrEngineFactory
         CoreFilterRegistry $coreFilterRegistry,
         Handler $contentHandler,
         DocumentMapper $documentMapper,
-        ResultExtractor $resultExtractor
+        ResultExtractor $contentResultExtractor,
+        ResultExtractor $locationResultExtractor
     ) {
         $this->repositoryConfigurationProvider = $repositoryConfigurationProvider;
         $this->defaultConnection = $defaultConnection;
@@ -60,7 +64,8 @@ class SolrEngineFactory
         $this->coreFilterRegistry = $coreFilterRegistry;
         $this->contentHandler = $contentHandler;
         $this->documentMapper = $documentMapper;
-        $this->resultExtractor = $resultExtractor;
+        $this->contentResultExtractor = $contentResultExtractor;
+        $this->locationResultExtractor = $locationResultExtractor;
     }
 
     public function buildEngine()
@@ -76,7 +81,8 @@ class SolrEngineFactory
             $gateway,
             $this->contentHandler,
             $this->documentMapper,
-            $this->resultExtractor,
+            $this->contentResultExtractor,
+            $this->locationResultExtractor,
             $coreFilter
         );
     }

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -15,7 +15,8 @@ services:
             $coreFilterRegistry: '@EzSystems\EzPlatformSolrSearchEngine\CoreFilter\CoreFilterRegistry'
             $contentHandler: "@ezpublish.spi.persistence.content_handler"
             $documentMapper: "@ezpublish.search.solr.document_mapper"
-            $resultExtractor: "@ezpublish.search.solr.result_extractor"
+            $contentResultExtractor: "@ezpublish.search.solr.result_extractor.content"
+            $locationResultExtractor: "@ezpublish.search.solr.result_extractor.location"
 
     ezpublish.solr.boost_factor_provider_factory:
         class: "%ezpublish.solr.boost_factor_provider_factory.class%"

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     ],
     "require": {
         "php": "^7.3",
+        "ext-json": "*",
         "ezsystems/ezplatform-kernel": "^1.2@dev",
         "netgen/query-translator": "^1.0.2",
         "symfony/http-kernel": "^5.0",

--- a/lib/FieldMapper/ContentFieldMapper/BlockDocumentsBaseContentFields.php
+++ b/lib/FieldMapper/ContentFieldMapper/BlockDocumentsBaseContentFields.php
@@ -143,6 +143,11 @@ class BlockDocumentsBaseContentFields extends ContentFieldMapper
                 new FieldType\MultipleStringField()
             ),
             new Field(
+                'content_language_codes_raw',
+                array_keys($versionInfo->names),
+                new FieldType\MultipleIdentifierField(['raw' => true])
+            ),
+            new Field(
                 'content_main_language_code',
                 $contentInfo->mainLanguageCode,
                 new FieldType\StringField()

--- a/lib/Gateway/Native.php
+++ b/lib/Gateway/Native.php
@@ -102,7 +102,7 @@ class Native extends Gateway
      */
     public function findContent(Query $query, array $languageSettings = [])
     {
-        $parameters = $this->contentQueryConverter->convert($query);
+        $parameters = $this->contentQueryConverter->convert($query, $languageSettings);
 
         return $this->internalFind($parameters, $languageSettings);
     }

--- a/lib/Handler.php
+++ b/lib/Handler.php
@@ -74,9 +74,25 @@ class Handler implements SearchHandlerInterface, Capable, ContentTranslationHand
     /**
      * Result extractor.
      *
+     * @deprecated since eZ Platform 3.2.0, to be removed in eZ Platform 4.0.0. Use $contentResultExtractor or $locationResultExtractor instead of $resultExtractor.
+     *
      * @var \EzSystems\EzPlatformSolrSearchEngine\ResultExtractor
      */
     protected $resultExtractor;
+
+    /**
+     * Content result extractor.
+     *
+     * @var \EzSystems\EzPlatformSolrSearchEngine\ResultExtractor
+     */
+    protected $contentResultExtractor;
+
+    /**
+     * Location result extractor.
+     *
+     * @var \EzSystems\EzPlatformSolrSearchEngine\ResultExtractor
+     */
+    protected $locationResultExtractor;
 
     /**
      * Core filter service.
@@ -97,14 +113,19 @@ class Handler implements SearchHandlerInterface, Capable, ContentTranslationHand
         Gateway $gateway,
         ContentHandler $contentHandler,
         DocumentMapper $mapper,
-        ResultExtractor $resultExtractor,
+        ResultExtractor $contentResultExtractor,
+        ResultExtractor $locationResultExtractor,
         CoreFilter $coreFilter
     ) {
         $this->gateway = $gateway;
         $this->contentHandler = $contentHandler;
         $this->mapper = $mapper;
-        $this->resultExtractor = $resultExtractor;
+        $this->contentResultExtractor = $contentResultExtractor;
+        $this->locationResultExtractor = $locationResultExtractor;
         $this->coreFilter = $coreFilter;
+
+        // For BC these are still set
+        $this->resultExtractor = $contentResultExtractor;
     }
 
     /**
@@ -131,9 +152,11 @@ class Handler implements SearchHandlerInterface, Capable, ContentTranslationHand
             DocumentMapper::DOCUMENT_TYPE_IDENTIFIER_CONTENT
         );
 
-        return $this->resultExtractor->extract(
+        return $this->contentResultExtractor->extract(
             $this->gateway->findContent($query, $languageFilter),
-            $query->facetBuilders
+            $query->facetBuilders,
+            $query->aggregations,
+            $languageFilter
         );
     }
 
@@ -201,9 +224,10 @@ class Handler implements SearchHandlerInterface, Capable, ContentTranslationHand
             DocumentMapper::DOCUMENT_TYPE_IDENTIFIER_LOCATION
         );
 
-        return $this->resultExtractor->extract(
+        return $this->locationResultExtractor->extract(
             $this->gateway->findLocations($query, $languageFilter),
-            $query->facetBuilders
+            $query->facetBuilders,
+            $query->aggregations
         );
     }
 

--- a/lib/Query/AggregationVisitor.php
+++ b/lib/Query/AggregationVisitor.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\Query;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+
+interface AggregationVisitor
+{
+    /**
+     * Check if visitor is applicable to current aggreagtion.
+     */
+    public function canVisit(Aggregation $aggregation, array $languageFilter): bool;
+
+    /**
+     * @return string[]
+     */
+    public function visit(
+        AggregationVisitor $dispatcherVisitor,
+        Aggregation $aggregation,
+        array $languageFilter
+    ): array;
+}

--- a/lib/Query/Common/AggregationVisitor/AbstractRangeAggregationVisitor.php
+++ b/lib/Query/Common/AggregationVisitor/AbstractRangeAggregationVisitor.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor;
+
+use DateTimeInterface;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\AbstractRangeAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use EzSystems\EzPlatformSolrSearchEngine\Query\AggregationVisitor;
+
+abstract class AbstractRangeAggregationVisitor implements AggregationVisitor
+{
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Aggregation\AbstractRangeAggregation $aggregation
+     */
+    public function visit(
+        AggregationVisitor $dispatcherVisitor,
+        Aggregation $aggregation,
+        array $languageFilter
+    ): array {
+        $field = $this->getTargetField($aggregation);
+
+        $rangeFacets = [];
+        foreach ($aggregation->getRanges() as $range) {
+            $from = $this->formatRangeValue($range->getFrom());
+            $to = $this->formatRangeValue($range->getTo());
+
+            $rangeFacets["${from}_${to}"] = [
+                'type' => 'query',
+                'q' => sprintf('%s:[%s TO %s}', $field, $from, $to),
+            ];
+        }
+
+        return [
+            'type' => 'query',
+            'q' => '*:*',
+            'facet' => $rangeFacets,
+        ];
+    }
+
+    abstract protected function getTargetField(AbstractRangeAggregation $aggregation): string;
+
+    private function formatRangeValue($value): string
+    {
+        if ($value === null) {
+            return '*';
+        }
+
+        if ($value instanceof DateTimeInterface) {
+            return $value->format('Y-m-d\\TH:i:s\\Z');
+        }
+
+        return (string)$value;
+    }
+}

--- a/lib/Query/Common/AggregationVisitor/AbstractStatsAggregationVisitor.php
+++ b/lib/Query/Common/AggregationVisitor/AbstractStatsAggregationVisitor.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\AbstractStatsAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use EzSystems\EzPlatformSolrSearchEngine\Query\AggregationVisitor;
+
+abstract class AbstractStatsAggregationVisitor implements AggregationVisitor
+{
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Aggregation\AbstractStatsAggregation $aggregation
+     */
+    public function visit(
+        AggregationVisitor $dispatcherVisitor,
+        Aggregation $aggregation,
+        array $languageFilter
+    ): array {
+        $field = $this->getTargetField($aggregation);
+
+        return [
+            'type' => 'query',
+            'q' => '*:*',
+            'facet' => [
+                'sum' => "sum($field)",
+                'min' => "min($field)",
+                'max' => "max($field)",
+                'avg' => "avg($field)",
+            ],
+        ];
+    }
+
+    abstract protected function getTargetField(AbstractStatsAggregation $aggregation): string;
+}

--- a/lib/Query/Common/AggregationVisitor/AbstractTermAggregationVisitor.php
+++ b/lib/Query/Common/AggregationVisitor/AbstractTermAggregationVisitor.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\AbstractTermAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use EzSystems\EzPlatformSolrSearchEngine\Query\AggregationVisitor;
+
+abstract class AbstractTermAggregationVisitor implements AggregationVisitor
+{
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Aggregation\AbstractTermAggregation $aggregation
+     */
+    public function visit(
+        AggregationVisitor $dispatcherVisitor,
+        Aggregation $aggregation,
+        array $languageFilter
+    ): array {
+        return [
+            'type' => 'terms',
+            'field' => $this->getTargetField($aggregation),
+            'limit' => $aggregation->getLimit(),
+            'mincount' => $aggregation->getMinCount(),
+        ];
+    }
+
+    abstract protected function getTargetField(AbstractTermAggregation $aggregation): string;
+}

--- a/lib/Query/Common/AggregationVisitor/AggregationFieldResolver.php
+++ b/lib/Query/Common/AggregationVisitor/AggregationFieldResolver.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+
+/**
+ * Resolves search index field name used for aggregation.
+ */
+interface AggregationFieldResolver
+{
+    public function resolveTargetField(Aggregation $aggregation): string;
+}

--- a/lib/Query/Common/AggregationVisitor/AggregationFieldResolver/ContentFieldAggregationFieldResolver.php
+++ b/lib/Query/Common/AggregationVisitor/AggregationFieldResolver/ContentFieldAggregationFieldResolver.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\AggregationFieldResolver;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\FieldAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use eZ\Publish\Core\Search\Common\FieldNameResolver;
+use EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\AggregationFieldResolver;
+use RuntimeException;
+
+final class ContentFieldAggregationFieldResolver implements AggregationFieldResolver
+{
+    /** @var \eZ\Publish\Core\Search\Common\FieldNameResolver */
+    private $fieldNameResolver;
+
+    /** @var string */
+    private $searchFieldName;
+
+    public function __construct(FieldNameResolver $fieldNameResolver, string $searchFieldName)
+    {
+        $this->fieldNameResolver = $fieldNameResolver;
+        $this->searchFieldName = $searchFieldName;
+    }
+
+    public function resolveTargetField(Aggregation $aggregation): string
+    {
+        if (!($aggregation instanceof FieldAggregation)) {
+            throw new RuntimeException('Expected instance of ' . FieldAggregation::class . ' , got ' . get_class($aggregation));
+        }
+
+        $searchFieldName = $this->fieldNameResolver->getAggregationFieldName(
+            $aggregation->getContentTypeIdentifier(),
+            $aggregation->getFieldDefinitionIdentifier(),
+            $this->searchFieldName
+        );
+
+        if ($searchFieldName === null) {
+            throw new RuntimeException('No searchable fields found for the provided aggregation target');
+        }
+
+        return $searchFieldName;
+    }
+}

--- a/lib/Query/Common/AggregationVisitor/AggregationFieldResolver/CountryFieldTermAggregationFieldResolver.php
+++ b/lib/Query/Common/AggregationVisitor/AggregationFieldResolver/CountryFieldTermAggregationFieldResolver.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\AggregationFieldResolver;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\CountryTermAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentValue;
+use eZ\Publish\Core\Search\Common\FieldNameResolver;
+use EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\AggregationFieldResolver;
+
+final class CountryFieldTermAggregationFieldResolver implements AggregationFieldResolver
+{
+    /** @var \eZ\Publish\Core\Search\Common\FieldNameResolver */
+    private $fieldNameResolver;
+
+    public function __construct(FieldNameResolver $fieldNameResolver)
+    {
+        $this->fieldNameResolver = $fieldNameResolver;
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\CountryTermAggregation $aggregation
+     */
+    public function resolveTargetField(Aggregation $aggregation): string
+    {
+        return $this->fieldNameResolver->getAggregationFieldName(
+            $aggregation->getContentTypeIdentifier(),
+            $aggregation->getFieldDefinitionIdentifier(),
+            $this->getSearchFieldName($aggregation)
+        );
+    }
+
+    /**
+     * @see \eZ\Publish\Core\FieldType\Country\SearchField::getIndexDefinition
+     */
+    private function getSearchFieldName(CountryTermAggregation $aggregation): string
+    {
+        switch ($aggregation->getType()) {
+            case CountryTermAggregation::TYPE_NAME:
+                return 'name';
+            case CountryTermAggregation::TYPE_ALPHA_2:
+                return 'alpha2';
+            case CountryTermAggregation::TYPE_ALPHA_3:
+                return 'alpha3';
+            case CountryTermAggregation::TYPE_IDC:
+                return 'idc';
+        }
+
+        throw new InvalidArgumentValue('$aggregation->type', 'Invalid aggregation type: ' . $aggregation->getType());
+    }
+}

--- a/lib/Query/Common/AggregationVisitor/AggregationFieldResolver/RawAggregationFieldResolver.php
+++ b/lib/Query/Common/AggregationVisitor/AggregationFieldResolver/RawAggregationFieldResolver.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\AggregationFieldResolver;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\AggregationFieldResolver;
+
+final class RawAggregationFieldResolver implements AggregationFieldResolver
+{
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Aggregation\RawAggregation $aggregation
+     */
+    public function resolveTargetField(Aggregation $aggregation): string
+    {
+        return $aggregation->getFieldName();
+    }
+}

--- a/lib/Query/Common/AggregationVisitor/AggregationFieldResolver/SearchFieldAggregationFieldResolver.php
+++ b/lib/Query/Common/AggregationVisitor/AggregationFieldResolver/SearchFieldAggregationFieldResolver.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\AggregationFieldResolver;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\AggregationFieldResolver;
+
+final class SearchFieldAggregationFieldResolver implements AggregationFieldResolver
+{
+    /** @var string */
+    private $searchIndexFieldName;
+
+    public function __construct(string $searchIndexFieldName)
+    {
+        $this->searchIndexFieldName = $searchIndexFieldName;
+    }
+
+    public function resolveTargetField(Aggregation $aggregation): string
+    {
+        return $this->searchIndexFieldName;
+    }
+}

--- a/lib/Query/Common/AggregationVisitor/DateMetadataRangeAggregationVisitor.php
+++ b/lib/Query/Common/AggregationVisitor/DateMetadataRangeAggregationVisitor.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\AbstractRangeAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\DateMetadataRangeAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use RuntimeException;
+
+final class DateMetadataRangeAggregationVisitor extends AbstractRangeAggregationVisitor
+{
+    public function canVisit(Aggregation $aggregation, array $languageFilter): bool
+    {
+        return $aggregation instanceof DateMetadataRangeAggregation;
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Aggregation\DateMetadataRangeAggregation $aggregation
+     */
+    protected function getTargetField(AbstractRangeAggregation $aggregation): string
+    {
+        switch ($aggregation->getType()) {
+            case DateMetadataRangeAggregation::PUBLISHED:
+                return 'content_publication_date_dt';
+            case DateMetadataRangeAggregation::MODIFIED:
+                return 'content_modification_date_dt';
+            default:
+                throw new RuntimeException("Unsupported DateMetadataRangeAggregation type {$aggregation->getType()}");
+        }
+    }
+}

--- a/lib/Query/Common/AggregationVisitor/DispatcherAggregationVisitor.php
+++ b/lib/Query/Common/AggregationVisitor/DispatcherAggregationVisitor.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor;
+
+use eZ\Publish\API\Repository\Exceptions\NotImplementedException;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use EzSystems\EzPlatformSolrSearchEngine\Query\AggregationVisitor;
+
+final class DispatcherAggregationVisitor implements AggregationVisitor
+{
+    /** @var \EzSystems\EzPlatformSolrSearchEngine\Query\AggregationVisitor[] */
+    private $visitors;
+
+    /**
+     * @var \EzSystems\EzPlatformSolrSearchEngine\Query\AggregationVisitor[]
+     */
+    public function __construct(iterable $visitors)
+    {
+        $this->visitors = $visitors;
+    }
+
+    public function canVisit(Aggregation $aggregation, array $languageFilter): bool
+    {
+        return $this->findVisitor($aggregation, $languageFilter) !== null;
+    }
+
+    public function visit(
+        AggregationVisitor $dispatcherVisitor,
+        Aggregation $aggregation,
+        array $languageFilter
+    ): array {
+        $visitor = $this->findVisitor($aggregation, $languageFilter);
+
+        if ($visitor === null) {
+            throw new NotImplementedException(
+                'No visitor available for: ' . get_class($aggregation)
+            );
+        }
+
+        return $visitor->visit($this, $aggregation, $languageFilter);
+    }
+
+    private function findVisitor(Aggregation $aggregation, array $languageFilter): ?AggregationVisitor
+    {
+        foreach ($this->visitors as $visitor) {
+            if ($visitor->canVisit($aggregation, $languageFilter)) {
+                return $visitor;
+            }
+        }
+
+        return null;
+    }
+}

--- a/lib/Query/Common/AggregationVisitor/Factory/ContentFieldAggregationVisitorFactory.php
+++ b/lib/Query/Common/AggregationVisitor/Factory/ContentFieldAggregationVisitorFactory.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\Factory;
+
+use eZ\Publish\Core\Search\Common\FieldNameResolver;
+use EzSystems\EzPlatformSolrSearchEngine\Query\AggregationVisitor;
+use EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\AggregationFieldResolver\ContentFieldAggregationFieldResolver;
+use EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\RangeAggregationVisitor;
+use EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\StatsAggregationVisitor;
+use EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\TermAggregationVisitor;
+
+final class ContentFieldAggregationVisitorFactory
+{
+    /** @var \eZ\Publish\Core\Search\Common\FieldNameResolver */
+    private $fieldNameResolver;
+
+    public function __construct(FieldNameResolver $fieldNameResolver)
+    {
+        $this->fieldNameResolver = $fieldNameResolver;
+    }
+
+    public function createRangeAggregationVisitor(
+        string $aggregationClass,
+        string $searchIndexFieldName
+    ): AggregationVisitor {
+        return new RangeAggregationVisitor(
+            $aggregationClass,
+            new ContentFieldAggregationFieldResolver(
+                $this->fieldNameResolver,
+                $searchIndexFieldName
+            )
+        );
+    }
+
+    public function createStatsAggregationVisitor(
+        string $aggregationClass,
+        string $searchIndexFieldName
+    ): AggregationVisitor {
+        return new StatsAggregationVisitor(
+            $aggregationClass,
+            new ContentFieldAggregationFieldResolver(
+                $this->fieldNameResolver,
+                $searchIndexFieldName
+            )
+        );
+    }
+
+    public function createTermAggregationVisitor(
+        string $aggregationClass,
+        string $searchIndexFieldName
+    ): AggregationVisitor {
+        return new TermAggregationVisitor(
+            $aggregationClass,
+            new ContentFieldAggregationFieldResolver(
+                $this->fieldNameResolver,
+                $searchIndexFieldName
+            )
+        );
+    }
+}

--- a/lib/Query/Common/AggregationVisitor/Factory/RawAggregationVisitorFactory.php
+++ b/lib/Query/Common/AggregationVisitor/Factory/RawAggregationVisitorFactory.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\Factory;
+
+use EzSystems\EzPlatformSolrSearchEngine\Query\AggregationVisitor;
+use EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\AggregationFieldResolver\RawAggregationFieldResolver;
+use EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\RangeAggregationVisitor;
+use EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\StatsAggregationVisitor;
+use EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\TermAggregationVisitor;
+
+final class RawAggregationVisitorFactory
+{
+    public function createRangeAggregationVisitor(
+        string $aggregationClass
+    ): AggregationVisitor {
+        return new RangeAggregationVisitor(
+            $aggregationClass,
+            new RawAggregationFieldResolver()
+        );
+    }
+
+    public function createStatsAggregationVisitor(
+        string $aggregationClass
+    ): AggregationVisitor {
+        return new StatsAggregationVisitor(
+            $aggregationClass,
+            new RawAggregationFieldResolver()
+        );
+    }
+
+    public function createTermAggregationVisitor(
+        string $aggregationClass
+    ): AggregationVisitor {
+        return new TermAggregationVisitor(
+            $aggregationClass,
+            new RawAggregationFieldResolver()
+        );
+    }
+}

--- a/lib/Query/Common/AggregationVisitor/Factory/SearchFieldAggregationVisitorFactory.php
+++ b/lib/Query/Common/AggregationVisitor/Factory/SearchFieldAggregationVisitorFactory.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\Factory;
+
+use EzSystems\EzPlatformSolrSearchEngine\Query\AggregationVisitor;
+use EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\AggregationFieldResolver\SearchFieldAggregationFieldResolver;
+use EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\RangeAggregationVisitor;
+use EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\StatsAggregationVisitor;
+use EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\TermAggregationVisitor;
+
+final class SearchFieldAggregationVisitorFactory
+{
+    public function createRangeAggregationVisitor(
+        string $aggregationClass,
+        string $searchIndexFieldName
+    ): AggregationVisitor {
+        return new RangeAggregationVisitor(
+            $aggregationClass,
+            new SearchFieldAggregationFieldResolver($searchIndexFieldName)
+        );
+    }
+
+    public function createStatsAggregationVisitor(
+        string $aggregationClass,
+        string $searchIndexFieldName
+    ): AggregationVisitor {
+        return new StatsAggregationVisitor(
+            $aggregationClass,
+            new SearchFieldAggregationFieldResolver($searchIndexFieldName)
+        );
+    }
+
+    public function createTermAggregationVisitor(
+        string $aggregationClass,
+        string $searchIndexFieldName
+    ): AggregationVisitor {
+        return new TermAggregationVisitor(
+            $aggregationClass,
+            new SearchFieldAggregationFieldResolver($searchIndexFieldName)
+        );
+    }
+}

--- a/lib/Query/Common/AggregationVisitor/ObjectStateAggregationVisitor.php
+++ b/lib/Query/Common/AggregationVisitor/ObjectStateAggregationVisitor.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\ObjectStateTermAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use EzSystems\EzPlatformSolrSearchEngine\Query\AggregationVisitor;
+
+final class ObjectStateAggregationVisitor implements AggregationVisitor
+{
+    public function canVisit(Aggregation $aggregation, array $languageFilter): bool
+    {
+        return $aggregation instanceof ObjectStateTermAggregation;
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Aggregation\ObjectStateTermAggregation $aggregation
+     */
+    public function visit(
+        AggregationVisitor $dispatcherVisitor,
+        Aggregation $aggregation,
+        array $languageFilter
+    ): array {
+        return [
+            'type' => 'terms',
+            'field' => 'content_object_state_identifiers_ms',
+            'prefix' => $aggregation->getObjectStateGroupIdentifier() . ':',
+            'limit' => $aggregation->getLimit(),
+            'mincount' => $aggregation->getMinCount(),
+        ];
+    }
+}

--- a/lib/Query/Common/AggregationVisitor/RangeAggregationVisitor.php
+++ b/lib/Query/Common/AggregationVisitor/RangeAggregationVisitor.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\AbstractRangeAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+
+final class RangeAggregationVisitor extends AbstractRangeAggregationVisitor
+{
+    /** @var string */
+    private $aggregationClass;
+
+    /** @var \EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\AggregationFieldResolver */
+    private $aggregationFieldResolver;
+
+    public function __construct(string $aggregationClass, AggregationFieldResolver $aggregationFieldResolver)
+    {
+        $this->aggregationClass = $aggregationClass;
+        $this->aggregationFieldResolver = $aggregationFieldResolver;
+    }
+
+    public function canVisit(Aggregation $aggregation, array $languageFilter): bool
+    {
+        return $aggregation instanceof $this->aggregationClass;
+    }
+
+    protected function getTargetField(AbstractRangeAggregation $aggregation): string
+    {
+        return $this->aggregationFieldResolver->resolveTargetField($aggregation);
+    }
+}

--- a/lib/Query/Common/AggregationVisitor/StatsAggregationVisitor.php
+++ b/lib/Query/Common/AggregationVisitor/StatsAggregationVisitor.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\AbstractStatsAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+
+final class StatsAggregationVisitor extends AbstractStatsAggregationVisitor
+{
+    /** @var string */
+    private $aggregationClass;
+
+    /** @var \EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\AggregationFieldResolver */
+    private $aggregationFieldResolver;
+
+    public function __construct(string $aggregationClass, AggregationFieldResolver $aggregationFieldResolver)
+    {
+        $this->aggregationClass = $aggregationClass;
+        $this->aggregationFieldResolver = $aggregationFieldResolver;
+    }
+
+    public function canVisit(Aggregation $aggregation, array $languageFilter): bool
+    {
+        return $aggregation instanceof $this->aggregationClass;
+    }
+
+    protected function getTargetField(AbstractStatsAggregation $aggregation): string
+    {
+        return $this->aggregationFieldResolver->resolveTargetField($aggregation);
+    }
+}

--- a/lib/Query/Common/AggregationVisitor/TermAggregationVisitor.php
+++ b/lib/Query/Common/AggregationVisitor/TermAggregationVisitor.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\AbstractTermAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+
+final class TermAggregationVisitor extends AbstractTermAggregationVisitor
+{
+    /** @var string */
+    private $aggregationClass;
+
+    /** @var \EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\AggregationFieldResolver */
+    private $aggregationFieldResolver;
+
+    public function __construct(string $aggregationClass, AggregationFieldResolver $aggregationFieldResolver)
+    {
+        $this->aggregationClass = $aggregationClass;
+        $this->aggregationFieldResolver = $aggregationFieldResolver;
+    }
+
+    public function canVisit(Aggregation $aggregation, array $languageFilter): bool
+    {
+        return $aggregation instanceof $this->aggregationClass;
+    }
+
+    protected function getTargetField(AbstractTermAggregation $aggregation): string
+    {
+        return $this->aggregationFieldResolver->resolveTargetField($aggregation);
+    }
+}

--- a/lib/Query/Common/AggregationVisitor/UserMetadataTermAggregationVisitor.php
+++ b/lib/Query/Common/AggregationVisitor/UserMetadataTermAggregationVisitor.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\AbstractTermAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\UserMetadataTermAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
+
+final class UserMetadataTermAggregationVisitor extends AbstractTermAggregationVisitor
+{
+    public function canVisit(Aggregation $aggregation, array $languageFilter): bool
+    {
+        return $aggregation instanceof UserMetadataTermAggregation;
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Aggregation\UserMetadataTermAggregation $aggregation
+     */
+    protected function getTargetField(AbstractTermAggregation $aggregation): string
+    {
+        switch ($aggregation->getType()) {
+            case UserMetadataTermAggregation::OWNER:
+                return 'content_owner_user_id_id';
+            case UserMetadataTermAggregation::GROUP:
+                return 'content_owner_user_group_ids_mid';
+            case UserMetadataTermAggregation::MODIFIER:
+                return 'content_version_creator_user_id_id';
+            default:
+                throw new InvalidArgumentException(
+                    '$type',
+                    'Unsupported UserMetadataTermAggregation type: ' . $aggregation->getType()
+                );
+        }
+    }
+}

--- a/lib/Query/Common/CriterionVisitor/CompositeCriterion.php
+++ b/lib/Query/Common/CriterionVisitor/CompositeCriterion.php
@@ -11,7 +11,7 @@ namespace EzSystems\EzPlatformSolrSearchEngine\Query\Common\CriterionVisitor;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use EzSystems\EzPlatformSolrSearchEngine\Query\CriterionVisitor;
 
-class CompositeCriterion extends CriterionVisitor
+final class CompositeCriterion extends CriterionVisitor
 {
     public function canVisit(Criterion $criterion): bool
     {

--- a/lib/Query/Common/FacetBuilderVisitor/Aggregate.php
+++ b/lib/Query/Common/FacetBuilderVisitor/Aggregate.php
@@ -16,6 +16,8 @@ use EzSystems\EzPlatformSolrSearchEngine\Query\FacetFieldVisitor;
 
 /**
  * Visits the facet builder tree into a Solr query.
+ *
+ * @deprecated since eZ Platform 3.2.0, to be removed in eZ Platform 4.0.0.
  */
 class Aggregate extends FacetBuilderVisitor implements FacetFieldVisitor
 {

--- a/lib/Query/Common/FacetBuilderVisitor/ContentType.php
+++ b/lib/Query/Common/FacetBuilderVisitor/ContentType.php
@@ -17,6 +17,8 @@ use EzSystems\EzPlatformSolrSearchEngine\Query\FacetFieldVisitor;
 
 /**
  * Visits the ContentType facet builder.
+ *
+ * @deprecated since eZ Platform 3.2.0, to be removed in eZ Platform 4.0.0.
  */
 class ContentType extends FacetBuilderVisitor implements FacetFieldVisitor
 {

--- a/lib/Query/Common/FacetBuilderVisitor/Section.php
+++ b/lib/Query/Common/FacetBuilderVisitor/Section.php
@@ -17,6 +17,8 @@ use EzSystems\EzPlatformSolrSearchEngine\Query\FacetFieldVisitor;
 
 /**
  * Visits the Section facet builder.
+ *
+ * @deprecated since eZ Platform 3.2.0, to be removed in eZ Platform 4.0.0.
  */
 class Section extends FacetBuilderVisitor implements FacetFieldVisitor
 {

--- a/lib/Query/Common/FacetBuilderVisitor/User.php
+++ b/lib/Query/Common/FacetBuilderVisitor/User.php
@@ -18,6 +18,8 @@ use EzSystems\EzPlatformSolrSearchEngine\Query\FacetFieldVisitor;
 
 /**
  * Visits the User facet builder.
+ *
+ * @deprecated since eZ Platform 3.2.0, to be removed in eZ Platform 4.0.0.
  */
 class User extends FacetBuilderVisitor implements FacetFieldVisitor
 {

--- a/lib/Query/FacetBuilderVisitor.php
+++ b/lib/Query/FacetBuilderVisitor.php
@@ -14,6 +14,8 @@ use eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder;
 
 /**
  * Visits the facet builder tree into a Solr query.
+ *
+ * @deprecated since eZ Platform 3.2.0, to be removed in eZ Platform 4.0.0.
  */
 abstract class FacetBuilderVisitor
 {

--- a/lib/Query/FacetFieldVisitor.php
+++ b/lib/Query/FacetFieldVisitor.php
@@ -13,7 +13,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder;
 /**
  * Visits Solr results into correct facet and facet builder combination.
  *
- * NOTE: Will be deprecated in 2.0 and methods will be moved into FacetBuilderVisitor.
+ * @deprecated since eZ Platform 3.2.0, to be removed in eZ Platform 4.0.0.
  */
 interface FacetFieldVisitor
 {

--- a/lib/Query/QueryConverter.php
+++ b/lib/Query/QueryConverter.php
@@ -20,7 +20,10 @@ abstract class QueryConverter
     /**
      * Map query to a proper Solr representation.
      *
+     * @param array $languageSettings - a map of filters for the returned fields.
+     *        Currently supported: <code>array("languages" => array(<language1>,..))</code>.
+     *
      * @return array
      */
-    abstract public function convert(Query $query);
+    abstract public function convert(Query $query, array $languageSettings = []);
 }

--- a/lib/Resources/config/container/solr.yml
+++ b/lib/Resources/config/container/solr.yml
@@ -5,6 +5,8 @@ imports:
     - {resource: solr/query_translator.yml}
     - {resource: solr/services.yml}
     - {resource: solr/sort_clause_visitors.yml}
+    - {resource: solr/aggregation_result_extractors.yml}
+    - {resource: solr/aggregation_visitors.yml}
 
 parameters:
     ezpublish.search.solr.connection.server: http://localhost:8983/solr/core0
@@ -69,10 +71,33 @@ services:
         class: "%ezpublish.search.solr.result_extractor.native.class%"
         arguments:
             - "@ezpublish.search.solr.query.content.facet_builder_visitor.aggregate"
+            - "@ezpublish.search.solr.query.content.aggregation_result_extractor.dispatcher"
+            - "@ezpublish.search.solr.gateway.endpoint_registry"
+        deprecated: 'The "%service_id%" service is deprecated since eZ Platform 3.2.0, to be removed in eZ Platform 4.0.0., use ezpublish.search.solr.result_extractor.content.native or ezpublish.search.solr.result_extractor.location.native instead.'
+
+    ezpublish.search.solr.result_extractor.content.native:
+        class: "%ezpublish.search.solr.result_extractor.native.class%"
+        arguments:
+            - "@ezpublish.search.solr.query.content.facet_builder_visitor.aggregate"
+            - "@ezpublish.search.solr.query.content.aggregation_result_extractor.dispatcher"
+            - "@ezpublish.search.solr.gateway.endpoint_registry"
+
+    ezpublish.search.solr.result_extractor.location.native:
+        class: "%ezpublish.search.solr.result_extractor.native.class%"
+        arguments:
+            - "@ezpublish.search.solr.query.content.facet_builder_visitor.aggregate"
+            - "@ezpublish.search.solr.query.location.aggregation_result_extractor.dispatcher"
             - "@ezpublish.search.solr.gateway.endpoint_registry"
 
     ezpublish.search.solr.result_extractor:
         alias: ezpublish.search.solr.result_extractor.native
+        deprecated: 'The "%alias_id%" alias is deprecated since eZ Platform 3.2.0, to be removed in eZ Platform 4.0.0. Use ezpublish.search.solr.result_extractor.content or ezpublish.search.solr.result_extractor.location instead'
+
+    ezpublish.search.solr.result_extractor.content:
+        alias: ezpublish.search.solr.result_extractor.content.native
+
+    ezpublish.search.solr.result_extractor.location:
+        alias: ezpublish.search.solr.result_extractor.location.native
 
     ezpublish.search.solr.query_converter.content:
         class: "%ezpublish.search.solr.query_converter.class%"
@@ -80,6 +105,7 @@ services:
             - "@ezpublish.search.solr.query.content.criterion_visitor.aggregate"
             - "@ezpublish.search.solr.query.content.sort_clause_visitor.aggregate"
             - "@ezpublish.search.solr.query.content.facet_builder_visitor.aggregate"
+            - "@ezpublish.search.solr.query.content.aggregation_visitor.dispatcher"
 
     ezpublish.search.solr.query_converter.location:
         class: "%ezpublish.search.solr.query_converter.class%"
@@ -87,6 +113,7 @@ services:
             - "@ezpublish.search.solr.query.location.criterion_visitor.aggregate"
             - "@ezpublish.search.solr.query.location.sort_clause_visitor.aggregate"
             - "@ezpublish.search.solr.query.location.facet_builder_visitor.aggregate"
+            - "@ezpublish.search.solr.query.location.aggregation_visitor.dispatcher"
 
     ezpublish.search.solr.gateway.update_serializer:
         class: "%ezpublish.search.solr.gateway.update_serializer.class%"
@@ -120,7 +147,8 @@ services:
             - "@ezpublish.search.solr.gateway"
             - "@ezpublish.spi.persistence.content_handler"
             - "@ezpublish.search.solr.document_mapper"
-            - "@ezpublish.search.solr.result_extractor"
+            - "@ezpublish.search.solr.result_extractor.content"
+            - "@ezpublish.search.solr.result_extractor.location"
             - "@ezpublish.search.solr.core_filter"
         tags:
             - {name: ezplatform.search_engine, alias: solr}

--- a/lib/Resources/config/container/solr/aggregation_result_extractors.yml
+++ b/lib/Resources/config/container/solr/aggregation_result_extractors.yml
@@ -1,0 +1,250 @@
+services:
+  _defaults:
+    autowire: true
+    autoconfigure: true
+    public: false
+
+  ezpublish.search.solr.query.content.aggregation_result_extractor.dispatcher:
+    class: EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\DispatcherAggregationResultExtractor
+    arguments:
+      $extractors: !tagged ezplatform.search.solr.query.content.aggregation_result_extractor
+
+  ezpublish.search.solr.query.location.aggregation_result_extractor.dispatcher:
+    class: EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\DispatcherAggregationResultExtractor
+    arguments:
+      $extractors: !tagged ezplatform.search.solr.query.location.aggregation_result_extractor
+
+  ### Key mappers
+
+  EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\BooleanAggregationKeyMapper: ~
+
+  EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\CountryAggregationKeyMapper:
+    arguments:
+      $countriesInfo: '%ezpublish.fieldType.ezcountry.data%'
+
+  EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\ContentTypeAggregationKeyMapper: ~
+
+  EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\ContentTypeGroupAggregationKeyMapper: ~
+
+  EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\InvertedBooleanAggregationKeyMapper: ~
+
+  EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\LanguageAggregationKeyMapper: ~
+
+  EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\ObjectStateAggregationKeyMapper: ~
+
+  EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\SectionAggregationKeyMapper: ~
+
+  EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\UserMetadataAggregationKeyMapper: ~
+
+  EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\RangeAggregationKeyMapper\DateTimeRangeAggregationKeyMapper: ~
+
+  EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\RangeAggregationKeyMapper\FloatRangeAggregationKeyMapper: ~
+
+  EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\RangeAggregationKeyMapper\IntRangeAggregationKeyMapper: ~
+
+  EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\RangeAggregationKeyMapper\NullRangeAggregationKeyMapper: ~
+
+  ### Extractors
+
+  ezplatform.search.solr.query.common.aggregation_result_extractor.content_type_term:
+    class: EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationResultExtractor
+    arguments:
+      $aggregationClass: 'eZ\Publish\API\Repository\Values\Content\Query\Aggregation\ContentTypeTermAggregation'
+      $keyMapper: '@EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\ContentTypeAggregationKeyMapper'
+    tags:
+      - { name: ezplatform.search.solr.query.content.aggregation_result_extractor }
+      - { name: ezplatform.search.solr.query.location.aggregation_result_extractor }
+
+  ezplatform.search.solr.query.common.aggregation_result_extractor.content_type_group_term:
+    class: EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationResultExtractor
+    arguments:
+      $aggregationClass: 'eZ\Publish\API\Repository\Values\Content\Query\Aggregation\ContentTypeGroupTermAggregation'
+      $keyMapper: '@EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\ContentTypeGroupAggregationKeyMapper'
+    tags:
+      - { name: ezplatform.search.solr.query.content.aggregation_result_extractor }
+      - { name: ezplatform.search.solr.query.location.aggregation_result_extractor }
+
+  ezplatform.search.solr.query.common.aggregation_result_extractor.data_metadata_range:
+    class: EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\RangeAggregationResultExtractor
+    arguments:
+      $aggregationClass: 'eZ\Publish\API\Repository\Values\Content\Query\Aggregation\DateMetadataRangeAggregation'
+      $keyMapper: '@EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\RangeAggregationKeyMapper\DateTimeRangeAggregationKeyMapper'
+    tags:
+      - { name: ezplatform.search.solr.query.content.aggregation_result_extractor }
+      - { name: ezplatform.search.solr.query.location.aggregation_result_extractor }
+
+  ezplatform.search.solr.query.common.aggregation_result_extractor.langauge_term:
+    class: EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationResultExtractor
+    arguments:
+      $aggregationClass: 'eZ\Publish\API\Repository\Values\Content\Query\Aggregation\LanguageTermAggregation'
+      $keyMapper: '@EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\LanguageAggregationKeyMapper'
+    tags:
+      - { name: ezplatform.search.solr.query.content.aggregation_result_extractor }
+      - { name: ezplatform.search.solr.query.location.aggregation_result_extractor }
+
+  ezplatform.search.solr.query.common.aggregation_result_extractor.raw_range:
+    class: EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\RangeAggregationResultExtractor
+    arguments:
+      $aggregationClass: 'eZ\Publish\API\Repository\Values\Content\Query\Aggregation\RawRangeAggregation'
+      $keyMapper: '@EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\RangeAggregationKeyMapper\NullRangeAggregationKeyMapper'
+    tags:
+      - { name: ezplatform.search.solr.query.content.aggregation_result_extractor }
+      - { name: ezplatform.search.solr.query.location.aggregation_result_extractor }
+
+  ezplatform.search.solr.query.common.aggregation_result_extractor.raw_stats:
+    class: EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\StatsAggregationResultExtractor
+    arguments:
+      $aggregationClass: 'eZ\Publish\API\Repository\Values\Content\Query\Aggregation\RawStatsAggregation'
+    tags:
+      - { name: ezplatform.search.solr.query.content.aggregation_result_extractor }
+      - { name: ezplatform.search.solr.query.location.aggregation_result_extractor }
+
+  ezplatform.search.solr.query.common.aggregation_result_extractor.raw_term:
+    class: EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationResultExtractor
+    arguments:
+      $aggregationClass: 'eZ\Publish\API\Repository\Values\Content\Query\Aggregation\RawTermAggregation'
+    tags:
+      - { name: ezplatform.search.solr.query.content.aggregation_result_extractor }
+      - { name: ezplatform.search.solr.query.location.aggregation_result_extractor }
+
+  ezplatform.search.solr.query.common.aggregation_result_extractor.object_state_term:
+    class: EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationResultExtractor
+    arguments:
+      $aggregationClass: 'eZ\Publish\API\Repository\Values\Content\Query\Aggregation\ObjectStateTermAggregation'
+      $keyMapper: '@EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\ObjectStateAggregationKeyMapper'
+    tags:
+      - { name: ezplatform.search.solr.query.content.aggregation_result_extractor }
+      - { name: ezplatform.search.solr.query.location.aggregation_result_extractor }
+
+  ezplatform.search.solr.query.common.aggregation_result_extractor.section_term:
+    class: EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationResultExtractor
+    arguments:
+      $aggregationClass: 'eZ\Publish\API\Repository\Values\Content\Query\Aggregation\SectionTermAggregation'
+      $keyMapper: '@EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\SectionAggregationKeyMapper'
+    tags:
+      - { name: ezplatform.search.solr.query.content.aggregation_result_extractor }
+      - { name: ezplatform.search.solr.query.location.aggregation_result_extractor }
+
+  ezplatform.search.solr.query.common.aggregation_result_extractor.user_metadata_term:
+    class: EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationResultExtractor
+    arguments:
+      $aggregationClass: 'eZ\Publish\API\Repository\Values\Content\Query\Aggregation\UserMetadataTermAggregation'
+      $keyMapper: '@EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\UserMetadataAggregationKeyMapper'
+    tags:
+      - { name: ezplatform.search.solr.query.content.aggregation_result_extractor }
+      - { name: ezplatform.search.solr.query.location.aggregation_result_extractor }
+
+  ezplatform.search.solr.query.common.aggregation_result_extractor.field.checkbox_term:
+    class: EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationResultExtractor
+    arguments:
+      $aggregationClass: 'eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\CheckboxTermAggregation'
+      $keyMapper: '@EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\BooleanAggregationKeyMapper'
+    tags:
+      - { name: ezplatform.search.solr.query.content.aggregation_result_extractor }
+      - { name: ezplatform.search.solr.query.location.aggregation_result_extractor }
+
+  ezplatform.search.solr.query.common.aggregation_result_extractor.field.country:
+    class: EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationResultExtractor
+    arguments:
+      $aggregationClass: 'eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\CountryTermAggregation'
+      $keyMapper: '@EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\CountryAggregationKeyMapper'
+    tags:
+      - { name: ezplatform.search.solr.query.content.aggregation_result_extractor }
+      - { name: ezplatform.search.solr.query.location.aggregation_result_extractor }
+
+  ezplatform.search.solr.query.common.aggregation_result_extractor.field.date_range:
+    class: EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\RangeAggregationResultExtractor
+    arguments:
+      $aggregationClass: 'eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\DateRangeAggregation'
+      $keyMapper: '@EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\RangeAggregationKeyMapper\DateTimeRangeAggregationKeyMapper'
+    tags:
+      - { name: ezplatform.search.solr.query.content.aggregation_result_extractor }
+      - { name: ezplatform.search.solr.query.location.aggregation_result_extractor }
+
+  ezplatform.search.solr.query.common.aggregation_result_extractor.field.datetime_range:
+    class: EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\RangeAggregationResultExtractor
+    arguments:
+      $aggregationClass: 'eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\DateTimeRangeAggregation'
+      $keyMapper: '@EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\RangeAggregationKeyMapper\DateTimeRangeAggregationKeyMapper'
+    tags:
+      - { name: ezplatform.search.solr.query.content.aggregation_result_extractor }
+      - { name: ezplatform.search.solr.query.location.aggregation_result_extractor }
+
+  ezplatform.search.solr.query.common.aggregation_result_extractor.field.float_range:
+    class: EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\RangeAggregationResultExtractor
+    arguments:
+      $aggregationClass: 'eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\FloatRangeAggregation'
+      $keyMapper: '@EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\RangeAggregationKeyMapper\FloatRangeAggregationKeyMapper'
+    tags:
+      - { name: ezplatform.search.solr.query.content.aggregation_result_extractor }
+      - { name: ezplatform.search.solr.query.location.aggregation_result_extractor }
+
+  ezplatform.search.solr.query.common.aggregation_result_extractor.field.float_stats:
+    class: EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\StatsAggregationResultExtractor
+    arguments:
+      $aggregationClass: 'eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\FloatStatsAggregation'
+    tags:
+      - { name: ezplatform.search.solr.query.content.aggregation_result_extractor }
+      - { name: ezplatform.search.solr.query.location.aggregation_result_extractor }
+
+  ezplatform.search.solr.query.common.aggregation_result_extractor.field.integer_range:
+    class: EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\RangeAggregationResultExtractor
+    arguments:
+      $aggregationClass: 'eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\IntegerRangeAggregation'
+      $keyMapper: '@EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\RangeAggregationKeyMapper\IntRangeAggregationKeyMapper'
+    tags:
+      - { name: ezplatform.search.solr.query.content.aggregation_result_extractor }
+      - { name: ezplatform.search.solr.query.location.aggregation_result_extractor }
+
+  ezplatform.search.solr.query.common.aggregation_result_extractor.field.integer_stats:
+    class: EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\StatsAggregationResultExtractor
+    arguments:
+      $aggregationClass: 'eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\IntegerStatsAggregation'
+    tags:
+      - { name: ezplatform.search.solr.query.content.aggregation_result_extractor }
+      - { name: ezplatform.search.solr.query.location.aggregation_result_extractor }
+
+  ezplatform.search.solr.query.common.aggregation_result_extractor.field.keyword_term:
+    class: EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationResultExtractor
+    arguments:
+      $aggregationClass: 'eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\KeywordTermAggregation'
+    tags:
+      - { name: ezplatform.search.solr.query.content.aggregation_result_extractor }
+      - { name: ezplatform.search.solr.query.location.aggregation_result_extractor }
+
+  ezplatform.search.solr.query.common.aggregation_result_extractor.field.selection_term:
+    class: EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationResultExtractor
+    arguments:
+      $aggregationClass: 'eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\SelectionTermAggregation'
+    tags:
+      - { name: ezplatform.search.solr.query.content.aggregation_result_extractor }
+      - { name: ezplatform.search.solr.query.location.aggregation_result_extractor }
+
+  ezplatform.search.solr.query.common.aggregation_result_extractor.field.time_range:
+    class: EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\RangeAggregationResultExtractor
+    arguments:
+      $aggregationClass: 'eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\TimeRangeAggregation'
+      $keyMapper: '@EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\RangeAggregationKeyMapper\IntRangeAggregationKeyMapper'
+    tags:
+      - { name: ezplatform.search.solr.query.content.aggregation_result_extractor }
+      - { name: ezplatform.search.solr.query.location.aggregation_result_extractor }
+
+  ### Content specific
+
+  ezplatform.search.solr.query.content.aggregation_result_extractor.visibility:
+    class: EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationResultExtractor
+    arguments:
+      $aggregationClass: 'eZ\Publish\API\Repository\Values\Content\Query\Aggregation\VisibilityTermAggregation'
+      $keyMapper: '@EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\BooleanAggregationKeyMapper'
+    tags:
+      - { name: ezplatform.search.solr.query.content.aggregation_result_extractor }
+
+  ### Location specific
+
+  ezplatform.search.solr.query.location.aggregation_result_extractor.visibility:
+    class: EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationResultExtractor
+    arguments:
+      $aggregationClass: 'eZ\Publish\API\Repository\Values\Content\Query\Aggregation\VisibilityTermAggregation'
+      $keyMapper: '@EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\InvertedBooleanAggregationKeyMapper'
+    tags:
+      - { name: ezplatform.search.solr.query.location.aggregation_result_extractor }

--- a/lib/Resources/config/container/solr/aggregation_visitors.yml
+++ b/lib/Resources/config/container/solr/aggregation_visitors.yml
@@ -1,0 +1,241 @@
+services:
+  _defaults:
+    autowire: true
+    autoconfigure: true
+    public: false
+
+  ezpublish.search.solr.query.content.aggregation_visitor.dispatcher:
+    class: EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\DispatcherAggregationVisitor
+    arguments:
+      $visitors: !tagged ezplatform.search.solr.query.content.aggregation_visitor
+
+  ezpublish.search.solr.query.location.aggregation_visitor.dispatcher:
+    class: EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\DispatcherAggregationVisitor
+    arguments:
+      $visitors: !tagged ezplatform.search.solr.query.location.aggregation_visitor
+
+  ### Factories
+
+  EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\Factory\ContentFieldAggregationVisitorFactory:
+    arguments:
+      $fieldNameResolver: '@ezpublish.search.common.field_name_resolver'
+
+  EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\Factory\RawAggregationVisitorFactory: ~
+
+  EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\Factory\SearchFieldAggregationVisitorFactory: ~
+
+  ### Aggregation visitors
+
+  ezpublish.search.solr.query.common.aggregation_visitor.content_type:
+    class: EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\TermAggregationVisitor
+    factory: ['@EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\Factory\SearchFieldAggregationVisitorFactory', 'createTermAggregationVisitor']
+    arguments:
+      $aggregationClass: 'eZ\Publish\API\Repository\Values\Content\Query\Aggregation\ContentTypeTermAggregation'
+      $searchIndexFieldName: 'content_type_id_id'
+    tags:
+      - { name: ezplatform.search.solr.query.content.aggregation_visitor }
+      - { name: ezplatform.search.solr.query.location.aggregation_visitor }
+
+  ezpublish.search.solr.query.common.aggregation_visitor.content_type_group:
+    class: EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\TermAggregationVisitor
+    factory: ['@EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\Factory\SearchFieldAggregationVisitorFactory', 'createTermAggregationVisitor']
+    arguments:
+      $aggregationClass: 'eZ\Publish\API\Repository\Values\Content\Query\Aggregation\ContentTypeGroupTermAggregation'
+      $searchIndexFieldName: 'content_type_group_ids_mid'
+    tags:
+      - { name: ezplatform.search.solr.query.content.aggregation_visitor }
+      - { name: ezplatform.search.solr.query.location.aggregation_visitor }
+
+  ezpublish.search.solr.query.common.aggregation_visitor.field.checkbox_term:
+    class: EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\TermAggregationVisitor
+    factory: ['@EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\Factory\ContentFieldAggregationVisitorFactory', 'createTermAggregationVisitor']
+    arguments:
+      $aggregationClass: 'eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\CheckboxTermAggregation'
+      $searchIndexFieldName: 'value'
+    tags:
+      - { name: ezplatform.search.solr.query.content.aggregation_visitor }
+      - { name: ezplatform.search.solr.query.location.aggregation_visitor }
+
+  ezpublish.search.solr.query.common.aggregation_visitor.field.date_range:
+    class: EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\RangeAggregationVisitor
+    factory: ['@EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\Factory\ContentFieldAggregationVisitorFactory', 'createRangeAggregationVisitor']
+    arguments:
+      $aggregationClass: 'eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\DateRangeAggregation'
+      $searchIndexFieldName: 'value'
+    tags:
+      - { name: ezplatform.search.solr.query.content.aggregation_visitor }
+      - { name: ezplatform.search.solr.query.location.aggregation_visitor }
+
+  ezpublish.search.solr.query.common.aggregation_visitor.field.datetime_range:
+    class: EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\RangeAggregationVisitor
+    factory: ['@EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\Factory\ContentFieldAggregationVisitorFactory', 'createRangeAggregationVisitor']
+    arguments:
+      $aggregationClass: 'eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\DateTimeRangeAggregation'
+      $searchIndexFieldName: 'value'
+    tags:
+      - { name: ezplatform.search.solr.query.content.aggregation_visitor }
+      - { name: ezplatform.search.solr.query.location.aggregation_visitor }
+
+  ezpublish.search.solr.query.common.aggregation_visitor.field.country_term:
+    class: EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\TermAggregationVisitor
+    factory: ['@EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\Factory\ContentFieldAggregationVisitorFactory', 'createTermAggregationVisitor']
+    arguments:
+      $aggregationClass: 'eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\CountryTermAggregation'
+      $searchIndexFieldName: 'idc'
+    tags:
+      - { name: ezplatform.search.solr.query.content.aggregation_visitor }
+      - { name: ezplatform.search.solr.query.location.aggregation_visitor }
+
+  ezpublish.search.solr.query.common.aggregation_visitor.field.float_range:
+    class: EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\RangeAggregationVisitor
+    factory: ['@EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\Factory\ContentFieldAggregationVisitorFactory', 'createRangeAggregationVisitor']
+    arguments:
+      $aggregationClass: 'eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\FloatRangeAggregation'
+      $searchIndexFieldName: 'value'
+    tags:
+      - { name: ezplatform.search.solr.query.content.aggregation_visitor }
+      - { name: ezplatform.search.solr.query.location.aggregation_visitor }
+
+  ezpublish.search.solr.query.common.aggregation_visitor.field.float_stats:
+    class: EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\StatsAggregationVisitor
+    factory: ['@EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\Factory\ContentFieldAggregationVisitorFactory', 'createStatsAggregationVisitor']
+    arguments:
+      $aggregationClass: 'eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\FloatStatsAggregation'
+      $searchIndexFieldName: 'value'
+    tags:
+      - { name: ezplatform.search.solr.query.content.aggregation_visitor }
+      - { name: ezplatform.search.solr.query.location.aggregation_visitor }
+
+  ezpublish.search.solr.query.common.aggregation_visitor.field.integer_range:
+    class: EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\RangeAggregationVisitor
+    factory: ['@EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\Factory\ContentFieldAggregationVisitorFactory', 'createRangeAggregationVisitor']
+    arguments:
+      $aggregationClass: 'eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\IntegerRangeAggregation'
+      $searchIndexFieldName: 'value'
+    tags:
+      - { name: ezplatform.search.solr.query.content.aggregation_visitor }
+      - { name: ezplatform.search.solr.query.location.aggregation_visitor }
+
+  ezpublish.search.solr.query.common.aggregation_visitor.field.integer_stats:
+    class: EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\StatsAggregationVisitor
+    factory: ['@EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\Factory\ContentFieldAggregationVisitorFactory', 'createStatsAggregationVisitor']
+    arguments:
+      $aggregationClass: 'eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\IntegerStatsAggregation'
+      $searchIndexFieldName: 'value'
+    tags:
+      - { name: ezplatform.search.solr.query.content.aggregation_visitor }
+      - { name: ezplatform.search.solr.query.location.aggregation_visitor }
+
+  ezpublish.search.solr.query.common.aggregation_visitor.field.keyword_term:
+    class: EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\TermAggregationVisitor
+    factory: ['@EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\Factory\ContentFieldAggregationVisitorFactory', 'createTermAggregationVisitor']
+    arguments:
+      $aggregationClass: 'eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\KeywordTermAggregation'
+      $searchIndexFieldName: 'value'
+    tags:
+      - { name: ezplatform.search.solr.query.content.aggregation_visitor }
+      - { name: ezplatform.search.solr.query.location.aggregation_visitor }
+
+  ezpublish.search.solr.query.common.aggregation_visitor.field.selection_term:
+    class: EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\TermAggregationVisitor
+    factory: ['@EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\Factory\ContentFieldAggregationVisitorFactory', 'createTermAggregationVisitor']
+    arguments:
+      $aggregationClass: 'eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\SelectionTermAggregation'
+      $searchIndexFieldName: 'selected_option_value'
+    tags:
+      - { name: ezplatform.search.solr.query.content.aggregation_visitor }
+      - { name: ezplatform.search.solr.query.location.aggregation_visitor }
+
+  ezpublish.search.solr.query.common.aggregation_visitor.field.time_range:
+    class: EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\RangeAggregationVisitor
+    factory: ['@EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\Factory\ContentFieldAggregationVisitorFactory', 'createRangeAggregationVisitor']
+    arguments:
+      $aggregationClass: 'eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\TimeRangeAggregation'
+      $searchIndexFieldName: 'value'
+    tags:
+      - { name: ezplatform.search.solr.query.content.aggregation_visitor }
+      - { name: ezplatform.search.solr.query.location.aggregation_visitor }
+
+  ezpublish.search.solr.query.common.aggregation_visitor.language:
+    class: EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\TermAggregationVisitor
+    factory: ['@EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\Factory\SearchFieldAggregationVisitorFactory', 'createTermAggregationVisitor']
+    arguments:
+      $aggregationClass: 'eZ\Publish\API\Repository\Values\Content\Query\Aggregation\LanguageTermAggregation'
+      $searchIndexFieldName: 'content_language_codes_raw_mid'
+    tags:
+      - { name: ezplatform.search.solr.query.content.aggregation_visitor }
+      - { name: ezplatform.search.solr.query.location.aggregation_visitor }
+
+  ezpublish.search.solr.query.common.aggregation_visitor.raw_range:
+    class: EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\RangeAggregationVisitor
+    factory: ['@EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\Factory\RawAggregationVisitorFactory', 'createRangeAggregationVisitor']
+    arguments:
+      $aggregationClass: 'eZ\Publish\API\Repository\Values\Content\Query\Aggregation\RawRangeAggregation'
+    tags:
+      - { name: ezplatform.search.solr.query.content.aggregation_visitor }
+      - { name: ezplatform.search.solr.query.location.aggregation_visitor }
+
+  ezpublish.search.solr.query.common.aggregation_visitor.raw_stats:
+    class: EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\StatsAggregationVisitor
+    factory: ['@EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\Factory\RawAggregationVisitorFactory', 'createStatsAggregationVisitor']
+    arguments:
+      $aggregationClass: 'eZ\Publish\API\Repository\Values\Content\Query\Aggregation\RawStatsAggregation'
+    tags:
+      - { name: ezplatform.search.solr.query.content.aggregation_visitor }
+      - { name: ezplatform.search.solr.query.location.aggregation_visitor }
+
+  ezpublish.search.solr.query.common.aggregation_visitor.raw_term:
+    class: EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\TermAggregationVisitor
+    factory: ['@EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\Factory\RawAggregationVisitorFactory', 'createTermAggregationVisitor']
+    arguments:
+      $aggregationClass: 'eZ\Publish\API\Repository\Values\Content\Query\Aggregation\RawTermAggregation'
+    tags:
+      - { name: ezplatform.search.solr.query.content.aggregation_visitor }
+      - { name: ezplatform.search.solr.query.location.aggregation_visitor }
+
+  ezpublish.search.solr.query.common.aggregation_visitor.section:
+    class: EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\TermAggregationVisitor
+    factory: ['@EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\Factory\SearchFieldAggregationVisitorFactory', 'createTermAggregationVisitor']
+    arguments:
+      $aggregationClass: 'eZ\Publish\API\Repository\Values\Content\Query\Aggregation\SectionTermAggregation'
+      $searchIndexFieldName: 'content_section_id_id'
+    tags:
+      - { name: ezplatform.search.solr.query.content.aggregation_visitor }
+      - { name: ezplatform.search.solr.query.location.aggregation_visitor }
+
+  EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\DateMetadataRangeAggregationVisitor:
+    tags:
+      - { name: ezplatform.search.solr.query.content.aggregation_visitor }
+      - { name: ezplatform.search.solr.query.location.aggregation_visitor }
+
+  EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\ObjectStateAggregationVisitor:
+    tags:
+      - { name: ezplatform.search.solr.query.content.aggregation_visitor }
+      - { name: ezplatform.search.solr.query.location.aggregation_visitor }
+
+  EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\UserMetadataTermAggregationVisitor:
+    tags:
+      - { name: ezplatform.search.solr.query.content.aggregation_visitor }
+      - { name: ezplatform.search.solr.query.location.aggregation_visitor }
+
+  ### Content specific visitors
+
+  ezpublish.search.solr.query.content.aggregation_visitor.visibility:
+    class: EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\TermAggregationVisitor
+    factory: ['@EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\Factory\SearchFieldAggregationVisitorFactory', 'createTermAggregationVisitor']
+    arguments:
+      $aggregationClass: 'eZ\Publish\API\Repository\Values\Content\Query\Aggregation\VisibilityTermAggregation'
+      $searchIndexFieldName: 'location_visible_b'
+    tags:
+      - { name: ezplatform.search.solr.query.content.aggregation_visitor }
+
+  ### Location specific visitors
+
+  ezpublish.search.solr.query.location.aggregation_visitor.visibility:
+    class: EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\TermAggregationVisitor
+    factory: ['@EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\Factory\SearchFieldAggregationVisitorFactory', 'createTermAggregationVisitor']
+    arguments:
+      $aggregationClass: 'eZ\Publish\API\Repository\Values\Content\Query\Aggregation\VisibilityTermAggregation'
+      $searchIndexFieldName: 'invisible_b'
+    tags:
+      - { name: ezplatform.search.solr.query.location.aggregation_visitor }

--- a/lib/ResultExtractor/AggregationResultExtractor.php
+++ b/lib/ResultExtractor/AggregationResultExtractor.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\ResultExtractor;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use eZ\Publish\API\Repository\Values\Content\Search\AggregationResult;
+use stdClass;
+
+interface AggregationResultExtractor
+{
+    public function canVisit(Aggregation $aggregation, array $languageFilter): bool;
+
+    public function extract(Aggregation $aggregation, array $languageFilter, stdClass $data): AggregationResult;
+}

--- a/lib/ResultExtractor/AggregationResultExtractor/DispatcherAggregationResultExtractor.php
+++ b/lib/ResultExtractor/AggregationResultExtractor/DispatcherAggregationResultExtractor.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor;
+
+use eZ\Publish\API\Repository\Exceptions\NotImplementedException;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use eZ\Publish\API\Repository\Values\Content\Search\AggregationResult;
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor;
+use stdClass;
+
+final class DispatcherAggregationResultExtractor implements AggregationResultExtractor
+{
+    /** @var \EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor[] */
+    private $extractors;
+
+    /**
+     * @param \EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor[] $extractors
+     */
+    public function __construct(iterable $extractors)
+    {
+        $this->extractors = $extractors;
+    }
+
+    public function canVisit(Aggregation $aggregation, array $languageFilter): bool
+    {
+        return $this->findExtractor($aggregation, $languageFilter) !== null;
+    }
+
+    public function extract(Aggregation $aggregation, array $languageFilter, stdClass $data): AggregationResult
+    {
+        $extractor = $this->findExtractor($aggregation, $languageFilter);
+
+        if ($extractor === null) {
+            throw new NotImplementedException(
+                'No result extractor available for aggregation: ' . get_class($aggregation)
+            );
+        }
+
+        return $extractor->extract($aggregation, $languageFilter, $data);
+    }
+
+    private function findExtractor(
+        Aggregation $aggregation,
+        array $languageFilter
+    ): ?AggregationResultExtractor {
+        foreach ($this->extractors as $extractor) {
+            if ($extractor->canVisit($aggregation, $languageFilter)) {
+                return $extractor;
+            }
+        }
+
+        return null;
+    }
+}

--- a/lib/ResultExtractor/AggregationResultExtractor/RangeAggregationKeyMapper.php
+++ b/lib/ResultExtractor/AggregationResultExtractor/RangeAggregationKeyMapper.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+
+interface RangeAggregationKeyMapper
+{
+    public function map(Aggregation $aggregation, array $languageFilter, string $key);
+}

--- a/lib/ResultExtractor/AggregationResultExtractor/RangeAggregationKeyMapper/DateTimeRangeAggregationKeyMapper.php
+++ b/lib/ResultExtractor/AggregationResultExtractor/RangeAggregationKeyMapper/DateTimeRangeAggregationKeyMapper.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\RangeAggregationKeyMapper;
+
+use DateTimeImmutable;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\RangeAggregationKeyMapper;
+
+final class DateTimeRangeAggregationKeyMapper implements RangeAggregationKeyMapper
+{
+    public function map(Aggregation $aggregation, array $languageFilter, string $key)
+    {
+        if ($key === '*') {
+            return null;
+        }
+
+        return new DateTimeImmutable($key);
+    }
+}

--- a/lib/ResultExtractor/AggregationResultExtractor/RangeAggregationKeyMapper/FloatRangeAggregationKeyMapper.php
+++ b/lib/ResultExtractor/AggregationResultExtractor/RangeAggregationKeyMapper/FloatRangeAggregationKeyMapper.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\RangeAggregationKeyMapper;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\RangeAggregationKeyMapper;
+
+final class FloatRangeAggregationKeyMapper implements RangeAggregationKeyMapper
+{
+    public function map(Aggregation $aggregation, array $languageFilter, string $key)
+    {
+        if ($key === '*') {
+            return null;
+        }
+
+        return (float)$key;
+    }
+}

--- a/lib/ResultExtractor/AggregationResultExtractor/RangeAggregationKeyMapper/IntRangeAggregationKeyMapper.php
+++ b/lib/ResultExtractor/AggregationResultExtractor/RangeAggregationKeyMapper/IntRangeAggregationKeyMapper.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\RangeAggregationKeyMapper;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\RangeAggregationKeyMapper;
+
+final class IntRangeAggregationKeyMapper implements RangeAggregationKeyMapper
+{
+    public function map(Aggregation $aggregation, array $languageFilter, string $key)
+    {
+        if ($key === '*') {
+            return null;
+        }
+
+        return (int)$key;
+    }
+}

--- a/lib/ResultExtractor/AggregationResultExtractor/RangeAggregationKeyMapper/NullRangeAggregationKeyMapper.php
+++ b/lib/ResultExtractor/AggregationResultExtractor/RangeAggregationKeyMapper/NullRangeAggregationKeyMapper.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\RangeAggregationKeyMapper;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\RangeAggregationKeyMapper;
+
+final class NullRangeAggregationKeyMapper implements RangeAggregationKeyMapper
+{
+    public function map(Aggregation $aggregation, array $languageFilter, string $key)
+    {
+        if ($key === '*') {
+            return null;
+        }
+
+        return $key;
+    }
+}

--- a/lib/ResultExtractor/AggregationResultExtractor/RangeAggregationResultExtractor.php
+++ b/lib/ResultExtractor/AggregationResultExtractor/RangeAggregationResultExtractor.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Range;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use eZ\Publish\API\Repository\Values\Content\Search\AggregationResult;
+use eZ\Publish\API\Repository\Values\Content\Search\AggregationResult\RangeAggregationResult;
+use eZ\Publish\API\Repository\Values\Content\Search\AggregationResult\RangeAggregationResultEntry;
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor;
+use stdClass;
+
+final class RangeAggregationResultExtractor implements AggregationResultExtractor
+{
+    /** @var string */
+    private $aggregationClass;
+
+    /** @var \EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\RangeAggregationKeyMapper */
+    private $keyMapper;
+
+    public function __construct(string $aggregationClass, RangeAggregationKeyMapper $keyMapper)
+    {
+        $this->aggregationClass = $aggregationClass;
+        $this->keyMapper = $keyMapper;
+    }
+
+    public function canVisit(Aggregation $aggregation, array $languageFilter): bool
+    {
+        return $aggregation instanceof $this->aggregationClass;
+    }
+
+    public function extract(Aggregation $aggregation, array $languageFilter, stdClass $data): AggregationResult
+    {
+        $entries = [];
+
+        foreach ($data as $key => $bucket) {
+            if ($key === 'count') {
+                continue;
+            }
+
+            if (strpos($key, '_') === false) {
+                continue;
+            }
+
+            list($from, $to) = explode('_', $key, 2);
+
+            $entries[] = new RangeAggregationResultEntry(
+                new Range(
+                    $this->keyMapper->map($aggregation, $languageFilter, $from),
+                    $this->keyMapper->map($aggregation, $languageFilter, $to),
+                ),
+                $bucket->count
+            );
+        }
+
+        return new RangeAggregationResult($aggregation->getName(), $entries);
+    }
+}

--- a/lib/ResultExtractor/AggregationResultExtractor/StatsAggregationResultExtractor.php
+++ b/lib/ResultExtractor/AggregationResultExtractor/StatsAggregationResultExtractor.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use eZ\Publish\API\Repository\Values\Content\Search\AggregationResult;
+use eZ\Publish\API\Repository\Values\Content\Search\AggregationResult\StatsAggregationResult;
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor;
+use stdClass;
+
+final class StatsAggregationResultExtractor implements AggregationResultExtractor
+{
+    /** @var string */
+    private $aggregationClass;
+
+    public function __construct(string $aggregationClass)
+    {
+        $this->aggregationClass = $aggregationClass;
+    }
+
+    public function canVisit(Aggregation $aggregation, array $languageFilter): bool
+    {
+        return $aggregation instanceof $this->aggregationClass;
+    }
+
+    public function extract(Aggregation $aggregation, array $languageFilter, stdClass $data): AggregationResult
+    {
+        return new StatsAggregationResult(
+            $aggregation->getName(),
+            $data->count ?? null,
+            $data->min ?? null,
+            $data->max ?? null,
+            $data->avg ?? null,
+            $data->sum ?? null,
+        );
+    }
+}

--- a/lib/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper.php
+++ b/lib/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+
+interface TermAggregationKeyMapper
+{
+    public function map(Aggregation $aggregation, array $languageFilter, array $keys): array;
+}

--- a/lib/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/BooleanAggregationKeyMapper.php
+++ b/lib/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/BooleanAggregationKeyMapper.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper;
+
+final class BooleanAggregationKeyMapper implements TermAggregationKeyMapper
+{
+    public function map(Aggregation $aggregation, array $languageFilter, array $keys): array
+    {
+        return [
+            true => true,
+            false => false,
+        ];
+    }
+}

--- a/lib/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/ContentTypeAggregationKeyMapper.php
+++ b/lib/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/ContentTypeAggregationKeyMapper.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper;
+
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper;
+
+final class ContentTypeAggregationKeyMapper implements TermAggregationKeyMapper
+{
+    /** @var \eZ\Publish\API\Repository\ContentTypeService */
+    private $contentTypeService;
+
+    public function __construct(ContentTypeService $contentTypeService)
+    {
+        $this->contentTypeService = $contentTypeService;
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Aggregation\ContentTypeTermAggregation $aggregation
+     * @param array $languageFilter
+     * @param string[] $keys
+     *
+     * @return \eZ\Publish\API\Repository\Values\ContentType\ContentType[]
+     */
+    public function map(Aggregation $aggregation, array $languageFilter, array $keys): array
+    {
+        $result = [];
+
+        $contentTypes = $this->contentTypeService->loadContentTypeList(array_map('intval', $keys));
+        foreach ($contentTypes as $contentType) {
+            $result["{$contentType->id}"] = $contentType;
+        }
+
+        return $result;
+    }
+}

--- a/lib/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/ContentTypeGroupAggregationKeyMapper.php
+++ b/lib/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/ContentTypeGroupAggregationKeyMapper.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper;
+
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper;
+
+final class ContentTypeGroupAggregationKeyMapper implements TermAggregationKeyMapper
+{
+    /** @var \eZ\Publish\API\Repository\ContentTypeService */
+    private $contentTypeService;
+
+    public function __construct(ContentTypeService $contentTypeService)
+    {
+        $this->contentTypeService = $contentTypeService;
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Aggregation\ContentTypeGroupTermAggregation $aggregation
+     * @param string[] $keys
+     *
+     * @return \eZ\Publish\API\Repository\Values\ContentType\ContentTypeGroup[]
+     */
+    public function map(Aggregation $aggregation, array $languageFilter, array $keys): array
+    {
+        $result = [];
+
+        foreach ($keys as $key) {
+            try {
+                $result[$key] = $this->contentTypeService->loadContentTypeGroup((int)$key);
+            } catch (NotFoundException $e) {
+                // Skip missing content type groups
+            }
+        }
+
+        return $result;
+    }
+}

--- a/lib/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/CountryAggregationKeyMapper.php
+++ b/lib/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/CountryAggregationKeyMapper.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\CountryTermAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper;
+
+final class CountryAggregationKeyMapper implements TermAggregationKeyMapper
+{
+    /** @var array */
+    private $countriesInfo;
+
+    /**
+     * @param array $countriesInfo Array of countries data
+     */
+    public function __construct(array $countriesInfo)
+    {
+        $this->countriesInfo = $countriesInfo;
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\CountryTermAggregation $aggregation
+     */
+    public function map(Aggregation $aggregation, array $languageFilter, array $keys): array
+    {
+        $results = [];
+        foreach ($keys as $key) {
+            $results[$key] = $this->mapKey($aggregation, $key);
+        }
+
+        return $results;
+    }
+
+    private function mapKey(Aggregation $aggregation, int $key): ?string
+    {
+        $countryInfo = $this->findCountryInfoByIDC($key);
+
+        if ($countryInfo === null) {
+            return null;
+        }
+
+        switch ($aggregation->getType()) {
+            case CountryTermAggregation::TYPE_NAME:
+                return $countryInfo['Name'];
+            case CountryTermAggregation::TYPE_IDC:
+                return $countryInfo['IDC'];
+            case CountryTermAggregation::TYPE_ALPHA_2:
+                return $countryInfo['Alpha2'];
+            case CountryTermAggregation::TYPE_ALPHA_3:
+                return $countryInfo['Alpha3'];
+            default:
+                return null;
+        }
+    }
+
+    private function findCountryInfoByIDC(int $idc): ?array
+    {
+        foreach ($this->countriesInfo as $countryInfo) {
+            if ((int)$countryInfo['IDC'] === $idc) {
+                return $countryInfo;
+            }
+        }
+
+        return null;
+    }
+}

--- a/lib/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/InvertedBooleanAggregationKeyMapper.php
+++ b/lib/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/InvertedBooleanAggregationKeyMapper.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper;
+
+final class InvertedBooleanAggregationKeyMapper implements TermAggregationKeyMapper
+{
+    public function map(Aggregation $aggregation, array $languageFilter, array $keys): array
+    {
+        return [
+            true => false,
+            false => true,
+        ];
+    }
+}

--- a/lib/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/LanguageAggregationKeyMapper.php
+++ b/lib/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/LanguageAggregationKeyMapper.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper;
+
+use eZ\Publish\API\Repository\LanguageService;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper;
+
+final class LanguageAggregationKeyMapper implements TermAggregationKeyMapper
+{
+    /** @var \eZ\Publish\API\Repository\LanguageService */
+    private $languageService;
+
+    public function __construct(LanguageService $languageService)
+    {
+        $this->languageService = $languageService;
+    }
+
+    public function map(Aggregation $aggregation, array $languageFilter, array $keys): array
+    {
+        $result = [];
+
+        $languages = $this->languageService->loadLanguageListByCode($keys);
+        foreach ($languages as $language) {
+            $result[$language->languageCode] = $language;
+        }
+
+        return $result;
+    }
+}

--- a/lib/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/LocationAggregationKeyMapper.php
+++ b/lib/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/LocationAggregationKeyMapper.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper;
+
+use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper;
+
+final class LocationAggregationKeyMapper implements TermAggregationKeyMapper
+{
+    /** @var \eZ\Publish\API\Repository\LocationService */
+    private $locationService;
+
+    public function __construct(LocationService $locationService)
+    {
+        $this->locationService = $locationService;
+    }
+
+    public function map(Aggregation $aggregation, array $languageFilter, array $keys): array
+    {
+        $result = [];
+
+        $locations = $this->locationService->loadLocationList(array_map('intval', $keys));
+        foreach ($locations as $id => $location) {
+            $result["$id"] = $location;
+        }
+
+        return $result;
+    }
+}

--- a/lib/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/NullAggregationKeyMapper.php
+++ b/lib/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/NullAggregationKeyMapper.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper;
+
+final class NullAggregationKeyMapper implements TermAggregationKeyMapper
+{
+    public function map(Aggregation $aggregation, array $languageFilter, array $keys): array
+    {
+        return array_combine($keys, $keys);
+    }
+}

--- a/lib/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/ObjectStateAggregationKeyMapper.php
+++ b/lib/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/ObjectStateAggregationKeyMapper.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper;
+
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+use eZ\Publish\API\Repository\ObjectStateService;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper;
+
+final class ObjectStateAggregationKeyMapper implements TermAggregationKeyMapper
+{
+    /** @var \eZ\Publish\API\Repository\ObjectStateService */
+    private $objectStateService;
+
+    public function __construct(ObjectStateService $objectStateService)
+    {
+        $this->objectStateService = $objectStateService;
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Aggregation\ObjectStateTermAggregation $aggregation
+     */
+    public function map(Aggregation $aggregation, array $languageFilter, array $keys): array
+    {
+        $objectStateGroup = $this->objectStateService->loadObjectStateGroupByIdentifier(
+            $aggregation->getObjectStateGroupIdentifier()
+        );
+
+        $mapped = [];
+        foreach ($keys as $key) {
+            list(, $stateIdentifier) = explode(':', $key, 2);
+
+            try {
+                $mapped[$key] = $this->objectStateService->loadObjectStateByIdentifier(
+                    $objectStateGroup,
+                    $stateIdentifier
+                );
+            } catch (NotFoundException $e) {
+                // Skip non-existing object states
+            }
+        }
+
+        return $mapped;
+    }
+}

--- a/lib/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/SectionAggregationKeyMapper.php
+++ b/lib/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/SectionAggregationKeyMapper.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper;
+
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
+use eZ\Publish\API\Repository\SectionService;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper;
+
+final class SectionAggregationKeyMapper implements TermAggregationKeyMapper
+{
+    /** @var \eZ\Publish\API\Repository\SectionService */
+    private $sectionService;
+
+    public function __construct(SectionService $sectionService)
+    {
+        $this->sectionService = $sectionService;
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Aggregation\SectionTermAggregation $aggregation
+     * @param array $languageFilter
+     * @param string[] $keys
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Section[]
+     */
+    public function map(Aggregation $aggregation, array $languageFilter, array $keys): array
+    {
+        $result = [];
+        foreach ($keys as $key) {
+            try {
+                $result[$key] = $this->sectionService->loadSection((int)$key);
+            } catch (NotFoundException | UnauthorizedException $e) {
+                // Skip missing section
+            }
+        }
+
+        return $result;
+    }
+}

--- a/lib/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/UserMetadataAggregationKeyMapper.php
+++ b/lib/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/UserMetadataAggregationKeyMapper.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper;
+
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
+use eZ\Publish\API\Repository\UserService;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\UserMetadataTermAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper;
+
+final class UserMetadataAggregationKeyMapper implements TermAggregationKeyMapper
+{
+    /** @var \eZ\Publish\API\Repository\UserService */
+    private $userService;
+
+    public function __construct(UserService $userService)
+    {
+        $this->userService = $userService;
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Aggregation\UserMetadataTermAggregation $aggregation
+     * @param string[] $keys
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\User[]
+     */
+    public function map(Aggregation $aggregation, array $languageFilter, array $keys): array
+    {
+        $loader = $this->resolveKeyLoader($aggregation);
+
+        $results = [];
+        foreach ($keys as $key) {
+            try {
+                $results[$key] = $loader((int)$key);
+            } catch (NotFoundException | UnauthorizedException $e) {
+                // Skip missing users / user groups
+            }
+        }
+
+        return $results;
+    }
+
+    private function resolveKeyLoader(Aggregation $aggregation): callable
+    {
+        switch ($aggregation->getType()) {
+            case UserMetadataTermAggregation::OWNER:
+            case UserMetadataTermAggregation::MODIFIER:
+                return [$this->userService, 'loadUser'];
+            case UserMetadataTermAggregation::GROUP:
+                return [$this->userService, 'loadUserGroup'];
+        }
+    }
+}

--- a/lib/ResultExtractor/AggregationResultExtractor/TermAggregationResultExtractor.php
+++ b/lib/ResultExtractor/AggregationResultExtractor/TermAggregationResultExtractor.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use eZ\Publish\API\Repository\Values\Content\Search\AggregationResult;
+use eZ\Publish\API\Repository\Values\Content\Search\AggregationResult\TermAggregationResult;
+use eZ\Publish\API\Repository\Values\Content\Search\AggregationResult\TermAggregationResultEntry;
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor;
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\NullAggregationKeyMapper;
+use stdClass;
+
+final class TermAggregationResultExtractor implements AggregationResultExtractor
+{
+    /** @var \EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper */
+    private $keyMapper;
+
+    /** @var string */
+    private $aggregationClass;
+
+    public function __construct(string $aggregationClass, TermAggregationKeyMapper $keyMapper = null)
+    {
+        if ($keyMapper === null) {
+            $keyMapper = new NullAggregationKeyMapper();
+        }
+
+        $this->keyMapper = $keyMapper;
+        $this->aggregationClass = $aggregationClass;
+    }
+
+    public function canVisit(Aggregation $aggregation, array $languageFilter): bool
+    {
+        return $aggregation instanceof $this->aggregationClass;
+    }
+
+    public function extract(Aggregation $aggregation, array $languageFilter, stdClass $data): AggregationResult
+    {
+        $entries = [];
+
+        $mappedKeys = $this->keyMapper->map(
+            $aggregation,
+            $languageFilter,
+            $this->getKeys($data)
+        );
+
+        foreach ($data->buckets as $bucket) {
+            $key = $bucket->val;
+
+            if (isset($mappedKeys[$key])) {
+                $entries[] = new TermAggregationResultEntry(
+                    $mappedKeys[$key],
+                    $bucket->count
+                );
+            }
+        }
+
+        return new TermAggregationResult($aggregation->getName(), $entries);
+    }
+
+    private function getKeys(stdClass $data): array
+    {
+        $keys = [];
+        foreach ($data->buckets as $bucket) {
+            $keys[] = $bucket->val;
+        }
+
+        return $keys;
+    }
+}

--- a/tests/lib/Search/Query/Common/AggregationVisitor/AbstractAggregationVisitorTest.php
+++ b/tests/lib/Search/Query/Common/AggregationVisitor/AbstractAggregationVisitorTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\Tests\Search\Query\Common\AggregationVisitor;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use EzSystems\EzPlatformSolrSearchEngine\Query\AggregationVisitor;
+use PHPUnit\Framework\TestCase;
+
+abstract class AbstractAggregationVisitorTest extends TestCase
+{
+    protected const EXAMPLE_LANGUAGE_FILTER = [
+        'languageCode' => 'eng-gb',
+    ];
+
+    /** @var \EzSystems\EzPlatformSolrSearchEngine\Query\AggregationVisitor */
+    protected $visitor;
+
+    /** @var \EzSystems\EzPlatformSolrSearchEngine\Query\AggregationVisitor|\PHPUnit\Framework\MockObject\MockObject */
+    protected $dispatcherVisitor;
+
+    protected function setUp(): void
+    {
+        $this->visitor = $this->createVisitor();
+        $this->dispatcherVisitor = $this->createMock(AggregationVisitor::class);
+    }
+
+    abstract protected function createVisitor(): AggregationVisitor;
+
+    /**
+     * @dataProvider dataProviderForCanVisit
+     */
+    final public function testCanVisit(
+        Aggregation $aggregation,
+        array $languageFilter,
+        bool $expectedValue
+    ): void {
+        $this->assertEquals(
+            $expectedValue,
+            $this->visitor->canVisit($aggregation, $languageFilter)
+        );
+    }
+
+    abstract public function dataProviderForCanVisit(): iterable;
+
+    /**
+     * @dataProvider dataProviderForVisit
+     */
+    final public function testVisit(
+        Aggregation $aggregation,
+        array $languageFilter,
+        array $expectedResult
+    ): void {
+        $this->configureMocksForTestVisit($aggregation, $languageFilter, $expectedResult);
+
+        $this->assertEquals(
+            $expectedResult,
+            $this->visitor->visit($this->dispatcherVisitor, $aggregation, $languageFilter)
+        );
+    }
+
+    abstract public function dataProviderForVisit(): iterable;
+
+    protected function configureMocksForTestVisit(
+        Aggregation $aggregation,
+        array $languageFilter,
+        array $expectedResult
+    ): void {
+        // Overwrite in parent class to configure additional mocks
+    }
+}

--- a/tests/lib/Search/Query/Common/AggregationVisitor/AggregationFieldResolver/SearchFieldAggregationFieldResolverTest.php
+++ b/tests/lib/Search/Query/Common/AggregationVisitor/AggregationFieldResolver/SearchFieldAggregationFieldResolverTest.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\Tests\Search\Query\Common\AggregationVisitor\AggregationFieldResolver;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\AggregationFieldResolver\SearchFieldAggregationFieldResolver;
+use PHPUnit\Framework\TestCase;
+
+final class SearchFieldAggregationFieldResolverTest extends TestCase
+{
+    public function testResolveTargetField(): void
+    {
+        $aggregation = $this->createMock(Aggregation::class);
+
+        $aggregationFieldResolver = new SearchFieldAggregationFieldResolver('custom_field_id');
+
+        $this->assertEquals(
+            'custom_field_id',
+            $aggregationFieldResolver->resolveTargetField($aggregation)
+        );
+    }
+}

--- a/tests/lib/Search/Query/Common/AggregationVisitor/DateMetadataRangeAggregationVisitorTest.php
+++ b/tests/lib/Search/Query/Common/AggregationVisitor/DateMetadataRangeAggregationVisitorTest.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\Tests\Search\Query\Common\AggregationVisitor;
+
+use DateTime;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\DateMetadataRangeAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Range;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use EzSystems\EzPlatformSolrSearchEngine\Query\AggregationVisitor;
+use EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\DateMetadataRangeAggregationVisitor;
+
+final class DateMetadataRangeAggregationVisitorTest extends AbstractAggregationVisitorTest
+{
+    protected function createVisitor(): AggregationVisitor
+    {
+        return new DateMetadataRangeAggregationVisitor();
+    }
+
+    public function dataProviderForCanVisit(): iterable
+    {
+        yield 'true' => [
+             new DateMetadataRangeAggregation('foo', DateMetadataRangeAggregation::PUBLISHED, []),
+            self::EXAMPLE_LANGUAGE_FILTER,
+            true,
+        ];
+
+        yield 'false' => [
+            $this->createMock(Aggregation::class),
+            self::EXAMPLE_LANGUAGE_FILTER,
+            false,
+        ];
+    }
+
+    public function dataProviderForVisit(): iterable
+    {
+        $ranges = [
+            new Range(
+                null,
+                new DateTime('2018-01-01 00:00:00')
+            ),
+            new Range(
+                new DateTime('2018-01-01 00:00:00'),
+                new DateTime('2019-01-01 00:00:00')
+            ),
+            new Range(
+                new DateTime('2019-01-01 00:00:00'),
+                null
+            ),
+        ];
+
+        yield DateMetadataRangeAggregation::PUBLISHED => [
+            new DateMetadataRangeAggregation('typical', DateMetadataRangeAggregation::PUBLISHED, $ranges),
+            self::EXAMPLE_LANGUAGE_FILTER,
+            [
+                'type' => 'query',
+                'q' => '*:*',
+                'facet' => [
+                    '*_2018-01-01T00:00:00Z' => [
+                        'type' => 'query',
+                        'q' => 'content_publication_date_dt:[* TO 2018-01-01T00:00:00Z}',
+                    ],
+                    '2018-01-01T00:00:00Z_2019-01-01T00:00:00Z' => [
+                        'type' => 'query',
+                        'q' => 'content_publication_date_dt:[2018-01-01T00:00:00Z TO 2019-01-01T00:00:00Z}',
+                    ],
+                    '2019-01-01T00:00:00Z_*' => [
+                        'type' => 'query',
+                        'q' => 'content_publication_date_dt:[2019-01-01T00:00:00Z TO *}',
+                    ],
+                ],
+            ],
+        ];
+
+        yield DateMetadataRangeAggregation::MODIFIED => [
+            new DateMetadataRangeAggregation('typical', DateMetadataRangeAggregation::MODIFIED, $ranges),
+            self::EXAMPLE_LANGUAGE_FILTER,
+            [
+                'type' => 'query',
+                'q' => '*:*',
+                'facet' => [
+                    '*_2018-01-01T00:00:00Z' => [
+                        'type' => 'query',
+                        'q' => 'content_modification_date_dt:[* TO 2018-01-01T00:00:00Z}',
+                    ],
+                    '2018-01-01T00:00:00Z_2019-01-01T00:00:00Z' => [
+                        'type' => 'query',
+                        'q' => 'content_modification_date_dt:[2018-01-01T00:00:00Z TO 2019-01-01T00:00:00Z}',
+                    ],
+                    '2019-01-01T00:00:00Z_*' => [
+                        'type' => 'query',
+                        'q' => 'content_modification_date_dt:[2019-01-01T00:00:00Z TO *}',
+                    ],
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/lib/Search/Query/Common/AggregationVisitor/DispatcherAggregationVisitorTest.php
+++ b/tests/lib/Search/Query/Common/AggregationVisitor/DispatcherAggregationVisitorTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\Tests\Search\Query\Common\AggregationVisitor;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use EzSystems\EzPlatformSolrSearchEngine\Query\AggregationVisitor;
+use EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\DispatcherAggregationVisitor;
+use EzSystems\EzPlatformSolrSearchEngine\Tests\Search\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+
+final class DispatcherAggregationVisitorTest extends TestCase
+{
+    private const EXAMPLE_LANGUAGE_FILTER = [
+        'languageCode' => 'eng-gb',
+    ];
+
+    private const EXAMPLE_VISITOR_RESULT = [
+        'type' => 'terms',
+        'field' => 'foo',
+        'limit' => 100,
+        'mincount' => 10,
+    ];
+
+    public function testCanVisitOnSupportedAggregation(): void
+    {
+        $aggregation = $this->createMock(Aggregation::class);
+
+        $dispatcher = new DispatcherAggregationVisitor([
+            $this->createVisitorMock($aggregation, self::EXAMPLE_LANGUAGE_FILTER, false),
+            $this->createVisitorMock($aggregation, self::EXAMPLE_LANGUAGE_FILTER, true),
+            $this->createVisitorMock($aggregation, self::EXAMPLE_LANGUAGE_FILTER, false),
+        ]);
+
+        $this->assertTrue($dispatcher->canVisit($aggregation, self::EXAMPLE_LANGUAGE_FILTER));
+    }
+
+    public function testCanVisitOnNonSupportedAggregation(): void
+    {
+        $aggregation = $this->createMock(Aggregation::class);
+
+        $dispatcher = new DispatcherAggregationVisitor([
+            $this->createVisitorMock($aggregation, self::EXAMPLE_LANGUAGE_FILTER, false),
+            $this->createVisitorMock($aggregation, self::EXAMPLE_LANGUAGE_FILTER, false),
+            $this->createVisitorMock($aggregation, self::EXAMPLE_LANGUAGE_FILTER, false),
+        ]);
+
+        $this->assertFalse($dispatcher->canVisit($aggregation, self::EXAMPLE_LANGUAGE_FILTER));
+    }
+
+    public function testVisit(): void
+    {
+        $aggregation = $this->createMock(Aggregation::class);
+
+        $visitorA = $this->createVisitorMock($aggregation, self::EXAMPLE_LANGUAGE_FILTER, false);
+        $visitorB = $this->createVisitorMock($aggregation, self::EXAMPLE_LANGUAGE_FILTER, true);
+        $visitorC = $this->createVisitorMock($aggregation, self::EXAMPLE_LANGUAGE_FILTER, false);
+
+        $dispatcher = new DispatcherAggregationVisitor([$visitorA, $visitorB, $visitorC]);
+
+        $visitorB
+            ->method('visit')
+            ->with($dispatcher, $aggregation, self::EXAMPLE_LANGUAGE_FILTER)
+            ->willReturn(self::EXAMPLE_VISITOR_RESULT);
+
+        $this->assertEquals(
+            self::EXAMPLE_VISITOR_RESULT,
+            $dispatcher->visit($dispatcher, $aggregation, self::EXAMPLE_LANGUAGE_FILTER)
+        );
+    }
+
+    private function createVisitorMock(
+       Aggregation $aggregation,
+       array $languageFilter,
+       bool $supports
+    ): MockObject {
+        $visitor = $this->createMock(AggregationVisitor::class);
+        $visitor->method('canVisit')->with($aggregation, $languageFilter)->willReturn($supports);
+
+        return $visitor;
+    }
+}

--- a/tests/lib/Search/Query/Common/AggregationVisitor/ObjectStateGroupAggregationVisitorTest.php
+++ b/tests/lib/Search/Query/Common/AggregationVisitor/ObjectStateGroupAggregationVisitorTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\Tests\Search\Query\Common\AggregationVisitor;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\ObjectStateTermAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use EzSystems\EzPlatformSolrSearchEngine\Query\AggregationVisitor;
+use EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\ObjectStateAggregationVisitor;
+
+final class ObjectStateGroupAggregationVisitorTest extends AbstractAggregationVisitorTest
+{
+    protected function createVisitor(): AggregationVisitor
+    {
+        return new ObjectStateAggregationVisitor();
+    }
+
+    public function dataProviderForCanVisit(): iterable
+    {
+        yield 'true' => [
+            new ObjectStateTermAggregation('foo', 'ez_lock'),
+            self::EXAMPLE_LANGUAGE_FILTER,
+            true,
+        ];
+
+        yield 'false' => [
+            $this->createMock(Aggregation::class),
+            self::EXAMPLE_LANGUAGE_FILTER,
+            false,
+        ];
+    }
+
+    public function dataProviderForVisit(): iterable
+    {
+        yield 'defaults' => [
+            new ObjectStateTermAggregation('foo', 'ez_lock'),
+            self::EXAMPLE_LANGUAGE_FILTER,
+            [
+                'type' => 'terms',
+                'field' => 'content_object_state_identifiers_ms',
+                'prefix' => 'ez_lock:',
+                'limit' => ObjectStateTermAggregation::DEFAULT_LIMIT,
+                'mincount' => ObjectStateTermAggregation::DEFAULT_MIN_COUNT,
+            ],
+        ];
+
+        $aggregation = new ObjectStateTermAggregation('foo', 'ez_lock');
+        $aggregation->setLimit(100);
+        $aggregation->setMinCount(10);
+
+        yield 'custom' => [
+            $aggregation,
+            self::EXAMPLE_LANGUAGE_FILTER,
+            [
+                'type' => 'terms',
+                'field' => 'content_object_state_identifiers_ms',
+                'prefix' => 'ez_lock:',
+                'limit' => 100,
+                'mincount' => 10,
+            ],
+        ];
+    }
+}

--- a/tests/lib/Search/Query/Common/AggregationVisitor/RangeAggregationVisitorTest.php
+++ b/tests/lib/Search/Query/Common/AggregationVisitor/RangeAggregationVisitorTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\Tests\Search\Query\Common\AggregationVisitor;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\AbstractRangeAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Range;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use EzSystems\EzPlatformSolrSearchEngine\Query\AggregationVisitor;
+use EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\AggregationFieldResolver;
+use EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\RangeAggregationVisitor;
+
+final class RangeAggregationVisitorTest extends AbstractAggregationVisitorTest
+{
+    /** @var \EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\AggregationFieldResolver|\PHPUnit\Framework\MockObject\MockObject */
+    private $aggregationFieldResolver;
+
+    protected function setUp(): void
+    {
+        $this->aggregationFieldResolver = $this->createMock(AggregationFieldResolver::class);
+        $this->aggregationFieldResolver
+            ->method('resolveTargetField')
+            ->with($this->isInstanceOf(AbstractRangeAggregation::class))
+            ->willReturn('custom_field_id');
+
+        parent::setUp();
+    }
+
+    protected function createVisitor(): AggregationVisitor
+    {
+        return new RangeAggregationVisitor(AbstractRangeAggregation::class, $this->aggregationFieldResolver);
+    }
+
+    public function dataProviderForCanVisit(): iterable
+    {
+        yield 'true' => [
+            $this->createMock(AbstractRangeAggregation::class),
+            self::EXAMPLE_LANGUAGE_FILTER,
+            true,
+        ];
+
+        yield 'false' => [
+            $this->createMock(Aggregation::class),
+            self::EXAMPLE_LANGUAGE_FILTER,
+            false,
+        ];
+    }
+
+    public function dataProviderForVisit(): iterable
+    {
+        $aggregation = $this->createMock(AbstractRangeAggregation::class);
+        $aggregation->method('getRanges')->willReturn([
+            new Range(null, 10),
+            new Range(10, 100),
+            new Range(100, null),
+        ]);
+
+        yield [
+            $aggregation,
+            self::EXAMPLE_LANGUAGE_FILTER,
+            [
+                'type' => 'query',
+                'q' => '*:*',
+                'facet' => [
+                    '*_10' => [
+                        'type' => 'query',
+                        'q' => 'custom_field_id:[* TO 10}',
+                    ],
+                    '10_100' => [
+                        'type' => 'query',
+                        'q' => 'custom_field_id:[10 TO 100}',
+                    ],
+                    '100_*' => [
+                        'type' => 'query',
+                        'q' => 'custom_field_id:[100 TO *}',
+                    ],
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/lib/Search/Query/Common/AggregationVisitor/StatsAggregationVisitorTest.php
+++ b/tests/lib/Search/Query/Common/AggregationVisitor/StatsAggregationVisitorTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\Tests\Search\Query\Common\AggregationVisitor;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\AbstractStatsAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use EzSystems\EzPlatformSolrSearchEngine\Query\AggregationVisitor;
+use EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\AggregationFieldResolver;
+use EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\StatsAggregationVisitor;
+
+final class StatsAggregationVisitorTest extends AbstractAggregationVisitorTest
+{
+    /** @var \EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\AggregationFieldResolver|\PHPUnit\Framework\MockObject\MockObject */
+    private $aggregationFieldResolver;
+
+    protected function setUp(): void
+    {
+        $this->aggregationFieldResolver = $this->createMock(AggregationFieldResolver::class);
+        $this->aggregationFieldResolver
+            ->method('resolveTargetField')
+            ->with($this->isInstanceOf(AbstractStatsAggregation::class))
+            ->willReturn('custom_field_id');
+
+        parent::setUp();
+    }
+
+    protected function createVisitor(): AggregationVisitor
+    {
+        return new StatsAggregationVisitor(AbstractStatsAggregation::class, $this->aggregationFieldResolver);
+    }
+
+    public function dataProviderForCanVisit(): iterable
+    {
+        yield 'true' => [
+            $this->createMock(AbstractStatsAggregation::class),
+            self::EXAMPLE_LANGUAGE_FILTER,
+            true,
+        ];
+
+        yield 'false' => [
+            $this->createMock(Aggregation::class),
+            self::EXAMPLE_LANGUAGE_FILTER,
+            false,
+        ];
+    }
+
+    public function dataProviderForVisit(): iterable
+    {
+        yield [
+            $this->createMock(AbstractStatsAggregation::class),
+            self::EXAMPLE_LANGUAGE_FILTER,
+            [
+                'type' => 'query',
+                'q' => '*:*',
+                'facet' => [
+                    'sum' => 'sum(custom_field_id)',
+                    'min' => 'min(custom_field_id)',
+                    'max' => 'max(custom_field_id)',
+                    'avg' => 'avg(custom_field_id)',
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/lib/Search/Query/Common/AggregationVisitor/TermAggregationVisitorTest.php
+++ b/tests/lib/Search/Query/Common/AggregationVisitor/TermAggregationVisitorTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\Tests\Search\Query\Common\AggregationVisitor;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\AbstractTermAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use EzSystems\EzPlatformSolrSearchEngine\Query\AggregationVisitor;
+use EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\AggregationFieldResolver;
+use EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\TermAggregationVisitor;
+
+final class TermAggregationVisitorTest extends AbstractAggregationVisitorTest
+{
+    /** @var \EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\AggregationFieldResolver|\PHPUnit\Framework\MockObject\MockObject */
+    private $aggregationFieldResolver;
+
+    protected function setUp(): void
+    {
+        $this->aggregationFieldResolver = $this->createMock(AggregationFieldResolver::class);
+        $this->aggregationFieldResolver
+            ->method('resolveTargetField')
+            ->with($this->isInstanceOf(AbstractTermAggregation::class))
+            ->willReturn('custom_field_id');
+
+        parent::setUp();
+    }
+
+    protected function createVisitor(): AggregationVisitor
+    {
+        return new TermAggregationVisitor(AbstractTermAggregation::class, $this->aggregationFieldResolver);
+    }
+
+    public function dataProviderForCanVisit(): iterable
+    {
+        yield 'true' => [
+            $this->createMock(AbstractTermAggregation::class),
+            self::EXAMPLE_LANGUAGE_FILTER,
+            true,
+        ];
+
+        yield 'false' => [
+            $this->createMock(Aggregation::class),
+            self::EXAMPLE_LANGUAGE_FILTER,
+            false,
+        ];
+    }
+
+    public function dataProviderForVisit(): iterable
+    {
+        $aggregation = $this->createMock(AbstractTermAggregation::class);
+        $aggregation->method('getLimit')->willReturn(100);
+        $aggregation->method('getMinCount')->willReturn(10);
+
+        yield [
+            $aggregation,
+            self::EXAMPLE_LANGUAGE_FILTER,
+            [
+                'type' => 'terms',
+                'field' => 'custom_field_id',
+                'limit' => 100,
+                'mincount' => 10,
+            ],
+        ];
+    }
+}

--- a/tests/lib/Search/Query/Common/AggregationVisitor/UserMetadataTermAggregationVisitorTest.php
+++ b/tests/lib/Search/Query/Common/AggregationVisitor/UserMetadataTermAggregationVisitorTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\Tests\Search\Query\Common\AggregationVisitor;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\UserMetadataTermAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use EzSystems\EzPlatformSolrSearchEngine\Query\AggregationVisitor;
+use EzSystems\EzPlatformSolrSearchEngine\Query\Common\AggregationVisitor\UserMetadataTermAggregationVisitor;
+
+final class UserMetadataTermAggregationVisitorTest extends AbstractAggregationVisitorTest
+{
+    protected function createVisitor(): AggregationVisitor
+    {
+        return new UserMetadataTermAggregationVisitor();
+    }
+
+    public function dataProviderForCanVisit(): iterable
+    {
+        yield 'true' => [
+            new UserMetadataTermAggregation('foo', UserMetadataTermAggregation::OWNER),
+            self::EXAMPLE_LANGUAGE_FILTER,
+            true,
+        ];
+
+        yield 'false' => [
+            $this->createMock(Aggregation::class),
+            self::EXAMPLE_LANGUAGE_FILTER,
+            false,
+        ];
+    }
+
+    public function dataProviderForVisit(): iterable
+    {
+        yield UserMetadataTermAggregation::OWNER => [
+            new UserMetadataTermAggregation('foo', UserMetadataTermAggregation::OWNER),
+            self::EXAMPLE_LANGUAGE_FILTER,
+            [
+                'type' => 'terms',
+                'field' => 'content_owner_user_id_id',
+                'limit' => UserMetadataTermAggregation::DEFAULT_LIMIT,
+                'mincount' => UserMetadataTermAggregation::DEFAULT_MIN_COUNT,
+            ],
+        ];
+
+        yield UserMetadataTermAggregation::MODIFIER => [
+            new UserMetadataTermAggregation('foo', UserMetadataTermAggregation::MODIFIER),
+            self::EXAMPLE_LANGUAGE_FILTER,
+            [
+                'type' => 'terms',
+                'field' => 'content_version_creator_user_id_id',
+                'limit' => UserMetadataTermAggregation::DEFAULT_LIMIT,
+                'mincount' => UserMetadataTermAggregation::DEFAULT_MIN_COUNT,
+            ],
+        ];
+
+        yield UserMetadataTermAggregation::GROUP => [
+            new UserMetadataTermAggregation('foo', UserMetadataTermAggregation::GROUP),
+            self::EXAMPLE_LANGUAGE_FILTER,
+            [
+                'type' => 'terms',
+                'field' => 'content_owner_user_group_ids_mid',
+                'limit' => UserMetadataTermAggregation::DEFAULT_LIMIT,
+                'mincount' => UserMetadataTermAggregation::DEFAULT_MIN_COUNT,
+            ],
+        ];
+    }
+}

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/AbstractAggregationResultExtractorTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/AbstractAggregationResultExtractorTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\Tests\Search\ResultExtractor\AggregationResultExtractor;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use eZ\Publish\API\Repository\Values\Content\Search\AggregationResult;
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+abstract class AbstractAggregationResultExtractorTest extends TestCase
+{
+    protected const EXAMPLE_AGGREGATION_NAME = 'custom_aggregation';
+    protected const EXAMPLE_LANGUAGE_FILTER = [];
+
+    /** @var \EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor */
+    protected $extractor;
+
+    protected function setUp(): void
+    {
+        $this->extractor = $this->createExtractor();
+    }
+
+    abstract protected function createExtractor(): AggregationResultExtractor;
+
+    /**
+     * @dataProvider dataProviderForTestCanVisit
+     */
+    public function testCanVisit(
+        Aggregation $aggregation,
+        array $languageFilter,
+        bool $expectedResult
+    ): void {
+        $this->assertEquals(
+            $expectedResult,
+            $this->extractor->canVisit($aggregation, $languageFilter)
+        );
+    }
+
+    abstract public function dataProviderForTestCanVisit(): iterable;
+
+    /**
+     * @dataProvider dataProviderForTestExtract
+     */
+    public function testExtract(
+        Aggregation $aggregation,
+        array $languageFilter,
+        stdClass $rawData,
+        AggregationResult $expectedResult
+    ): void {
+        $this->assertEquals(
+            $expectedResult,
+            $this->extractor->extract($aggregation, $languageFilter, $rawData)
+        );
+    }
+
+    abstract public function dataProviderForTestExtract(): iterable;
+}

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/AggregationResultExtractorTestUtils.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/AggregationResultExtractorTestUtils.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\Tests\Search\ResultExtractor\AggregationResultExtractor;
+
+final class AggregationResultExtractorTestUtils
+{
+    public const EXAMPLE_LANGUAGE_FILTER = [
+        'languageCode' => 'eng-GB',
+        'useAlwaysAvailable' => false,
+    ];
+
+    private function __construct()
+    {
+        /* This class shouldn't be instantiated */
+    }
+}

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/DispatcherAggregationResultExtractorTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/DispatcherAggregationResultExtractorTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\Tests\Search\ResultExtractor\AggregationResultExtractor;
+
+use eZ\Publish\API\Repository\Exceptions\NotImplementedException;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use eZ\Publish\API\Repository\Values\Content\Search\AggregationResult;
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor;
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\DispatcherAggregationResultExtractor;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+final class DispatcherAggregationResultExtractorTest extends TestCase
+{
+    private const EXAMPLE_LANGUAGE_FILTER = [];
+
+    public function testSupportsReturnsTrue(): void
+    {
+        $aggregation = $this->createMock(Aggregation::class);
+
+        $dispatcher = new DispatcherAggregationResultExtractor([
+            $this->createExtractorMockWithCanVisit($aggregation, self::EXAMPLE_LANGUAGE_FILTER, false),
+            $this->createExtractorMockWithCanVisit($aggregation, self::EXAMPLE_LANGUAGE_FILTER, true),
+            $this->createExtractorMockWithCanVisit($aggregation, self::EXAMPLE_LANGUAGE_FILTER, false),
+        ]);
+
+        $this->assertTrue($dispatcher->canVisit($aggregation, self::EXAMPLE_LANGUAGE_FILTER));
+    }
+
+    public function testSupportsReturnsFalse(): void
+    {
+        $aggregation = $this->createMock(Aggregation::class);
+
+        $dispatcher = new DispatcherAggregationResultExtractor([
+            $this->createExtractorMockWithCanVisit($aggregation, self::EXAMPLE_LANGUAGE_FILTER, false),
+            $this->createExtractorMockWithCanVisit($aggregation, self::EXAMPLE_LANGUAGE_FILTER, false),
+            $this->createExtractorMockWithCanVisit($aggregation, self::EXAMPLE_LANGUAGE_FILTER, false),
+        ]);
+
+        $this->assertFalse($dispatcher->canVisit($aggregation, self::EXAMPLE_LANGUAGE_FILTER));
+    }
+
+    public function testExtract(): void
+    {
+        $aggregation = $this->createMock(Aggregation::class);
+        $data = new stdClass();
+
+        $extractorA = $this->createExtractorMockWithCanVisit($aggregation, self::EXAMPLE_LANGUAGE_FILTER, false);
+        $extractorB = $this->createExtractorMockWithCanVisit($aggregation, self::EXAMPLE_LANGUAGE_FILTER, true);
+        $extractorC = $this->createExtractorMockWithCanVisit($aggregation, self::EXAMPLE_LANGUAGE_FILTER, false);
+
+        $dispatcher = new DispatcherAggregationResultExtractor([$extractorA, $extractorB, $extractorC]);
+
+        $expectedResult = $this->createMock(AggregationResult::class);
+
+        $extractorB
+            ->method('extract')
+            ->with($aggregation, self::EXAMPLE_LANGUAGE_FILTER, $data)
+            ->willReturn($expectedResult);
+
+        $this->assertEquals(
+            $expectedResult,
+            $dispatcher->extract($aggregation, self::EXAMPLE_LANGUAGE_FILTER, $data)
+        );
+    }
+
+    public function testVisitThrowsNotImplementedException(): void
+    {
+        $this->expectException(NotImplementedException::class);
+        $this->expectExceptionMessage('No result extractor available for aggregation: ');
+
+        $aggregation = $this->createMock(Aggregation::class);
+
+        $dispatcher = new DispatcherAggregationResultExtractor([
+            $this->createExtractorMockWithCanVisit($aggregation, self::EXAMPLE_LANGUAGE_FILTER, false),
+            $this->createExtractorMockWithCanVisit($aggregation, self::EXAMPLE_LANGUAGE_FILTER, false),
+            $this->createExtractorMockWithCanVisit($aggregation, self::EXAMPLE_LANGUAGE_FILTER, false),
+        ]);
+
+        $dispatcher->extract($aggregation, self::EXAMPLE_LANGUAGE_FILTER, new stdClass());
+    }
+
+    private function createExtractorMockWithCanVisit(
+        Aggregation $aggregation,
+        array $languageFilter,
+        bool $supports
+    ): AggregationResultExtractor {
+        $extractor = $this->createMock(AggregationResultExtractor::class);
+        $extractor->method('canVisit')->with($aggregation, $languageFilter)->willReturn($supports);
+
+        return $extractor;
+    }
+}

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/RangeAggregationKeyMapper/AbstractRangeAggregationKeyMapperTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/RangeAggregationKeyMapper/AbstractRangeAggregationKeyMapperTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\Tests\Search\ResultExtractor\AggregationResultExtractor\RangeAggregationKeyMapper;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\RangeAggregationKeyMapper;
+use PHPUnit\Framework\TestCase;
+
+abstract class AbstractRangeAggregationKeyMapperTest extends TestCase
+{
+    protected const EXAMPLE_LANGUAGE_FILTER = [];
+
+    /**
+     * @dataProvider dataProviderForTestMap
+     */
+    final public function testMap(Aggregation $aggregation, array $languageFilter, string $key, $expectedResult): void
+    {
+        $mapper = $this->createRangeAggregationKeyMapper();
+
+        $this->assertEquals(
+            $expectedResult,
+            $mapper->map($aggregation, $languageFilter, $key)
+        );
+    }
+
+    abstract public function dataProviderForTestMap(): iterable;
+
+    abstract protected function createRangeAggregationKeyMapper(): RangeAggregationKeyMapper;
+
+    protected function createAggregationMock(): Aggregation
+    {
+        return $this->createMock(Aggregation::class);
+    }
+}

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/RangeAggregationKeyMapper/DateTimeRangeAggregationKeyMapperTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/RangeAggregationKeyMapper/DateTimeRangeAggregationKeyMapperTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\Tests\Search\ResultExtractor\AggregationResultExtractor\RangeAggregationKeyMapper;
+
+use DateTimeImmutable;
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\RangeAggregationKeyMapper;
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\RangeAggregationKeyMapper\DateTimeRangeAggregationKeyMapper;
+
+final class DateTimeRangeAggregationKeyMapperTest extends AbstractRangeAggregationKeyMapperTest
+{
+    public function dataProviderForTestMap(): iterable
+    {
+        yield 'null' => [
+            $this->createAggregationMock(),
+            self::EXAMPLE_LANGUAGE_FILTER,
+            '*',
+            null,
+        ];
+
+        yield 'date string' => [
+            $this->createAggregationMock(),
+            self::EXAMPLE_LANGUAGE_FILTER,
+            '2020-01-01T00:00:00Z',
+            new DateTimeImmutable('2020-01-01T00:00:00Z'),
+        ];
+    }
+
+    protected function createRangeAggregationKeyMapper(): RangeAggregationKeyMapper
+    {
+        return new DateTimeRangeAggregationKeyMapper();
+    }
+}

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/RangeAggregationKeyMapper/FloatRangeAggregationKeyMapperTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/RangeAggregationKeyMapper/FloatRangeAggregationKeyMapperTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\Tests\Search\ResultExtractor\AggregationResultExtractor\RangeAggregationKeyMapper;
+
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\RangeAggregationKeyMapper;
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\RangeAggregationKeyMapper\FloatRangeAggregationKeyMapper;
+
+final class FloatRangeAggregationKeyMapperTest extends AbstractRangeAggregationKeyMapperTest
+{
+    public function dataProviderForTestMap(): iterable
+    {
+        yield 'null' => [
+            $this->createAggregationMock(),
+            self::EXAMPLE_LANGUAGE_FILTER,
+            '*',
+            null,
+        ];
+
+        yield 'float' => [
+            $this->createAggregationMock(),
+            self::EXAMPLE_LANGUAGE_FILTER,
+            '3.14',
+            3.14,
+        ];
+    }
+
+    protected function createRangeAggregationKeyMapper(): RangeAggregationKeyMapper
+    {
+        return new FloatRangeAggregationKeyMapper();
+    }
+}

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/RangeAggregationKeyMapper/IntRangeAggregationKeyMapperTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/RangeAggregationKeyMapper/IntRangeAggregationKeyMapperTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\Tests\Search\ResultExtractor\AggregationResultExtractor\RangeAggregationKeyMapper;
+
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\RangeAggregationKeyMapper;
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\RangeAggregationKeyMapper\IntRangeAggregationKeyMapper;
+
+final class IntRangeAggregationKeyMapperTest extends AbstractRangeAggregationKeyMapperTest
+{
+    public function dataProviderForTestMap(): iterable
+    {
+        yield 'null' => [
+            $this->createAggregationMock(),
+            self::EXAMPLE_LANGUAGE_FILTER,
+            '*',
+            null,
+        ];
+
+        yield 'int' => [
+            $this->createAggregationMock(),
+            self::EXAMPLE_LANGUAGE_FILTER,
+            '7',
+            7,
+        ];
+    }
+
+    protected function createRangeAggregationKeyMapper(): RangeAggregationKeyMapper
+    {
+        return new IntRangeAggregationKeyMapper();
+    }
+}

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/RangeAggregationKeyMapper/NullRangeAggregationKeyMapperTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/RangeAggregationKeyMapper/NullRangeAggregationKeyMapperTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\Tests\Search\ResultExtractor\AggregationResultExtractor\RangeAggregationKeyMapper;
+
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\RangeAggregationKeyMapper;
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\RangeAggregationKeyMapper\NullRangeAggregationKeyMapper;
+
+final class NullRangeAggregationKeyMapperTest extends AbstractRangeAggregationKeyMapperTest
+{
+    public function dataProviderForTestMap(): iterable
+    {
+        yield 'null' => [
+            $this->createAggregationMock(),
+            self::EXAMPLE_LANGUAGE_FILTER,
+            '*',
+            null,
+        ];
+
+        yield 'key' => [
+            $this->createAggregationMock(),
+            self::EXAMPLE_LANGUAGE_FILTER,
+            'foo',
+            'foo',
+        ];
+    }
+
+    protected function createRangeAggregationKeyMapper(): RangeAggregationKeyMapper
+    {
+        return new NullRangeAggregationKeyMapper();
+    }
+}

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/RangeAggregationResultExtractorTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/RangeAggregationResultExtractorTest.php
@@ -1,0 +1,115 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\Tests\Search\ResultExtractor\AggregationResultExtractor;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\AbstractRangeAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Range;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use eZ\Publish\API\Repository\Values\Content\Search\AggregationResult\RangeAggregationResult;
+use eZ\Publish\API\Repository\Values\Content\Search\AggregationResult\RangeAggregationResultEntry;
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor;
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\RangeAggregationKeyMapper;
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\RangeAggregationResultExtractor;
+use stdClass;
+
+final class RangeAggregationResultExtractorTest extends AbstractAggregationResultExtractorTest
+{
+    /** @var \EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\RangeAggregationKeyMapper|\PHPUnit\Framework\MockObject\MockObject */
+    private $keyMapper;
+
+    protected function setUp(): void
+    {
+        $this->keyMapper = $this->createMock(RangeAggregationKeyMapper::class);
+        $this->keyMapper
+            ->method('map')
+            ->willReturnCallback(function (
+                Aggregation $aggregation,
+                array $languageFilter,
+                string $key
+            ): ?string {
+                return $key !== '*' ? $key : null;
+            });
+
+        $this->extractor = $this->createExtractor();
+    }
+
+    protected function createExtractor(): AggregationResultExtractor
+    {
+        return new RangeAggregationResultExtractor(AbstractRangeAggregation::class, $this->keyMapper);
+    }
+
+    public function dataProviderForTestCanVisit(): iterable
+    {
+        yield 'true' => [
+            $this->createMock(AbstractRangeAggregation::class),
+            self::EXAMPLE_LANGUAGE_FILTER,
+            true,
+        ];
+
+        yield 'false' => [
+            $this->createMock(Aggregation::class),
+            self::EXAMPLE_LANGUAGE_FILTER,
+            false,
+        ];
+    }
+
+    public function dataProviderForTestExtract(): iterable
+    {
+        $aggregation = $this->createMock(AbstractRangeAggregation::class);
+        $aggregation->method('getName')->willReturn(self::EXAMPLE_AGGREGATION_NAME);
+
+        yield 'default' => [
+            $aggregation,
+            self::EXAMPLE_LANGUAGE_FILTER,
+            $this->createEmptyRawData(),
+            new RangeAggregationResult(self::EXAMPLE_AGGREGATION_NAME, []),
+        ];
+
+        yield 'typical' => [
+            $aggregation,
+            self::EXAMPLE_LANGUAGE_FILTER,
+            $this->createTypicalRawData(),
+            new RangeAggregationResult(
+                self::EXAMPLE_AGGREGATION_NAME,
+                [
+                    new RangeAggregationResultEntry(new Range(null, '10'), 10),
+                    new RangeAggregationResultEntry(new Range('10', '100'), 100),
+                    new RangeAggregationResultEntry(new Range('100', null), 1000),
+                ]
+            ),
+        ];
+    }
+
+    private function createEmptyRawData(): stdClass
+    {
+        $data = new stdClass();
+        $data->buckets = [];
+
+        return $data;
+    }
+
+    private function createTypicalRawData(): stdClass
+    {
+        $data = new stdClass();
+        $data->{'*_10'} = $this->createRawBucket('*_10', 10);
+        $data->{'10_100'} = $this->createRawBucket('10_100', 100);
+        $data->{'100_*'} = $this->createRawBucket('100_*', 1000);
+
+        return $data;
+    }
+
+    private function createRawBucket(string $val, int $count): stdClass
+    {
+        $bucket = new stdClass();
+        $bucket->val = $val;
+        $bucket->count = $count;
+
+        return $bucket;
+    }
+}

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/StatsAggregationResultExtractorTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/StatsAggregationResultExtractorTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\Tests\Search\ResultExtractor\AggregationResultExtractor;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\AbstractStatsAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use eZ\Publish\API\Repository\Values\Content\Search\AggregationResult\StatsAggregationResult;
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor;
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\StatsAggregationResultExtractor;
+use stdClass;
+
+final class StatsAggregationResultExtractorTest extends AbstractAggregationResultExtractorTest
+{
+    protected function createExtractor(): AggregationResultExtractor
+    {
+        return new StatsAggregationResultExtractor(AbstractStatsAggregation::class);
+    }
+
+    public function dataProviderForTestCanVisit(): iterable
+    {
+        yield 'true' => [
+            $this->createMock(AbstractStatsAggregation::class),
+            self::EXAMPLE_LANGUAGE_FILTER,
+            true,
+        ];
+
+        yield 'false' => [
+            $this->createMock(Aggregation::class),
+            self::EXAMPLE_LANGUAGE_FILTER,
+            false,
+        ];
+    }
+
+    public function dataProviderForTestExtract(): iterable
+    {
+        $aggregation = $this->createMock(AbstractStatsAggregation::class);
+        $aggregation->method('getName')->willReturn(self::EXAMPLE_AGGREGATION_NAME);
+
+        yield 'defaults' => [
+            $aggregation,
+            self::EXAMPLE_LANGUAGE_FILTER,
+            $this->getEmptyRawData(),
+            new StatsAggregationResult(
+                self::EXAMPLE_AGGREGATION_NAME,
+                null,
+                null,
+                null,
+                null,
+                null,
+            ),
+        ];
+
+        yield 'typical' => [
+            $aggregation,
+            self::EXAMPLE_LANGUAGE_FILTER,
+            $this->getTypicalRawData(),
+            new StatsAggregationResult(
+                self::EXAMPLE_AGGREGATION_NAME,
+                1000,
+                0,
+                125.0,
+                100.0,
+                1000.0
+            ),
+        ];
+    }
+
+    private function getEmptyRawData(): stdClass
+    {
+        $data = new stdClass();
+        $data->count = null;
+        $data->min = null;
+        $data->max = null;
+        $data->avg = null;
+        $data->sum = null;
+
+        return $data;
+    }
+
+    private function getTypicalRawData(): stdClass
+    {
+        $data = new stdClass();
+        $data->count = 1000;
+        $data->min = 0.0;
+        $data->max = 125.0;
+        $data->avg = 100.0;
+        $data->sum = 1000.0;
+
+        return $data;
+    }
+}

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/BooleanAggregationKeyMapperTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/BooleanAggregationKeyMapperTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\Tests\Search\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\BooleanAggregationKeyMapper;
+use EzSystems\EzPlatformSolrSearchEngine\Tests\Search\ResultExtractor\AggregationResultExtractor\AggregationResultExtractorTestUtils;
+use PHPUnit\Framework\TestCase;
+
+final class BooleanAggregationKeyMapperTest extends TestCase
+{
+    public function testMap(): void
+    {
+        $mapper = new BooleanAggregationKeyMapper();
+
+        $this->assertEquals(
+            [
+                false => false,
+                true => true,
+            ],
+            $mapper->map(
+                $this->createMock(Aggregation::class),
+                AggregationResultExtractorTestUtils::EXAMPLE_LANGUAGE_FILTER,
+                [
+                    false => false,
+                    true => true,
+                ],
+            )
+        );
+    }
+}

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/ContentTypeAggregationKeyMapperTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/ContentTypeAggregationKeyMapperTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\Tests\Search\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper;
+
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\ContentTypeAggregationKeyMapper;
+use EzSystems\EzPlatformSolrSearchEngine\Tests\Search\ResultExtractor\AggregationResultExtractor\AggregationResultExtractorTestUtils;
+use PHPUnit\Framework\TestCase;
+
+final class ContentTypeAggregationKeyMapperTest extends TestCase
+{
+    private const EXAMPLE_CONTENT_TYPE_IDS = [1, 2, 3];
+
+    /** @var \eZ\Publish\API\Repository\ContentTypeService|\PHPUnit\Framework\MockObject\MockObject */
+    private $contentTypeService;
+
+    protected function setUp(): void
+    {
+        $this->contentTypeService = $this->createMock(ContentTypeService::class);
+    }
+
+    public function testMap(): void
+    {
+        $expectedContentTypes = $this->createContentTypesList(self::EXAMPLE_CONTENT_TYPE_IDS);
+
+        $this->contentTypeService
+            ->method('loadContentTypeList')
+            ->with(self::EXAMPLE_CONTENT_TYPE_IDS, [])
+            ->willReturn($expectedContentTypes);
+
+        $mapper = new ContentTypeAggregationKeyMapper($this->contentTypeService);
+
+        $this->assertEquals(
+            array_combine(
+                self::EXAMPLE_CONTENT_TYPE_IDS,
+                $expectedContentTypes
+            ),
+            $mapper->map(
+                $this->createMock(Aggregation::class),
+                AggregationResultExtractorTestUtils::EXAMPLE_LANGUAGE_FILTER,
+                self::EXAMPLE_CONTENT_TYPE_IDS
+            )
+        );
+    }
+
+    private function createContentTypesList(iterable $ids): array
+    {
+        $contentTypes = [];
+        foreach ($ids as $id) {
+            $contentType = $this->createMock(ContentType::class);
+            $contentType->method('__get')->with('id')->willReturn($id);
+
+            $contentTypes[] = $contentType;
+        }
+
+        return $contentTypes;
+    }
+}

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/ContentTypeGroupAggregationKeyMapperTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/ContentTypeGroupAggregationKeyMapperTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\Tests\Search\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper;
+
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use eZ\Publish\API\Repository\Values\ContentType\ContentTypeGroup;
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\ContentTypeGroupAggregationKeyMapper;
+use EzSystems\EzPlatformSolrSearchEngine\Tests\Search\ResultExtractor\AggregationResultExtractor\AggregationResultExtractorTestUtils;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class ContentTypeGroupAggregationKeyMapperTest extends TestCase
+{
+    private const EXAMPLE_CONTENT_TYPE_GROUPS_IDS = ['1', '2', '3'];
+
+    /** @var MockObject */
+    private $contentTypeService;
+
+    protected function setUp(): void
+    {
+        $this->contentTypeService = $this->createMock(ContentTypeService::class);
+    }
+
+    public function testMap(): void
+    {
+        $expectedContentTypesGroups = $this->createExpectedLanguages();
+
+        $mapper = new ContentTypeGroupAggregationKeyMapper($this->contentTypeService);
+
+        $this->assertEquals(
+            $expectedContentTypesGroups,
+            $mapper->map(
+                $this->createMock(Aggregation::class),
+                AggregationResultExtractorTestUtils::EXAMPLE_LANGUAGE_FILTER,
+                self::EXAMPLE_CONTENT_TYPE_GROUPS_IDS
+            )
+        );
+    }
+
+    private function createContentTypeGroupWithIds(int $id): ContentTypeGroup
+    {
+        $contentTypeGroup = $this->createMock(ContentTypeGroup::class);
+        $contentTypeGroup->method('__get')->with('id')->willReturn($id);
+
+        return $contentTypeGroup;
+    }
+
+    private function createExpectedLanguages(): array
+    {
+        $expectedContentTypesGroups = [];
+
+        foreach (self::EXAMPLE_CONTENT_TYPE_GROUPS_IDS as $i => $id) {
+            $contentTypeGroup = $this->createContentTypeGroupWithIds((int)$id);
+
+            $this->contentTypeService
+                ->expects($this->at($i))
+                ->method('loadContentTypeGroup')
+                ->with((int)$id, [])
+                ->willReturn($contentTypeGroup);
+
+            $expectedContentTypesGroups[$id] = $contentTypeGroup;
+        }
+
+        return $expectedContentTypesGroups;
+    }
+}

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/CountryAggregationKeyMapperTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/CountryAggregationKeyMapperTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\Tests\Search\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\CountryTermAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\CountryAggregationKeyMapper;
+use EzSystems\EzPlatformSolrSearchEngine\Tests\Search\ResultExtractor\AggregationResultExtractor\AggregationResultExtractorTestUtils;
+use PHPUnit\Framework\TestCase;
+
+final class CountryAggregationKeyMapperTest extends TestCase
+{
+    private const EXAMPLE_RAW_KEYS = [93, 94, 55];
+
+    /**
+     * Example country info entries from ezpublish.fieldType.ezcountry.data parameter.
+     */
+    private const EXAMPLE_COUNTRIES_INFO = [
+        'AF' => [
+            'Name' => 'Afghanistan',
+            'Alpha2' => 'AF',
+            'Alpha3' => 'AFG',
+            'IDC' => '93',
+        ],
+        'AR' => [
+            'Name' => 'Argentina',
+            'Alpha2' => 'AR',
+            'Alpha3' => 'ARG',
+            'IDC' => '94',
+        ],
+        'BR' => [
+            'Name' => 'Brazil',
+            'Alpha2' => 'BR',
+            'Alpha3' => 'BRA',
+            'IDC' => '55',
+        ],
+    ];
+
+    /**
+     * @dataProvider dataProviderForTestMap
+     */
+    public function testMap(
+        Aggregation $aggregation,
+        array $languageFilter,
+        array $keys,
+        array $expectedResult
+    ): void {
+        $mapper = new CountryAggregationKeyMapper(self::EXAMPLE_COUNTRIES_INFO);
+
+        $this->assertEquals(
+            $expectedResult,
+            $mapper->map(
+                $aggregation,
+                $languageFilter,
+                $keys
+            )
+        );
+    }
+
+    public function dataProviderForTestMap(): iterable
+    {
+        yield 'default' => [
+            new CountryTermAggregation('aggregation', 'product', 'country'),
+            AggregationResultExtractorTestUtils::EXAMPLE_LANGUAGE_FILTER,
+            self::EXAMPLE_RAW_KEYS,
+            [
+                93 => 'AFG',
+                94 => 'ARG',
+                55 => 'BRA',
+            ],
+        ];
+
+        yield 'alpha2' => [
+            new CountryTermAggregation('aggregation', 'product', 'country', CountryTermAggregation::TYPE_ALPHA_2),
+            AggregationResultExtractorTestUtils::EXAMPLE_LANGUAGE_FILTER,
+            self::EXAMPLE_RAW_KEYS,
+            [
+                93 => 'AF',
+                94 => 'AR',
+                55 => 'BR',
+            ],
+        ];
+
+        yield 'alpha3' => [
+            new CountryTermAggregation('aggregation', 'product', 'country', CountryTermAggregation::TYPE_ALPHA_3),
+            AggregationResultExtractorTestUtils::EXAMPLE_LANGUAGE_FILTER,
+            self::EXAMPLE_RAW_KEYS,
+            [
+                93 => 'AFG',
+                94 => 'ARG',
+                55 => 'BRA',
+            ],
+        ];
+
+        yield 'name' => [
+            new CountryTermAggregation('aggregation', 'product', 'country', CountryTermAggregation::TYPE_NAME),
+            AggregationResultExtractorTestUtils::EXAMPLE_LANGUAGE_FILTER,
+            self::EXAMPLE_RAW_KEYS,
+            [
+                93 => 'Afghanistan',
+                94 => 'Argentina',
+                55 => 'Brazil',
+            ],
+        ];
+
+        yield 'idc' => [
+            new CountryTermAggregation('aggregation', 'product', 'country', CountryTermAggregation::TYPE_IDC),
+            AggregationResultExtractorTestUtils::EXAMPLE_LANGUAGE_FILTER,
+            self::EXAMPLE_RAW_KEYS,
+            [
+                93 => '93',
+                94 => '94',
+                55 => '55',
+            ],
+        ];
+    }
+}

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/InvertedBooleanAggregationKeyMapperTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/InvertedBooleanAggregationKeyMapperTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\Tests\Search\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\InvertedBooleanAggregationKeyMapper;
+use EzSystems\EzPlatformSolrSearchEngine\Tests\Search\ResultExtractor\AggregationResultExtractor\AggregationResultExtractorTestUtils;
+use PHPUnit\Framework\TestCase;
+
+final class InvertedBooleanAggregationKeyMapperTest extends TestCase
+{
+    public function testMap(): void
+    {
+        $mapper = new InvertedBooleanAggregationKeyMapper();
+
+        $this->assertEquals(
+            [
+                false => true,
+                true => false,
+            ],
+            $mapper->map(
+                $this->createMock(Aggregation::class),
+                AggregationResultExtractorTestUtils::EXAMPLE_LANGUAGE_FILTER,
+                [
+                    false => false,
+                    true => true,
+                ],
+            )
+        );
+    }
+}

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/LanguageAggregationKeyMapperTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/LanguageAggregationKeyMapperTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\Tests\Search\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper;
+
+use eZ\Publish\API\Repository\LanguageService;
+use eZ\Publish\API\Repository\Values\Content\Language;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\LanguageAggregationKeyMapper;
+use EzSystems\EzPlatformSolrSearchEngine\Tests\Search\ResultExtractor\AggregationResultExtractor\AggregationResultExtractorTestUtils;
+use PHPUnit\Framework\TestCase;
+
+final class LanguageAggregationKeyMapperTest extends TestCase
+{
+    private const EXAMPLE_LANGUAGE_CODES = [];
+
+    /** @var \eZ\Publish\API\Repository\LanguageService|\PHPUnit\Framework\MockObject\MockObject */
+    private $languageService;
+
+    /** @var \EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\CountryAggregationKeyMapper */
+    private $mapper;
+
+    protected function setUp(): void
+    {
+        $this->languageService = $this->createMock(LanguageService::class);
+        $this->mapper = new LanguageAggregationKeyMapper($this->languageService);
+    }
+
+    public function testMap(): void
+    {
+        $expectedLanguages = $this->configureLanguageServiceMock(self::EXAMPLE_LANGUAGE_CODES);
+
+        $this->languageService
+            ->method('loadLanguageListByCode')
+            ->with(self::EXAMPLE_LANGUAGE_CODES)
+            ->willReturn($expectedLanguages);
+
+        $this->assertEquals(
+            array_combine(
+                self::EXAMPLE_LANGUAGE_CODES,
+                $expectedLanguages
+            ),
+            $this->mapper->map(
+                $this->createMock(Aggregation::class),
+                AggregationResultExtractorTestUtils::EXAMPLE_LANGUAGE_FILTER,
+                self::EXAMPLE_LANGUAGE_CODES
+            )
+        );
+    }
+
+    private function configureLanguageServiceMock(iterable $languageCodes): array
+    {
+        $languages = [];
+        foreach ($languageCodes as $languageCode) {
+            $language = $this->createMock(Language::class);
+            $language->method('__get')->with('languageCode')->willReturn($languageCode);
+
+            $languages[] = $languageCode;
+        }
+
+        return $languages;
+    }
+}

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/LocationAggregationKeyMapperTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/LocationAggregationKeyMapperTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\Tests\Search\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper;
+
+use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\API\Repository\Values\Content\Location;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\LocationAggregationKeyMapper;
+use EzSystems\EzPlatformSolrSearchEngine\Tests\Search\ResultExtractor\AggregationResultExtractor\AggregationResultExtractorTestUtils;
+use PHPUnit\Framework\TestCase;
+
+final class LocationAggregationKeyMapperTest extends TestCase
+{
+    private const EXAMPLE_LOCATION_IDS = ['2', '54', '47'];
+
+    /** @var \eZ\Publish\API\Repository\LocationService|\PHPUnit\Framework\MockObject\MockObject */
+    private $locationService;
+
+    /** @var \EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\LocationAggregationKeyMapper */
+    private $mapper;
+
+    protected function setUp(): void
+    {
+        $this->locationService = $this->createMock(LocationService::class);
+        $this->mapper = new LocationAggregationKeyMapper($this->locationService);
+    }
+
+    public function testMap(): void
+    {
+        $expectedLocations = $this->createExpectedLocations(self::EXAMPLE_LOCATION_IDS);
+
+        $this->locationService
+            ->method('loadLocationList')
+            ->with(self::EXAMPLE_LOCATION_IDS)
+            ->willReturn($expectedLocations);
+
+        $this->assertEquals(
+            array_combine(
+                self::EXAMPLE_LOCATION_IDS,
+                $expectedLocations
+            ),
+            $this->mapper->map(
+                $this->createMock(Aggregation::class),
+                AggregationResultExtractorTestUtils::EXAMPLE_LANGUAGE_FILTER,
+                self::EXAMPLE_LOCATION_IDS
+            )
+        );
+    }
+
+    private function createExpectedLocations(iterable $locationIds): array
+    {
+        $locations = [];
+        foreach ($locationIds as $locationId) {
+            $locationId = (int)$locationId;
+
+            $location = $this->createMock(Location::class);
+            $location->method('__get')->with('id')->willReturn($locationId);
+
+            $locations[$locationId] = $location;
+        }
+
+        return $locations;
+    }
+}

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/NullAggregationKeyMapperTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/NullAggregationKeyMapperTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\Tests\Search\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\NullAggregationKeyMapper;
+use EzSystems\EzPlatformSolrSearchEngine\Tests\Search\ResultExtractor\AggregationResultExtractor\AggregationResultExtractorTestUtils;
+use PHPUnit\Framework\TestCase;
+
+final class NullAggregationKeyMapperTest extends TestCase
+{
+    public function testMap(): void
+    {
+        $mapper = new NullAggregationKeyMapper();
+
+        $this->assertEquals(
+            [
+                'foo' => 'foo',
+                'bar' => 'bar',
+                'baz' => 'baz',
+            ],
+            $mapper->map(
+                $this->createMock(Aggregation::class),
+                AggregationResultExtractorTestUtils::EXAMPLE_LANGUAGE_FILTER,
+                ['foo', 'bar', 'baz']
+            )
+        );
+    }
+}

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/ObjectStateAggregationKeyMapperTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/ObjectStateAggregationKeyMapperTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\Tests\Search\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper;
+
+use eZ\Publish\API\Repository\ObjectStateService;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\ObjectStateTermAggregation;
+use eZ\Publish\API\Repository\Values\ObjectState\ObjectState;
+use eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup;
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\ObjectStateAggregationKeyMapper;
+use EzSystems\EzPlatformSolrSearchEngine\Tests\Search\ResultExtractor\AggregationResultExtractor\AggregationResultExtractorTestUtils;
+use PHPUnit\Framework\TestCase;
+
+final class ObjectStateAggregationKeyMapperTest extends TestCase
+{
+    /** @var \eZ\Publish\API\Repository\ObjectStateService|\PHPUnit\Framework\MockObject\MockObject */
+    private $objectStateService;
+
+    /** @var \EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\ObjectStateAggregationKeyMapper */
+    private $mapper;
+
+    protected function setUp(): void
+    {
+        $this->objectStateService = $this->createMock(ObjectStateService::class);
+        $this->mapper = new ObjectStateAggregationKeyMapper($this->objectStateService);
+    }
+
+    public function testMap(): void
+    {
+        $expectedObjectStates = array_combine(
+            ['ez_lock:unlocked', 'ez_lock:locked'],
+            $this->configureObjectStateService('ez_lock', ['unlocked', 'locked'])
+        );
+
+        $this->assertEquals(
+            $expectedObjectStates,
+            $this->mapper->map(
+                new ObjectStateTermAggregation('aggregation', 'ez_lock'),
+                AggregationResultExtractorTestUtils::EXAMPLE_LANGUAGE_FILTER,
+                ['ez_lock:unlocked', 'ez_lock:locked']
+            )
+        );
+    }
+
+    private function configureObjectStateService(
+        string $objectStateGroupIdentifier,
+        iterable $objectStateIdentifiers
+    ): array {
+        $objectStateGroup = $this->createMock(ObjectStateGroup::class);
+
+        $this->objectStateService
+            ->method('loadObjectStateGroupByIdentifier')
+            ->with($objectStateGroupIdentifier)
+            ->willReturn($objectStateGroup);
+
+        $expectedObjectStates = [];
+        foreach ($objectStateIdentifiers as $i => $objectStateIdentifier) {
+            $objectState = $this->createMock(ObjectState::class);
+
+            $this->objectStateService
+                ->expects($this->at($i + 1))
+                ->method('loadObjectStateByIdentifier')
+                ->with($objectStateGroup, $objectStateIdentifier, [])
+                ->willReturn($objectState);
+
+            $expectedObjectStates[] = $objectState;
+        }
+
+        return $expectedObjectStates;
+    }
+}

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/SectionAggregationKeyMapperTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/SectionAggregationKeyMapperTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\Tests\Search\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper;
+
+use eZ\Publish\API\Repository\SectionService;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use eZ\Publish\API\Repository\Values\Content\Section;
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\SectionAggregationKeyMapper;
+use EzSystems\EzPlatformSolrSearchEngine\Tests\Search\ResultExtractor\AggregationResultExtractor\AggregationResultExtractorTestUtils;
+use PHPUnit\Framework\TestCase;
+
+final class SectionAggregationKeyMapperTest extends TestCase
+{
+    private const EXAMPLE_SECTION_IDS = [1, 2, 3];
+
+    /** @var \eZ\Publish\API\Repository\SectionService|\PHPUnit\Framework\MockObject\MockObject */
+    private $sectionService;
+
+    /** @var \EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\SectionAggregationKeyMapper */
+    private $mapper;
+
+    protected function setUp(): void
+    {
+        $this->sectionService = $this->createMock(SectionService::class);
+        $this->mapper = new SectionAggregationKeyMapper($this->sectionService);
+    }
+
+    public function testMap(): void
+    {
+        $expectedSections = $this->configureSectionServiceMock(self::EXAMPLE_SECTION_IDS);
+
+        $this->assertEquals(
+            $expectedSections,
+            $this->mapper->map(
+                $this->createMock(Aggregation::class),
+                AggregationResultExtractorTestUtils::EXAMPLE_LANGUAGE_FILTER,
+                self::EXAMPLE_SECTION_IDS
+            )
+        );
+    }
+
+    private function configureSectionServiceMock(iterable $sectionIds): array
+    {
+        $sections = [];
+        foreach ($sectionIds as $i => $sectionId) {
+            $section = $this->createMock(Section::class);
+
+            $this->sectionService
+                ->expects($this->at($i))
+                ->method('loadSection')
+                ->with($sectionId)
+                ->willReturn($section);
+
+            $sections[$sectionId] = $section;
+        }
+
+        return $sections;
+    }
+}

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/UserMetadataAggregationKeyMapperTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationKeyMapper/UserMetadataAggregationKeyMapperTest.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\Tests\Search\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper;
+
+use eZ\Publish\API\Repository\UserService;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\UserMetadataTermAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use eZ\Publish\API\Repository\Values\User\User;
+use eZ\Publish\API\Repository\Values\User\UserGroup;
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\UserMetadataAggregationKeyMapper;
+use EzSystems\EzPlatformSolrSearchEngine\Tests\Search\ResultExtractor\AggregationResultExtractor\AggregationResultExtractorTestUtils;
+use PHPUnit\Framework\TestCase;
+
+final class UserMetadataAggregationKeyMapperTest extends TestCase
+{
+    private const EXAMPLE_USER_IDS = [1, 2, 3];
+    private const EXAMPLE_USER_GROUP_IDS = [1, 2, 3];
+
+    /** @var \eZ\Publish\API\Repository\UserService|\PHPUnit\Framework\MockObject\MockObject */
+    private $userService;
+
+    /** @var \EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper\UserMetadataAggregationKeyMapper */
+    private $mapper;
+
+    protected function setUp(): void
+    {
+        $this->userService = $this->createMock(UserService::class);
+        $this->mapper = new UserMetadataAggregationKeyMapper($this->userService);
+    }
+
+    /**
+     * @dataProvider dataProviderForTestMapUser
+     */
+    public function testMapForUserKey(Aggregation $aggregation): void
+    {
+        $this->assertEquals(
+            $this->createExpectedResultForUserKey(self::EXAMPLE_USER_IDS),
+            $this->mapper->map(
+                $aggregation,
+                AggregationResultExtractorTestUtils::EXAMPLE_LANGUAGE_FILTER,
+                self::EXAMPLE_USER_IDS,
+            )
+        );
+    }
+
+    public function dataProviderForTestMapUser(): iterable
+    {
+        yield UserMetadataTermAggregation::OWNER => [
+            new UserMetadataTermAggregation('owner', UserMetadataTermAggregation::OWNER),
+        ];
+
+        yield UserMetadataTermAggregation::MODIFIER => [
+            new UserMetadataTermAggregation('modifier', UserMetadataTermAggregation::MODIFIER),
+        ];
+    }
+
+    public function testMapForUserGroup(): void
+    {
+        $aggregation = new UserMetadataTermAggregation('group', UserMetadataTermAggregation::GROUP);
+
+        $this->assertEquals(
+            $this->createExpectedResultForUserGroupKey(self::EXAMPLE_USER_GROUP_IDS),
+            $this->mapper->map(
+                $aggregation,
+                AggregationResultExtractorTestUtils::EXAMPLE_LANGUAGE_FILTER,
+                self::EXAMPLE_USER_GROUP_IDS,
+            )
+        );
+    }
+
+    private function createExpectedResultForUserKey(iterable $userIds): array
+    {
+        $users = [];
+        foreach ($userIds as $i => $userId) {
+            $user = $this->createMock(User::class);
+
+            $this->userService
+                ->expects($this->at($i))
+                ->method('loadUser')
+                ->with($userId)
+                ->willReturn($user);
+
+            $users[$userId] = $user;
+        }
+
+        return $users;
+    }
+
+    private function createExpectedResultForUserGroupKey(iterable $userGroupsIds): array
+    {
+        $users = [];
+        foreach ($userGroupsIds as $i => $userGroupId) {
+            $user = $this->createMock(UserGroup::class);
+
+            $this->userService
+                ->expects($this->at($i))
+                ->method('loadUserGroup')
+                ->with($userGroupId)
+                ->willReturn($user);
+
+            $users[$userGroupId] = $user;
+        }
+
+        return $users;
+    }
+}

--- a/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationResultExtractorTest.php
+++ b/tests/lib/Search/ResultExtractor/AggregationResultExtractor/TermAggregationResultExtractorTest.php
@@ -1,0 +1,118 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformSolrSearchEngine\Tests\Search\ResultExtractor\AggregationResultExtractor;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\AbstractTermAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use eZ\Publish\API\Repository\Values\Content\Search\AggregationResult\TermAggregationResult;
+use eZ\Publish\API\Repository\Values\Content\Search\AggregationResult\TermAggregationResultEntry;
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor;
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper;
+use EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationResultExtractor;
+use stdClass;
+
+final class TermAggregationResultExtractorTest extends AbstractAggregationResultExtractorTest
+{
+    /** @var \EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\TermAggregationKeyMapper|\PHPUnit\Framework\MockObject\MockObject */
+    private $keyMapper;
+
+    protected function setUp(): void
+    {
+        $this->keyMapper = $this->createMock(TermAggregationKeyMapper::class);
+        $this->keyMapper
+            ->method('map')
+            ->willReturnCallback(function (
+                Aggregation $aggregation,
+                array $languageFilter,
+                array $keys
+            ): array {
+                return array_combine($keys, array_map('strtoupper', $keys));
+            });
+
+        $this->extractor = $this->createExtractor();
+    }
+
+    protected function createExtractor(): AggregationResultExtractor
+    {
+        return new TermAggregationResultExtractor(
+            AbstractTermAggregation::class,
+            $this->keyMapper,
+        );
+    }
+
+    public function dataProviderForTestCanVisit(): iterable
+    {
+        yield 'true' => [
+            $this->createMock(AbstractTermAggregation::class),
+            self::EXAMPLE_LANGUAGE_FILTER,
+            true,
+        ];
+
+        yield 'false' => [
+            $this->createMock(Aggregation::class),
+            self::EXAMPLE_LANGUAGE_FILTER,
+            false,
+        ];
+    }
+
+    public function dataProviderForTestExtract(): iterable
+    {
+        $aggregation = $this->createMock(AbstractTermAggregation::class);
+        $aggregation->method('getName')->willReturn(self::EXAMPLE_AGGREGATION_NAME);
+
+        yield 'defaults' => [
+            $aggregation,
+            self::EXAMPLE_LANGUAGE_FILTER,
+            $this->createEmptyRawData(),
+            new TermAggregationResult(self::EXAMPLE_AGGREGATION_NAME, []),
+        ];
+
+        yield 'typical' => [
+            $aggregation,
+            self::EXAMPLE_LANGUAGE_FILTER,
+            $this->createTypicalRawData(),
+            new TermAggregationResult(
+                self::EXAMPLE_AGGREGATION_NAME,
+                [
+                    new TermAggregationResultEntry('FOO', 10),
+                    new TermAggregationResultEntry('BAR', 100),
+                    new TermAggregationResultEntry('BAZ', 1000),
+                ]
+            ),
+        ];
+    }
+
+    private function createEmptyRawData(): stdClass
+    {
+        $data = new stdClass();
+        $data->buckets = [];
+
+        return $data;
+    }
+
+    private function createTypicalRawData(): stdClass
+    {
+        $data = new stdClass();
+        $data->buckets = [];
+        $data->buckets[] = $this->createRawBucket('foo', 10);
+        $data->buckets[] = $this->createRawBucket('bar', 100);
+        $data->buckets[] = $this->createRawBucket('baz', 1000);
+
+        return $data;
+    }
+
+    private function createRawBucket(string $val, int $count): stdClass
+    {
+        $bucket = new stdClass();
+        $bucket->val = $val;
+        $bucket->count = $count;
+
+        return $bucket;
+    }
+}


### PR DESCRIPTION
### Description

Implementation of Aggregation API (see ezsystems/ezplatform-kernel#94) for Solr Search Engine.  

#### Sequence diagram

![](https://user-images.githubusercontent.com/211967/94679544-9515c200-0320-11eb-8346-67435183d799.png)

#### Extension points

The following extension points has been introduced in order to be able to handle custom aggregations. 

`EzSystems\EzPlatformSolrSearchEngine\Query\AggregationVisitor`

`AggregationVisitor` is responsible for building aggregation query base on aggregation definition.

```php
<?php

namespace EzSystems\EzPlatformSolrSearchEngine\Query;

use eZ\Publish\API\Repository\Values\Content\Query\AggregationInterface;

interface AggregationVisitor
{
    /**
     * Check if visitor is applicable to current aggreagtion.
     */
    public function canVisit(AggregationInterface $aggregation, array $languageFilter): bool;

    /**
     * @return string[]
     */
    public function visit(
        AggregationVisitor $dispatcherVisitor,
        AggregationInterface $aggregation,
        array $languageFilter
    ): array;
} 
```

`EzSystems\EzPlatformSolrSearchEngine\Query\AggregationVisitor::visit` result will be encoded as JSON and should be compatible with JSON Facet API described here: https://lucene.apache.org/solr/guide/7_7/json-facet-api.html. 

`AggregationVisitor` implementations should be registered as a service and tagged with `ezplatform.search.solr.query.content.aggregation_visitor` and/or `ezplatform.search.solr.query.location.aggregation_visitor` tag.

`EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor`

`AggregationResultExtractor` is responsible for transforming raw aggregation results into `AggregationResult` object. 

```php
<?php

namespace EzSystems\EzPlatformSolrSearchEngine\ResultExtractor;

use eZ\Publish\API\Repository\Values\Content\Query\AggregationInterface;
use eZ\Publish\API\Repository\Values\Content\Search\AggregationResult;
use stdClass;

interface AggregationResultExtractor
{
    public function canVisit(AggregationInterface $aggregation, array $languageFilter): bool;

    public function extract(AggregationInterface $aggregation, array $languageFilter, stdClass $data): AggregationResult;
} 
```

`AggregationResultExtractor` implementations should be registered as a service and tagged with `ezplatform.search.solr.query.content.aggregation_result_extractor` and/or `ezplatform.search.solr.query.location.aggregation_result_extractor` tag. 

#### Deprecations

The following classes/interfaces has been deprecated:

*   `\EzSystems\EzPlatformSolrSearchEngine\Query\FacetFieldVisitor`
*   `\EzSystems\EzPlatformSolrSearchEngine\Query\FacetBuilderVisitor` and all inheriting classes

as well as the following services/aliases:

*   `ezpublish.search.solr.result_extractor.native`
*   `ezpublish.search.solr.result_extractor`

#### BC Breaks

*   Added `$languageSettings` parameter to `EzSystems\EzPlatformSolrSearchEngine\Query\QueryConverter::convert`
*   Added `$languageFilter` and `$aggregations` parameters to `EzSystems\EzPlatformSolrSearchEngine\ResultExtractor::extract`

#### Links

*   ezsystems/ezplatform-kernel#94
*   https://lucene.apache.org/solr/guide/7_7/json-facet-api.html

## Checklist

*   [x] Rebase after #194 merge
*   [x] Code follows the code style of this project (use `$ composer fix-cs`).
*   [x] Change requires a change to the documentation.
*   [x] Code is ready for a review.