### PR TITLE
EZP-27458: Ensured that Range Aggregation results keeps user defined order

### DIFF
--- a/lib/ResultExtractor/AggregationResultExtractor/RangeAggregationResultExtractor.php
+++ b/lib/ResultExtractor/AggregationResultExtractor/RangeAggregationResultExtractor.php
@@ -37,7 +37,7 @@ final class RangeAggregationResultExtractor implements AggregationResultExtracto
     }
 
     /**
-     * @param AbstractRangeAggregation $aggregation
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Aggregation\AbstractRangeAggregation $aggregation
      */
     public function extract(Aggregation $aggregation, array $languageFilter, stdClass $data): AggregationResult
     {

--- a/lib/ResultExtractor/AggregationResultExtractor/RangeAggregationResultExtractor.php
+++ b/lib/ResultExtractor/AggregationResultExtractor/RangeAggregationResultExtractor.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor;
 
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\AbstractRangeAggregation;
 use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Range;
 use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
 use eZ\Publish\API\Repository\Values\Content\Search\AggregationResult;
@@ -35,6 +36,9 @@ final class RangeAggregationResultExtractor implements AggregationResultExtracto
         return $aggregation instanceof $this->aggregationClass;
     }
 
+    /**
+     * @param AbstractRangeAggregation $aggregation
+     */
     public function extract(Aggregation $aggregation, array $languageFilter, stdClass $data): AggregationResult
     {
         $entries = [];
@@ -59,6 +63,28 @@ final class RangeAggregationResultExtractor implements AggregationResultExtracto
             );
         }
 
+        $this->sort($aggregation, $entries);
+
         return new RangeAggregationResult($aggregation->getName(), $entries);
+    }
+
+    /**
+     * Ensures that results entries are in the exact same order as they ware defined in aggregation.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Aggregation\AbstractRangeAggregation $aggregation
+     * @param \eZ\Publish\API\Repository\Values\Content\Search\AggregationResult\RangeAggregationResultEntry[] $entries
+     */
+    private function sort(AbstractRangeAggregation $aggregation, array &$entries): void
+    {
+        $order = $aggregation->getRanges();
+
+        $comparator = static function (
+            RangeAggregationResultEntry $a,
+            RangeAggregationResultEntry $b
+        ) use ($order): int {
+            return array_search($a->getKey(), $order) <=> array_search($b->getKey(), $order);
+        };
+
+        usort($entries, $comparator);
     }
 }


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-27458

### Description

In non-single core setup order of range aggregation results are not guaranteed (see failing build  https://travis-ci.org/github/ezsystems/ezplatform-solr-search-engine/jobs/736166712). 

This PR ensures that entries in \`\\eZ\\Publish\\API\\Repository\\Values\\Content\\Search\\AggregationResult\\RangeAggregationResult\` are in the exact same order as they ware defined in \`eZ\\Publish\\API\\Repository\\Values\\Content\\Query\\Aggregation\\AbstractRangeAggregation\`.