### PR TITLE
EZP-27458: Limited stats aggregation to documents which contain aggregation target field

### DIFF
--- a/lib/Query/Common/AggregationVisitor/AbstractStatsAggregationVisitor.php
+++ b/lib/Query/Common/AggregationVisitor/AbstractStatsAggregationVisitor.php
@@ -26,7 +26,7 @@ abstract class AbstractStatsAggregationVisitor implements AggregationVisitor
 
         return [
             'type' => 'query',
-            'q' => '*:*',
+            'q' => $field . ':[* TO *]',
             'facet' => [
                 'sum' => "sum($field)",
                 'min' => "min($field)",

--- a/tests/lib/Search/Query/Common/AggregationVisitor/StatsAggregationVisitorTest.php
+++ b/tests/lib/Search/Query/Common/AggregationVisitor/StatsAggregationVisitorTest.php
@@ -57,7 +57,7 @@ final class StatsAggregationVisitorTest extends AbstractAggregationVisitorTest
             self::EXAMPLE_LANGUAGE_FILTER,
             [
                 'type' => 'query',
-                'q' => '*:*',
+                'q' => 'custom_field_id:[* TO *]',
                 'facet' => [
                     'sum' => 'sum(custom_field_id)',
                     'min' => 'min(custom_field_id)',


### PR DESCRIPTION
> JIRA: EZP-27458

### Description

Currently stats aggregation while computing count value take into account all examined documents instead of limit documents to those with really influence result. 

In other words we expect that result avg(filed) = sum(field) / count(field). Issue detected by https://travis-ci.com/github/ezsystems/ezplatform-kernel/jobs/407011420 (ezsystems/ezplatform-kernel#129)