### PR TITLE
Refactored ResultExtractor::extract method

### DIFF
--- a/lib/ResultExtractor.php
+++ b/lib/ResultExtractor.php
@@ -169,7 +169,7 @@ abstract class ResultExtractor
                     $facets[] = $this->facetBuilderVisitor->mapField(
                         $field,
                         (array)$facet,
-                        isset($facetBuildersById[$field]) ? $facetBuildersById[$field] : null
+                        $facetBuildersById[$field] ?? null
                     );
                 }
             }

--- a/lib/ResultExtractor.php
+++ b/lib/ResultExtractor.php
@@ -159,7 +159,7 @@ abstract class ResultExtractor
                 foreach ($facetCounts as $field => $facet) {
                     if (empty($facetBuildersById[$field])) {
                         @trigger_error(
-                            'Not setting id of field using FacetFieldVisitor::visitBuilder will not be supported in 2.0'
+                            'Not setting id of field using FacetFieldVisitor::visitBuilder will not be supported in 4.0'
                             . ', as it makes it impossible to exactly identify which facets belongs to which builder.'
                             . "\nMake sure to adapt your visitor for the following field: ${field}"
                             . "\nExample: 'facet.field' => \"{!ex=dt key=\${id}}${field}\",",


### PR DESCRIPTION
> JIRA: -

### Description 

Refactored `\EzSystems\EzPlatformSolrSearchEngine\ResultExtractor::extract` method by splitting it into several smaller methods. 

The main reason behind this PR is to simplify result extractor decoration in order to  to to be able to enrich search hits with custom metadata e.g. https://lucene.apache.org/solr/guide/7_3/spatial-search.html#SpatialSearch-geodist 

### Further refactoring

Next step in refactoring for 4.x is to extract SearchHit mapping logic  to dedicated ResutiHitExtractor service. 
