### PR TITLE
[Tests] Dropped unused searchable Field Types overrides

### DIFF
--- a/tests/lib/Resources/config/cloud.yml
+++ b/tests/lib/Resources/config/cloud.yml
@@ -2,12 +2,6 @@ imports:
     - {resource: common.yml}
 
 parameters:
-    # Redefining default field type classes with the implementation that defines the type
-    # as searchable. Needed in order to test searching wiht Solr engine.
-    ezpublish.fieldType.ezfloat.class: eZ\Publish\API\Repository\Tests\FieldType\SearchableFloat
-    ezpublish.fieldType.ezimage.class: eZ\Publish\API\Repository\Tests\FieldType\SearchableImage
-    ezpublish.fieldType.ezmedia.class: eZ\Publish\API\Repository\Tests\FieldType\SearchableMedia
-    ezpublish.fieldType.ezurl.class: eZ\Publish\API\Repository\Tests\FieldType\SearchableUrl
     languages:
         - eng-US
         - eng-GB

--- a/tests/lib/Resources/config/multicore_dedicated.yml
+++ b/tests/lib/Resources/config/multicore_dedicated.yml
@@ -2,12 +2,6 @@ imports:
     - {resource: common.yml}
 
 parameters:
-    # Redefining default field type classes with the implementation that defines the type
-    # as searchable. Needed in order to test searching wiht Solr engine.
-    ezpublish.fieldType.ezfloat.class: eZ\Publish\API\Repository\Tests\FieldType\SearchableFloat
-    ezpublish.fieldType.ezimage.class: eZ\Publish\API\Repository\Tests\FieldType\SearchableImage
-    ezpublish.fieldType.ezmedia.class: eZ\Publish\API\Repository\Tests\FieldType\SearchableMedia
-    ezpublish.fieldType.ezurl.class: eZ\Publish\API\Repository\Tests\FieldType\SearchableUrl
     languages:
         - eng-US
         - eng-GB

--- a/tests/lib/Resources/config/multicore_shared.yml
+++ b/tests/lib/Resources/config/multicore_shared.yml
@@ -2,12 +2,6 @@ imports:
     - {resource: common.yml}
 
 parameters:
-    # Redefining default field type classes with the implementation that defines the type
-    # as searchable. Needed in order to test searching wiht Solr engine.
-    ezpublish.fieldType.ezfloat.class: eZ\Publish\API\Repository\Tests\FieldType\SearchableFloat
-    ezpublish.fieldType.ezimage.class: eZ\Publish\API\Repository\Tests\FieldType\SearchableImage
-    ezpublish.fieldType.ezmedia.class: eZ\Publish\API\Repository\Tests\FieldType\SearchableMedia
-    ezpublish.fieldType.ezurl.class: eZ\Publish\API\Repository\Tests\FieldType\SearchableUrl
     languages:
         - eng-US
         - eng-GB

--- a/tests/lib/Resources/config/single_core.yml
+++ b/tests/lib/Resources/config/single_core.yml
@@ -2,12 +2,6 @@ imports:
     - {resource: common.yml}
 
 parameters:
-    # Redefining default field type classes with the implementation that defines the type
-    # as searchable. Needed in order to test searching wiht Solr engine.
-    ezpublish.fieldType.ezfloat.class: eZ\Publish\API\Repository\Tests\FieldType\SearchableFloat
-    ezpublish.fieldType.ezimage.class: eZ\Publish\API\Repository\Tests\FieldType\SearchableImage
-    ezpublish.fieldType.ezmedia.class: eZ\Publish\API\Repository\Tests\FieldType\SearchableMedia
-    ezpublish.fieldType.ezurl.class: eZ\Publish\API\Repository\Tests\FieldType\SearchableUrl
     languages:
         - eng-US
         - eng-GB


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | Related to [IBX-872](https://issues.ibexa.co/browse/IBX-872)
| **Related to**                           | ezsystems/ezplatform-kernel#223
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`+
| **BC breaks**                          | no
| **Doc needed**                       | no

Dropped unused searchable overrides for Float, Media, Image, and Url Field Types. They were overridden by `.class` parameters which were dropped for 3.0 via ezsystems/ezpublish-kernel#2911. The related classes were just dropped via  ezsystems/ezplatform-kernel#223 as they're not used anywhere.

The issue needs to be investigated deeper via [IBX-872](https://issues.ibexa.co/browse/IBX-872), however right now this is out of scope for rebranding process.