### PR TITLE
IBX-942: Add missing inner service argument

### DIFF
--- a/lib/Resources/config/container/solr/aggregation_result_extractors.yml
+++ b/lib/Resources/config/container/solr/aggregation_result_extractors.yml
@@ -158,6 +158,7 @@ services:
     class: EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\NestedAggregationResultExtractor
     decorates: ezplatform.search.solr.query.common.aggregation_result_extractor.subtree_term
     arguments:
+      $innerResultExtractor: '@.inner'
       $nestedResultKey: 'nested'
 
   ezplatform.search.solr.query.common.aggregation_result_extractor.user_metadata_term:


### PR DESCRIPTION
This explicitly set the inner service so autowiring does not fail on symfony 5.2.7