### PR TITLE
IBX-942: [Backport] Added missing inner service argument

### DIFF
--- a/lib/Resources/config/container/solr/aggregation_result_extractors.yml
+++ b/lib/Resources/config/container/solr/aggregation_result_extractors.yml
@@ -158,6 +158,7 @@ services:
     class: EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\NestedAggregationResultExtractor
     decorates: ezplatform.search.solr.query.common.aggregation_result_extractor.subtree_term
     arguments:
+      $innerResultExtractor: '@.inner'
       $nestedResultKey: 'nested'
 
   ezplatform.search.solr.query.common.aggregation_result_extractor.user_metadata_term:


### PR DESCRIPTION
Jira issue: [IBX-942](https://issues.ibexa.co/browse/IBX-942)

This is a backport of https://github.com/ezsystems/ezplatform-solr-search-engine/pull/217 that will most likely resolve failing tests in `ezplatform-richtext` bundle on branch 2.3. An example failing build: https://app.travis-ci.com/github/ezsystems/ezplatform-richtext/jobs/539330206#L1540.