### PR TITLE
[Travis] Updated to Focal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
           env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="6.6.5"  CORES_SETUP="single" SOLR_CORES="collection1"
         - php: 7.2
           env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="6.6.5"  CORES_SETUP="cloud" SOLR_CLOUD="yes"
-# test only master and stable branches (+ Pull requests against those)
+#A test only master and stable branches (+ Pull requests against those)
 branches:
     only:
         - master
@@ -29,11 +29,11 @@ branches:
 
 before_script:
     - phpenv config-rm xdebug.ini
-    # Disable expired certificate
+    #A Disable expired certificate
     - sed -i '/mozilla\/DST_Root_CA_X3.crt/ s/./!&/' /etc/ca-certificates.conf \ && update-ca-certificates --verbose
-    # Setup GitHub key to avoid api rate limit (pure auth read only key, no rights, for use by ezsystems repos only!)
+    #A Setup GitHub key to avoid api rate limit (pure auth read only key, no rights, for use by ezsystems repos only!)
     - composer config -g github-oauth.github.com "d0285ed5c8644f30547572ead2ed897431c1fc09"
-    # Avoid memory issues on composer install
+    #A Avoid memory issues on composer install
     - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
     - ./bin/.travis/enable_swap.sh
     - if [ "$COMPOSER_REQUIRE" != "" ] ; then composer require --no-update $COMPOSER_REQUIRE ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
-dist: bionic
+## Run on trusty environment as solr dies all the time on containers after travis move to gce
+sudo: required
+dist: trusty
+
 language: php
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,8 @@ branches:
 
 before_script:
     - phpenv config-rm xdebug.ini
-  # Disable expired certificate
-. - sed -i '/mozilla\/DST_Root_CA_X3.crt/ s/./!&/' /etc/ca-certificates.conf \ && update-ca-certificates --verbose
+    # Disable expired certificate
+    - sed -i '/mozilla\/DST_Root_CA_X3.crt/ s/./!&/' /etc/ca-certificates.conf \ && update-ca-certificates --verbose
     # Setup GitHub key to avoid api rate limit (pure auth read only key, no rights, for use by ezsystems repos only!)
     - composer config -g github-oauth.github.com "d0285ed5c8644f30547572ead2ed897431c1fc09"
     # Avoid memory issues on composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
           env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="6.6.5"  CORES_SETUP="single" SOLR_CORES="collection1"
         - php: 7.2
           env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="6.6.5"  CORES_SETUP="cloud" SOLR_CLOUD="yes"
-#A test only master and stable branches (+ Pull requests against those)
+# test only master and stable branches (+ Pull requests against those)
 branches:
     only:
         - master
@@ -29,11 +29,11 @@ branches:
 
 before_script:
     - phpenv config-rm xdebug.ini
-    #A Disable expired certificate
+    # Disable expired certificate
     - sed -i '/mozilla\/DST_Root_CA_X3.crt/ s/./!&/' /etc/ca-certificates.conf \ && update-ca-certificates --verbose
-    #A Setup GitHub key to avoid api rate limit (pure auth read only key, no rights, for use by ezsystems repos only!)
+    # Setup GitHub key to avoid api rate limit (pure auth read only key, no rights, for use by ezsystems repos only!)
     - composer config -g github-oauth.github.com "d0285ed5c8644f30547572ead2ed897431c1fc09"
-    #A Avoid memory issues on composer install
+    # Avoid memory issues on composer install
     - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
     - ./bin/.travis/enable_swap.sh
     - if [ "$COMPOSER_REQUIRE" != "" ] ; then composer require --no-update $COMPOSER_REQUIRE ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ branches:
 
 before_script:
     - phpenv config-rm xdebug.ini
+  # Disable expired certificate
+. - sed -i '/mozilla\/DST_Root_CA_X3.crt/ s/./!&/' /etc/ca-certificates.conf \ && update-ca-certificates --verbose
     # Setup GitHub key to avoid api rate limit (pure auth read only key, no rights, for use by ezsystems repos only!)
     - composer config -g github-oauth.github.com "d0285ed5c8644f30547572ead2ed897431c1fc09"
     # Avoid memory issues on composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
-## Run on trusty environment as solr dies all the time on containers after travis move to gce
-sudo: required
-dist: trusty
-
+dist: bionic
 language: php
 
 cache:


### PR DESCRIPTION
This PR updates the dist used by Travis to Focal. 

It's related to https://github.com/ezsystems/docker-php/pull/61 - Trusty has OpenSSL 1.0.2, which means that it produces errors when accessing sites using Let's Encrypt certificates. Focal uses the bug-free version (1.1.1).

Focal also has a higher Docker Compose version (1.29.2), which had a change in behaviour compared to the one used on Trusty:
```
Compose supports declaring default environment variables in an environment file named .env placed in the project directory. Docker Compose versions earlier than 1.28, load the .env file from the current working directory, where the command is executed, or from the project directory if this is explicitly set with the --project-directory option. This inconsistency has been addressed starting with +v1.28 by limiting the default .env file path to the project directory. You can use the --env-file commandline option to override the default .env and specify the path to a custom environment file.

The project directory is specified by the order of precedence:

    --project-directory flag
    Folder of the first --file flag
    Current directory
```
[ref](https://docs.docker.com/compose/env-file/)

I'm adding `--env-file=.env` to every docker-compose call to account for that.