### PR TITLE
IBX-1310: Created slots for assigning/unassigning user to groups

### DIFF
--- a/lib/Resources/config/container/solr/slots.yml
+++ b/lib/Resources/config/container/solr/slots.yml
@@ -193,3 +193,13 @@ services:
         parent: ezpublish.search.solr.slot
         tags:
             - {name: ezpublish.search.solr.slot, signal: SectionService\AssignSectionToSubtreeSignal}
+
+    eZ\Publish\Core\Search\Common\Slot\AssignUserToUserGroup:
+        parent: ezpublish.search.solr.slot
+        tags:
+            - {name: ezpublish.search.solr.slot, signal: UserService\AssignUserToUserGroupSignal}
+
+    eZ\Publish\Core\Search\Common\Slot\UnAssignUserFromUserGroup:
+        parent: ezpublish.search.solr.slot
+        tags:
+            - {name: ezpublish.search.solr.slot, signal: UserService\UnAssignUserFromUserGroupSignal}


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1310](https://issues.ibexa.co/browse/IBX-1310)
| **Type**                                   | bug
| **Target eZ Platform version** | `v2.5`
| **BC breaks**                          | no

The related Slots were missing for `assignUserToUserGroup` and `unAssignUserToUserGroup` `UserService`'s methods which resulted in not indexing the related subtrees.

The required PR: https://github.com/ezsystems/ezpublish-kernel/pull/3125

