### PR TITLE
IBX-1699: Bump defaults and requirements for Java, Solr, Elastic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,19 +11,29 @@ cache:
 env:
     global:
         - COMPOSER_MEMORY_LIMIT=6G
+        - TEST_CONFIG="phpunit-integration-legacy-solr.xml"
 
 matrix:
     include:
         - php: 7.2
           env: TEST_CONFIG="phpunit.xml"
         - php: 7.1
-          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="6.4.2"  CORES_SETUP="dedicated"
+          env: SOLR_VERSION="7.7.3"  CORES_SETUP="dedicated"
         - php: 7.2
-          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="6.5.1"  CORES_SETUP="shared"
+          env: SOLR_VERSION="7.7.3"  CORES_SETUP="shared"
         - php: 7.2
-          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="6.6.5"  CORES_SETUP="single" SOLR_CORES="collection1"
+          env: SOLR_VERSION="7.7.3"  CORES_SETUP="single" SOLR_CORES="collection1"
         - php: 7.2
-          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="6.6.5"  CORES_SETUP="cloud" SOLR_CLOUD="yes"
+          env: SOLR_VERSION="7.7.3"  CORES_SETUP="cloud" SOLR_CLOUD="yes"
+        - php: 7.1
+          env: SOLR_VERSION="8.11.1"  CORES_SETUP="dedicated"
+        - php: 7.2
+          env: SOLR_VERSION="8.11.1"  CORES_SETUP="shared"
+        - php: 7.2
+          env: SOLR_VERSION="8.11.1"  CORES_SETUP="single" SOLR_CORES="collection1"
+        - php: 7.2
+          env: SOLR_VERSION="8.11.1"  CORES_SETUP="cloud" SOLR_CLOUD="yes"
+
 # test only master and stable branches (+ Pull requests against those)
 branches:
     only:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![License](https://img.shields.io/github/license/ezsystems/ezplatform-solr-search-engine.svg?style=flat-square)](LICENSE)
 
 Solr Search Engine Bundle for use with:
+- v1.8+: eZ Platform 2.5LTS+ *(bundled out of the box)* with Solr 8.11.1
 - v1.6+: eZ Platform 2.5LTS+ *(bundled out of the box)* with Solr 6.x _(recommended: 6.6 which is an LTS)_
 - v1.5: eZ Platform 1.7LTS & 1.13LTS *(bundled out of the box)* with Solr 6.x or 4.10.4 _(recommended: 6.6 which is an LTS, and certain features only work on Solr 6)_
 - v1.0.x: eZ Publish Platform Enterprise 5.4.5+ *(optional, not as feature rich but helpful for scaling filtering queries)* with Solr 4.10.4

--- a/bin/.travis/init_solr.sh
+++ b/bin/.travis/init_solr.sh
@@ -16,7 +16,7 @@ default_shards=('shard0')
 
 SOLR_PORT=${SOLR_PORT:-8983}
 SOLR_DIR=${SOLR_DIR:-'__solr'}
-SOLR_VERSION=${SOLR_VERSION:-'6.6.5'}
+SOLR_VERSION=${SOLR_VERSION:-'8.11.1'}
 SOLR_INSTALL_DIR="${SOLR_DIR}/${SOLR_VERSION}"
 SOLR_DEBUG=${SOLR_DEBUG:-false}
 SOLR_HOME=${SOLR_HOME:-'ezcloud'}
@@ -45,7 +45,7 @@ fi
 download() {
     case ${SOLR_VERSION} in
         # PS!!: Append versions and don't remove old once, kernel uses this script!
-        6.3.0|6.4.1|6.4.2|6.5.1|6.6.0|6.6.5 )
+        6.3.0|6.4.1|6.4.2|6.5.1|6.6.0|6.6.5|8.11.1 )
             url="http://archive.apache.org/dist/lucene/solr/${SOLR_VERSION}/solr-${SOLR_VERSION}.tgz"
             ;;
         *)
@@ -132,7 +132,7 @@ wait_for_solr(){
     done
 }
 
-# Run for Solr 6
+# Run for Solr 6+
 solr_run() {
     echo "Running with version ${SOLR_VERSION} in standalone mode"
     echo "Starting solr on port ${SOLR_PORT}..."
@@ -144,7 +144,7 @@ solr_run() {
     solr_create_cores
 }
 
-# Create cores for Solr 6
+# Create cores for Solr 6+
 solr_create_cores() {
     home_dir="${SOLR_INSTALL_DIR}/server/${SOLR_HOME}"
     template_dir="${home_dir}/template"

--- a/bin/.travis/init_solr.sh
+++ b/bin/.travis/init_solr.sh
@@ -45,7 +45,7 @@ fi
 download() {
     case ${SOLR_VERSION} in
         # PS!!: Append versions and don't remove old once, kernel uses this script!
-        6.3.0|6.4.1|6.4.2|6.5.1|6.6.0|6.6.5|8.11.1 )
+        6.3.0|6.4.1|6.4.2|6.5.1|6.6.0|6.6.5|7.7.3|8.11.1 )
             url="http://archive.apache.org/dist/lucene/solr/${SOLR_VERSION}/solr-${SOLR_VERSION}.tgz"
             ;;
         *)

--- a/bin/.travis/init_solr.sh
+++ b/bin/.travis/init_solr.sh
@@ -219,13 +219,16 @@ solr_cloud_configure_collection() {
     create_dir ${TEMPLATE_DIR}
 
     local files=("${SOLR_CONFIG[@]}")
-    local config_dir="${INSTALL_DIR}/server/solr/configsets/basic_configs/conf"
+    local config_dir="${INSTALL_DIR}/server/solr/configsets/_default/conf"
 
-    files+=("${config_dir}/currency.xml")
     files+=("${config_dir}/stopwords.txt")
     files+=("${config_dir}/synonyms.txt")
-    files+=("${config_dir}/elevate.xml")
     files+=("${config_dir}/solrconfig.xml")
+
+    local config_dir_samples="${INSTALL_DIR}/server/solr/sample_techproducts_configs/_default/conf"
+
+    files+=("${config_dir_samples}/currency.xml")
+    files+=("${config_dir_samples}/elevate.xml")
 
     copy_files ${TEMPLATE_DIR} "${files[*]}"
 

--- a/bin/generate-solr-config.sh
+++ b/bin/generate-solr-config.sh
@@ -109,7 +109,9 @@ fi
 
 mkdir -p $DESTINATION_DIR
 cp -a ${EZ_BUNDLE_PATH}/lib/Resources/config/solr/* $DESTINATION_DIR
-cp ${SOLR_INSTALL_DIR}/server/solr/configsets/basic_configs/conf/{currency.xml,solrconfig.xml,stopwords.txt,synonyms.txt,elevate.xml} $DESTINATION_DIR
+cp ${SOLR_INSTALL_DIR}/server/solr/configsets/_default/conf/{solrconfig.xml,stopwords.txt,synonyms.txt} $DESTINATION_DIR
+cp ${SOLR_INSTALL_DIR}/server/solr/configsets/sample_techproducts_configs/conf/{currency.xml,elevate.xml} $DESTINATION_DIR
+
 
 if [[ ! $DESTINATION_DIR =~ ^\.platform ]]; then
     # If we are not targeting .platform(.sh) config, we also output default solr.xml

--- a/bin/generate-solr-config.sh
+++ b/bin/generate-solr-config.sh
@@ -3,8 +3,8 @@
 set -e
 
 # Default paramters, if not overloaded by user arguments
-DESTINATION_DIR=.platform/configsets/solr6/conf
-SOLR_VERSION=6.6.5
+DESTINATION_DIR=.platform/configsets/solr8/conf
+SOLR_VERSION=8.11.1
 FORCE=false
 SOLR_INSTALL_DIR=""
 
@@ -19,8 +19,8 @@ Help (this text):
 
 Usage with eZ Platform Cloud (arguments here can be skipped as they have default values):
 ./vendor/ezsystems/ezplatform-solr-search-engine/bin/generate-solr-config.sh \\
-  --destination-dir=.platform/configsets/solr6/conf \\
-  --solr-version=6.6.5
+  --destination-dir=.platform/configsets/solr8/conf \\
+  --solr-version=8.11.1
 
 Usage with on-premise version of Solr:
 ./vendor/ezsystems/ezplatform-solr-search-engine/bin/generate-solr-config.sh \\
@@ -33,7 +33,7 @@ Warning:
 
 Arguments:
   [--destination-dir=<dest.dir>]     : Location where solr config should be stored
-                                       Default value is .platform/configsets/solr6/conf
+                                       Default value is .platform/configsets/solr8/conf
   [-f|--force]                       : Overwrite destination-dir if it already exists
   [--solr-install-dir]               : Existing downloaded Solr install to copy base config from.
   [--solr-version]                   : Solr version to download & copy base config from, used only if --solr-install-dir is unset
@@ -94,7 +94,7 @@ if [ -e $DESTINATION_DIR ]; then
 fi
 
 if [ "$SOLR_INSTALL_DIR" == "" ]; then
-    # If we where not provided existing install directory we'll temporary download version of solr 6 to generate config.
+    # If we where not provided existing install directory we'll temporary download version of solr to generate config.
     GENERATE_SOLR_TMPDIR=`mktemp -d`
     echo "Downloading solr bundle:"
     curl http://archive.apache.org/dist/lucene/solr/${SOLR_VERSION}/solr-${SOLR_VERSION}.tgz > $GENERATE_SOLR_TMPDIR/solr-${SOLR_VERSION}.tgz


### PR DESCRIPTION
Install Solr 8.11.1 by default, as this includes the upgraded log4j with an important security fix.
For 1.7 branch, eZ Platform v2.5.
Maybe best to release as v1.8.0 with a new v2.5 release, could be compatibility issues.

Work in progress:
- [x] Install Solr 8.11.1 - ~this will fail as 8.11.1 is not available yet at https://archive.apache.org/dist/lucene/solr/~ (available now)
- [ ] Readme update is incomplete
- [ ] Nothing for Elasticsearch and Java yet