### PR TITLE
IBX-1699: Bump requirement for Solr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ cache:
 env:
     global:
         - COMPOSER_MEMORY_LIMIT=6G
+        - TEST_CONFIG="phpunit-integration-legacy-solr.xml"
 
 matrix:
     include:
@@ -24,15 +25,15 @@ matrix:
           env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="7.7.3"  CORES_SETUP="single" SOLR_CORES="collection1"
         - php: 7.1
           env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="7.7.3"  CORES_SETUP="cloud" SOLR_CLOUD="yes"
-        # Solr 8.6.3
-        - php: 7.1
-          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="8.6.3"  CORES_SETUP="dedicated"
-        - php: 7.1
-          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="8.6.3"  CORES_SETUP="shared"
-        - php: 7.1
-          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="8.6.3"  CORES_SETUP="single" SOLR_CORES="collection1"
-        - php: 7.1
-          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="8.6.3"  CORES_SETUP="cloud" SOLR_CLOUD="yes"
+        # Solr 8.11.1
+        - php: 7.2
+          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="8.11.1"  CORES_SETUP="dedicated"
+        - php: 7.2
+          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="8.11.1"  CORES_SETUP="shared"
+        - php: 7.2
+          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="8.11.1"  CORES_SETUP="single" SOLR_CORES="collection1"
+        - php: 7.2
+          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="8.11.1"  CORES_SETUP="cloud" SOLR_CLOUD="yes"
 # test only master and stable branches (+ Pull requests against those)
 branches:
     only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,13 +26,13 @@ matrix:
         - php: 7.1
           env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="7.7.3"  CORES_SETUP="cloud" SOLR_CLOUD="yes"
         # Solr 8.11.1
-        - php: 7.2
+        - php: 7.1
           env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="8.11.1"  CORES_SETUP="dedicated"
-        - php: 7.2
+        - php: 7.1
           env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="8.11.1"  CORES_SETUP="shared"
-        - php: 7.2
+        - php: 7.1
           env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="8.11.1"  CORES_SETUP="single" SOLR_CORES="collection1"
-        - php: 7.2
+        - php: 7.1
           env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="8.11.1"  CORES_SETUP="cloud" SOLR_CLOUD="yes"
 # test only master and stable branches (+ Pull requests against those)
 branches:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License](https://img.shields.io/github/license/ezsystems/ezplatform-solr-search-engine.svg?style=flat-square)](LICENSE)
 
 Solr Search Engine Bundle for use with:
-- v1.8+: eZ Platform 2.5LTS+ *(bundled out of the box)* with Solr 8.11.1
+- v2.0+: eZ Platform 2.5LTS+ *(bundled out of the box)* with Solr 8.11.1
 - v1.6+: eZ Platform 2.5LTS+ *(bundled out of the box)* with Solr 6.x _(recommended: 6.6 which is an LTS)_
 - v1.5: eZ Platform 1.7LTS & 1.13LTS *(bundled out of the box)* with Solr 6.x or 4.10.4 _(recommended: 6.6 which is an LTS, and certain features only work on Solr 6)_
 - v1.0.x: eZ Publish Platform Enterprise 5.4.5+ *(optional, not as feature rich but helpful for scaling filtering queries)* with Solr 4.10.4

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![License](https://img.shields.io/github/license/ezsystems/ezplatform-solr-search-engine.svg?style=flat-square)](LICENSE)
 
 Solr Search Engine Bundle for use with:
+- v1.8+: eZ Platform 2.5LTS+ *(bundled out of the box)* with Solr 8.11.1
 - v1.6+: eZ Platform 2.5LTS+ *(bundled out of the box)* with Solr 6.x _(recommended: 6.6 which is an LTS)_
 - v1.5: eZ Platform 1.7LTS & 1.13LTS *(bundled out of the box)* with Solr 6.x or 4.10.4 _(recommended: 6.6 which is an LTS, and certain features only work on Solr 6)_
 - v1.0.x: eZ Publish Platform Enterprise 5.4.5+ *(optional, not as feature rich but helpful for scaling filtering queries)* with Solr 4.10.4

--- a/bin/.travis/init_solr.sh
+++ b/bin/.travis/init_solr.sh
@@ -227,11 +227,6 @@ solr_cloud_configure_collection() {
     files+=("${config_dir}/stopwords.txt")
     files+=("${config_dir}/synonyms.txt")
 
-    local config_dir_samples="${INSTALL_DIR}/server/solr/configsets/sample_techproducts_configs/conf"
-
-    files+=("${config_dir_samples}/currency.xml")
-    files+=("${config_dir_samples}/elevate.xml")
-
     copy_files ${TEMPLATE_DIR} "${files[*]}"
 
     # modify solrconfig.xml to remove section that doesn't agree with our schema

--- a/bin/.travis/init_solr.sh
+++ b/bin/.travis/init_solr.sh
@@ -45,7 +45,7 @@ fi
 download() {
     case ${SOLR_VERSION} in
         # PS!!: Append versions and don't remove old ones, kernel uses this script!
-        7.7.* | 8.[5-8].* | 8.11.* )
+        7.7.* | 8.[5-11].* )
             url="http://archive.apache.org/dist/lucene/solr/${SOLR_VERSION}/solr-${SOLR_VERSION}.tgz"
             ;;
         *)

--- a/bin/.travis/init_solr.sh
+++ b/bin/.travis/init_solr.sh
@@ -227,7 +227,7 @@ solr_cloud_configure_collection() {
     files+=("${config_dir}/stopwords.txt")
     files+=("${config_dir}/synonyms.txt")
 
-    local config_dir_samples="${INSTALL_DIR}/server/solr/sample_techproducts_configs/_default/conf"
+    local config_dir_samples="${INSTALL_DIR}/server/solr/configsets/sample_techproducts_configs/conf"
 
     files+=("${config_dir_samples}/currency.xml")
     files+=("${config_dir_samples}/elevate.xml")

--- a/bin/.travis/init_solr.sh
+++ b/bin/.travis/init_solr.sh
@@ -45,7 +45,7 @@ fi
 download() {
     case ${SOLR_VERSION} in
         # PS!!: Append versions and don't remove old ones, kernel uses this script!
-        7.7.* | 8.[5-11].* )
+        7.7.* | 8.[5-8].* | 8.11.* )
             url="http://archive.apache.org/dist/lucene/solr/${SOLR_VERSION}/solr-${SOLR_VERSION}.tgz"
             ;;
         *)

--- a/bin/.travis/init_solr.sh
+++ b/bin/.travis/init_solr.sh
@@ -16,7 +16,7 @@ default_shards=('shard0')
 
 SOLR_PORT=${SOLR_PORT:-8983}
 SOLR_DIR=${SOLR_DIR:-'__solr'}
-SOLR_VERSION=${SOLR_VERSION:-'7.7.2'}
+SOLR_VERSION=${SOLR_VERSION:-'8.11.1'}
 SOLR_INSTALL_DIR="${SOLR_DIR}/${SOLR_VERSION}"
 SOLR_DEBUG=${SOLR_DEBUG:-false}
 SOLR_HOME=${SOLR_HOME:-'ezcloud'}
@@ -44,8 +44,8 @@ fi
 
 download() {
     case ${SOLR_VERSION} in
-        # PS!!: Append versions and don't remove old once, kernel uses this script!
-        7.7.* | 8.[5-8].* )
+        # PS!!: Append versions and don't remove old ones, kernel uses this script!
+        7.7.* | 8.[5-8].* | 8.11.* )
             url="http://archive.apache.org/dist/lucene/solr/${SOLR_VERSION}/solr-${SOLR_VERSION}.tgz"
             ;;
         *)
@@ -132,7 +132,7 @@ wait_for_solr(){
     done
 }
 
-# Run for Solr 7
+# Run for Solr 7+
 solr_run() {
     echo "Running with version ${SOLR_VERSION} in standalone mode"
     echo "Starting solr on port ${SOLR_PORT}..."
@@ -144,7 +144,7 @@ solr_run() {
     solr_create_cores
 }
 
-# Create cores for Solr 7
+# Create cores for Solr 7+
 solr_create_cores() {
     home_dir="${SOLR_INSTALL_DIR}/server/${SOLR_HOME}"
     template_dir="${home_dir}/template"
@@ -226,6 +226,11 @@ solr_cloud_configure_collection() {
     files+=("${config_dir}/solrconfig.xml")
     files+=("${config_dir}/stopwords.txt")
     files+=("${config_dir}/synonyms.txt")
+
+    local config_dir_samples="${INSTALL_DIR}/server/solr/sample_techproducts_configs/_default/conf"
+
+    files+=("${config_dir_samples}/currency.xml")
+    files+=("${config_dir_samples}/elevate.xml")
 
     copy_files ${TEMPLATE_DIR} "${files[*]}"
 

--- a/bin/generate-solr-config.sh
+++ b/bin/generate-solr-config.sh
@@ -3,8 +3,8 @@
 set -e
 
 # Default paramters, if not overloaded by user arguments
-DESTINATION_DIR=.platform/configsets/solr6/conf
-SOLR_VERSION=7.7.2
+DESTINATION_DIR=.platform/configsets/solr8/conf
+SOLR_VERSION=8.11.1
 FORCE=false
 SOLR_INSTALL_DIR=""
 
@@ -19,8 +19,8 @@ Help (this text):
 
 Usage with eZ Platform Cloud (arguments here can be skipped as they have default values):
 ./vendor/ezsystems/ezplatform-solr-search-engine/bin/generate-solr-config.sh \\
-  --destination-dir=.platform/configsets/solr6/conf \\
-  --solr-version=7.7.2
+  --destination-dir=.platform/configsets/solr8/conf \\
+  --solr-version=8.11.1
 
 Usage with on-premise version of Solr:
 ./vendor/ezsystems/ezplatform-solr-search-engine/bin/generate-solr-config.sh \\
@@ -33,7 +33,7 @@ Warning:
 
 Arguments:
   [--destination-dir=<dest.dir>]     : Location where solr config should be stored
-                                       Default value is .platform/configsets/solr6/conf
+                                       Default value is .platform/configsets/solr8/conf
   [-f|--force]                       : Overwrite destination-dir if it already exists
   [--solr-install-dir]               : Existing downloaded Solr install to copy base config from.
   [--solr-version]                   : Solr version to download & copy base config from, used only if --solr-install-dir is unset
@@ -94,7 +94,7 @@ if [ -e $DESTINATION_DIR ]; then
 fi
 
 if [ "$SOLR_INSTALL_DIR" == "" ]; then
-    # If we where not provided existing install directory we'll temporary download version of solr 7 to generate config.
+    # If we were not provided an existing install directory we'll temporarily download a version of solr to generate config.
     GENERATE_SOLR_TMPDIR=`mktemp -d`
     echo "Downloading solr bundle:"
     curl http://archive.apache.org/dist/lucene/solr/${SOLR_VERSION}/solr-${SOLR_VERSION}.tgz > $GENERATE_SOLR_TMPDIR/solr-${SOLR_VERSION}.tgz
@@ -110,6 +110,7 @@ fi
 mkdir -p $DESTINATION_DIR
 cp -a ${EZ_BUNDLE_PATH}/lib/Resources/config/solr/* $DESTINATION_DIR
 cp ${SOLR_INSTALL_DIR}/server/solr/configsets/_default/conf/{solrconfig.xml,stopwords.txt,synonyms.txt} $DESTINATION_DIR
+cp ${SOLR_INSTALL_DIR}/server/solr/configsets/sample_techproducts_configs/conf/{currency.xml,elevate.xml} $DESTINATION_DIR
 
 if [[ ! $DESTINATION_DIR =~ ^\.platform ]]; then
     # If we are not targeting .platform(.sh) config, we also output default solr.xml

--- a/bin/generate-solr-config.sh
+++ b/bin/generate-solr-config.sh
@@ -110,7 +110,6 @@ fi
 mkdir -p $DESTINATION_DIR
 cp -a ${EZ_BUNDLE_PATH}/lib/Resources/config/solr/* $DESTINATION_DIR
 cp ${SOLR_INSTALL_DIR}/server/solr/configsets/_default/conf/{solrconfig.xml,stopwords.txt,synonyms.txt} $DESTINATION_DIR
-cp ${SOLR_INSTALL_DIR}/server/solr/configsets/sample_techproducts_configs/conf/{currency.xml,elevate.xml} $DESTINATION_DIR
 
 if [[ ! $DESTINATION_DIR =~ ^\.platform ]]; then
     # If we are not targeting .platform(.sh) config, we also output default solr.xml


### PR DESCRIPTION
Install Solr 8.11.1 by default, as this includes the upgraded log4j with an important security fix.
For 2.0 branch, eZ Platform v2.5 (as of https://github.com/ezsystems/ezplatform/pull/677 )

Work in progress:
- [x] Install Solr 8.11.1
- [x] ~Readme update is incomplete~ Good enough. Little need up to date manual install intructions when we anyway refer to the script that does this for us anyway.