### PR TITLE
IBX-2618: Fixed mapping of content_language_codes Solr fields

### DIFF
--- a/lib/FieldMapper/ContentFieldMapper/BlockDocumentsBaseContentFields.php
+++ b/lib/FieldMapper/ContentFieldMapper/BlockDocumentsBaseContentFields.php
@@ -140,12 +140,12 @@ class BlockDocumentsBaseContentFields extends ContentFieldMapper
             ),
             new Field(
                 'content_language_codes',
-                array_keys($versionInfo->names),
+                $versionInfo->languageCodes,
                 new FieldType\MultipleStringField()
             ),
             new Field(
                 'content_language_codes_raw',
-                array_keys($versionInfo->names),
+                $versionInfo->languageCodes,
                 new FieldType\MultipleIdentifierField(['raw' => true])
             ),
             new Field(


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-2618](https://issues.ibexa.co/browse/IBX-2618)
| **Required by**                        | ezsystems/ezplatform-kernel#306
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`+
| **BC breaks**                          | no

Seems we use incorrect source for `content_language_codes*` Solr document fields. For a document to properly collapse into singular content search result, it needs to contain all language codes available for the version. 
```php
array_keys($versionInfo->names)
```
contains only loaded language codes. It worked so far because we always loaded all the languages of any given Version being indexed. This however is costly performance-wise ([IBX-2618](https://issues.ibexa.co/browse/IBX-2618)). With this change it is possible to update single document representing a language, without a need to load all translations.

## TODO
- [ ] See if the change passes CI (does not break anything else)

#### Checklist:
- [x] Provided PR description.
- [ ] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review.