### PR TITLE
[Tests] Removed obsolete syntaxCheck from PHPUnit config

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -3,8 +3,7 @@
          colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         syntaxCheck="true">
+         convertWarningsToExceptions="true">
     <php>
         <ini name="error_reporting" value="-1" />
     </php>


### PR DESCRIPTION
PHPUnit configuration contains obsolete `syntaxCheck` attribute which is gone for a long time and now on every run we see:
```
  Warning - The configuration file did not pass validation!
  The following problems have been detected:

  Line 7:
  - Element 'phpunit', attribute 'syntaxCheck': The attribute 'syntaxCheck' is not allowed.

  Test results may not be as expected.

```