### PR TITLE
IBX-2618: Fixed Solr dedicated cores setup for multilingual test case

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": "^7.3 || ^8.0",
         "ext-json": "*",
         "ext-xmlwriter": "*",
-        "ezsystems/ezplatform-kernel": "^1.3@dev",
+        "ezsystems/ezplatform-kernel": "dev-ibx-2618-enable-ibexa-integration-for-solr as 1.3.x-dev",
         "netgen/query-translator": "^1.0.2",
         "symfony/http-kernel": "^5.0",
         "symfony/dependency-injection": "^5.0",


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-2618](https://issues.ibexa.co/browse/IBX-2618)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`+
| **BC breaks**                          | no

Kernel integration tests  forward-compatible with Ibexa Core were not added to PHPUnit configuration for Solr and skipped.
~There is an issue with missing cores in case of more than default number of languages for the dedicated language for core setup.~

Decided to drop missing languages in ezsystems/ezplatform-kernel#316 as they don't provide any extra value for the test (were using to create a profile).

#### Checklist:
- [ ] **Removed TMP commit before merging**
- [x] Provided PR description.
- [ ] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review