### PR TITLE
IBX-3553: Moved common search service compiler passes to CoreBundle

### DIFF
--- a/bundle/EzSystemsEzPlatformSolrSearchEngineBundle.php
+++ b/bundle/EzSystemsEzPlatformSolrSearchEngineBundle.php
@@ -10,17 +10,15 @@
  */
 namespace EzSystems\EzPlatformSolrSearchEngineBundle;
 
-use EzSystems\EzPlatformSolrSearchEngine\Container\Compiler\CoreFilterRegistryPass;
-use EzSystems\EzPlatformSolrSearchEngine\Container\Compiler\GatewayRegistryPass;
-use Symfony\Component\HttpKernel\Bundle\Bundle;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use EzSystems\EzPlatformSolrSearchEngine\Container\Compiler\AggregateCriterionVisitorPass;
 use EzSystems\EzPlatformSolrSearchEngine\Container\Compiler\AggregateFacetBuilderVisitorPass;
 use EzSystems\EzPlatformSolrSearchEngine\Container\Compiler\AggregateSortClauseVisitorPass;
-use EzSystems\EzPlatformSolrSearchEngine\Container\Compiler\FieldMapperPass;
+use EzSystems\EzPlatformSolrSearchEngine\Container\Compiler\CoreFilterRegistryPass;
 use EzSystems\EzPlatformSolrSearchEngine\Container\Compiler\EndpointRegistryPass;
-use eZ\Publish\Core\Base\Container\Compiler\Search\AggregateFieldValueMapperPass;
-use eZ\Publish\Core\Base\Container\Compiler\Search\FieldRegistryPass;
+use EzSystems\EzPlatformSolrSearchEngine\Container\Compiler\FieldMapperPass;
+use EzSystems\EzPlatformSolrSearchEngine\Container\Compiler\GatewayRegistryPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class EzSystemsEzPlatformSolrSearchEngineBundle extends Bundle
 {
@@ -39,9 +37,6 @@ class EzSystemsEzPlatformSolrSearchEngineBundle extends Bundle
         $container->addCompilerPass(new EndpointRegistryPass());
         $container->addCompilerPass(new GatewayRegistryPass());
         $container->addCompilerPass(new CoreFilterRegistryPass());
-
-        $container->addCompilerPass(new AggregateFieldValueMapperPass());
-        $container->addCompilerPass(new FieldRegistryPass());
     }
 
     public function getContainerExtension()


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-3553](https://issues.ibexa.co/browse/IBX-3553)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

Companion PR:
 * https://github.com/ezsystems/ezplatform-kernel/pull/327

Moves compiler passes from SolrBundle into CoreBundle.

This fixes an issue that might occur if SolrBundle is not enabled, but Elasticsearch bundle is used:

```
Ibexa\Contracts\Migration\Exception\UnhandledMigrationException {#3839
  #message: "Intentionally not implemented: No mapper available for: Ibexa\Contracts\Core\Search\FieldType\IdentifierField"
  #code: 0
  #file: "./vendor/ibexa/migrations/src/lib/MigrationExecutor.php"
  #line: 71
  -previous: Ibexa\Contracts\Core\Repository\Exceptions\NotImplementedException {#5709
    #message: "Intentionally not implemented: No mapper available for: Ibexa\Contracts\Core\Search\FieldType\IdentifierField"
    #code: 0
    #file: "./vendor/ibexa/core/src/lib/Search/Common/FieldValueMapper/Aggregate.php"
    #line: 90
    trace: {
      ./vendor/ibexa/core/src/lib/Search/Common/FieldValueMapper/Aggregate.php:90 { …}
      ./vendor/ibexa/core/src/lib/Search/Common/FieldValueMapper/Aggregate.php:74 { …}
```
Where `Aggregate` class responsible for finding mappers is empty.

#### Checklist:
- [x] Provided PR description.
- [ ] Tested the solution manually.
- [ ] ~Provided automated test coverage~.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
