### PR TITLE
IBX-3863: Parametrized Solr HTTP Client timeout and max retries

### DIFF
--- a/bundle/DependencyInjection/Configuration.php
+++ b/bundle/DependencyInjection/Configuration.php
@@ -14,6 +14,9 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
+    public const SOLR_HTTP_CLIENT_DEFAULT_TIMEOUT = 10;
+    public const SOLR_HTTP_CLIENT_DEFAULT_MAX_RETRIES = 3;
+
     protected $rootNodeName;
 
     /**
@@ -48,6 +51,7 @@ class Configuration implements ConfigurationInterface
 
         $this->addEndpointsSection($rootNode);
         $this->addConnectionsSection($rootNode);
+        $this->addHttpClientConfigurationSection($rootNode);
 
         return $treeBuilder;
     }
@@ -389,6 +393,27 @@ class Configuration implements ConfigurationInterface
                                 ->end()
                             ->end()
                         ->end()
+                    ->end()
+                ->end()
+            ->end()
+        ->end();
+    }
+
+    private function addHttpClientConfigurationSection(ArrayNodeDefinition $node): void
+    {
+        $node->children()
+            ->arrayNode('http_client')
+                ->info('Configuration settings for HTTP Client used to communicate with Solr instance')
+                ->children()
+                    ->integerNode('timeout')
+                        ->info('HTTP Client timeout')
+                        ->min(0)
+                        ->defaultValue(self::SOLR_HTTP_CLIENT_DEFAULT_TIMEOUT)
+                    ->end()
+                    ->integerNode('max_retries')
+                        ->info('HTTP Client max retries after failure')
+                        ->min(0)
+                        ->defaultValue(self::SOLR_HTTP_CLIENT_DEFAULT_MAX_RETRIES)
                     ->end()
                 ->end()
             ->end()

--- a/bundle/DependencyInjection/EzSystemsEzPlatformSolrSearchEngineExtension.php
+++ b/bundle/DependencyInjection/EzSystemsEzPlatformSolrSearchEngineExtension.php
@@ -20,7 +20,7 @@ use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\Config\FileLocator;
 
 /**
- * @psalm-type SolrHttpClientConfigArray = array{timeout: int, max_retries: int}
+ * @phpstan-type SolrHttpClientConfigArray = array{timeout: int, max_retries: int}
  */
 class EzSystemsEzPlatformSolrSearchEngineExtension extends Extension
 {
@@ -324,7 +324,7 @@ class EzSystemsEzPlatformSolrSearchEngineExtension extends Extension
     }
 
     /**
-     * @psalm-param SolrHttpClientConfigArray $httpClientConfig
+     * @phpstan-param SolrHttpClientConfigArray $httpClientConfig
      */
     private function configureHttpClient(ContainerBuilder $container, array $httpClientConfig): void
     {

--- a/bundle/DependencyInjection/EzSystemsEzPlatformSolrSearchEngineExtension.php
+++ b/bundle/DependencyInjection/EzSystemsEzPlatformSolrSearchEngineExtension.php
@@ -19,6 +19,9 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\Config\FileLocator;
 
+/**
+ * @psalm-type SolrHttpClientConfigArray = array{timeout: int, max_retries: int}
+ */
 class EzSystemsEzPlatformSolrSearchEngineExtension extends Extension
 {
     /**
@@ -169,6 +172,10 @@ class EzSystemsEzPlatformSolrSearchEngineExtension extends Extension
         // Factory for BoostFactorProvider uses mapping configured for the connection in use
         $boostFactorProviderDef = $container->findDefinition(self::BOOST_FACTOR_PROVIDER_ID);
         $boostFactorProviderDef->setFactory([new Reference('ezpublish.solr.boost_factor_provider_factory'), 'buildService']);
+
+        if (isset($config['http_client'])) {
+            $this->configureHttpClient($container, $config['http_client']);
+        }
     }
 
     /**
@@ -314,5 +321,17 @@ class EzSystemsEzPlatformSolrSearchEngineExtension extends Extension
         }
 
         return $boostFactorMap;
+    }
+
+    /**
+     * @psalm-param SolrHttpClientConfigArray $httpClientConfig
+     */
+    private function configureHttpClient(ContainerBuilder $container, array $httpClientConfig): void
+    {
+        $container->setParameter('ibexa.solr.http_client.timeout', $httpClientConfig['timeout']);
+        $container->setParameter(
+            'ibexa.solr.http_client.max_retries',
+            $httpClientConfig['max_retries']
+        );
     }
 }

--- a/lib/Resources/config/container/solr/services.yml
+++ b/lib/Resources/config/container/solr/services.yml
@@ -13,6 +13,8 @@ parameters:
     ezpublish.search.solr.field_mapper.indexing_depth_provider.class: \EzSystems\EzPlatformSolrSearchEngine\FieldMapper\IndexingDepthProvider
     ezpublish.search.solr.field_mapper.indexing_depth_provider.map: []
     ezpublish.search.solr.field_mapper.indexing_depth_provider.default: 0
+    ibexa.solr.http_client.timeout: 10
+    ibexa.solr.http_client.max_retries: 5
 
 services:
     ibexa.solr.http_client.retryable:
@@ -21,7 +23,7 @@ services:
         arguments:
             $client: '@.inner'
             $strategy: null
-            $maxRetries: 5
+            $maxRetries: '%ibexa.solr.http_client.max_retries%'
             $logger: '@?logger'
         tags:
             - { name: monolog.logger, channel: solr }
@@ -39,6 +41,7 @@ services:
         autoconfigure: true
         arguments:
             $client: '@ibexa.solr.http_client'
+            $timeout: '%ibexa.solr.http_client.timeout%'
 
     # Note: services tagged with 'ezpublish.search.solr.query.content.criterion_visitor'
     # are registered to this one using compilation pass

--- a/lib/Resources/config/container/solr/services.yml
+++ b/lib/Resources/config/container/solr/services.yml
@@ -26,7 +26,7 @@ services:
             $maxRetries: '%ibexa.solr.http_client.max_retries%'
             $logger: '@?logger'
         tags:
-            - { name: monolog.logger, channel: solr }
+            - { name: monolog.logger, channel: ibexa.solr }
 
     ibexa.solr.http_client:
         class: Symfony\Contracts\HttpClient\HttpClientInterface
@@ -34,7 +34,7 @@ services:
         calls:
             - setLogger: ['@logger']
         tags:
-            - { name: monolog.logger, channel: solr }
+            - { name: monolog.logger, channel: ibexa.solr }
 
     ezpublish.search.solr.gateway.client.http.stream:
         class: '%ezpublish.search.solr.gateway.client.http.stream.class%'

--- a/lib/Resources/config/container/solr/services.yml
+++ b/lib/Resources/config/container/solr/services.yml
@@ -13,8 +13,8 @@ parameters:
     ezpublish.search.solr.field_mapper.indexing_depth_provider.class: \EzSystems\EzPlatformSolrSearchEngine\FieldMapper\IndexingDepthProvider
     ezpublish.search.solr.field_mapper.indexing_depth_provider.map: []
     ezpublish.search.solr.field_mapper.indexing_depth_provider.default: 0
-    ibexa.solr.http_client.timeout: 10
-    ibexa.solr.http_client.max_retries: 5
+    ibexa.solr.http_client.timeout: !php/const \EzSystems\EzPlatformSolrSearchEngineBundle\DependencyInjection\Configuration::SOLR_HTTP_CLIENT_DEFAULT_TIMEOUT
+    ibexa.solr.http_client.max_retries: !php/const \EzSystems\EzPlatformSolrSearchEngineBundle\DependencyInjection\Configuration::SOLR_HTTP_CLIENT_DEFAULT_MAX_RETRIES
 
 services:
     ibexa.solr.http_client.retryable:

--- a/lib/Resources/config/container/solr/services.yml
+++ b/lib/Resources/config/container/solr/services.yml
@@ -10,7 +10,7 @@ parameters:
     ezpublish.search.solr.field_mapper.location.class: EzSystems\EzPlatformSolrSearchEngine\FieldMapper\LocationFieldMapper\Aggregate
     ezpublish.search.solr.field_mapper.boost_factor_provider.class: EzSystems\EzPlatformSolrSearchEngine\FieldMapper\BoostFactorProvider
     ezpublish.search.solr.field_mapper.boost_factor_provider.map: []
-    ezpublish.search.solr.field_mapper.indexing_depth_provider.class: \EzSystems\EzPlatformSolrSearchEngine\FieldMapper\IndexingDepthProvider
+    ezpublish.search.solr.field_mapper.indexing_depth_provider.class: EzSystems\EzPlatformSolrSearchEngine\FieldMapper\IndexingDepthProvider
     ezpublish.search.solr.field_mapper.indexing_depth_provider.map: []
     ezpublish.search.solr.field_mapper.indexing_depth_provider.default: 0
     ibexa.solr.http_client.timeout: !php/const \EzSystems\EzPlatformSolrSearchEngineBundle\DependencyInjection\Configuration::SOLR_HTTP_CLIENT_DEFAULT_TIMEOUT

--- a/tests/bundle/DependencyInjection/EzPublishEzPlatformSolrSearchEngineExtensionTest.php
+++ b/tests/bundle/DependencyInjection/EzPublishEzPlatformSolrSearchEngineExtensionTest.php
@@ -16,7 +16,7 @@ use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
 /**
- * @psalm-import-type SolrHttpClientConfigArray from EzSystemsEzPlatformSolrSearchEngineExtension
+ * @phpstan-import-type SolrHttpClientConfigArray from EzSystemsEzPlatformSolrSearchEngineExtension
  */
 class EzPublishEzPlatformSolrSearchEngineExtensionTest extends AbstractExtensionTestCase
 {
@@ -658,7 +658,7 @@ class EzPublishEzPlatformSolrSearchEngineExtensionTest extends AbstractExtension
     /**
      * @dataProvider getDataForTestHttpClientConfiguration
      *
-     * @psalm-param SolrHttpClientConfigArray $httpClientConfig
+     * @phpstan-param SolrHttpClientConfigArray $httpClientConfig
      */
     public function testHttpClientConfiguration(array $config): void
     {

--- a/tests/bundle/DependencyInjection/EzPublishEzPlatformSolrSearchEngineExtensionTest.php
+++ b/tests/bundle/DependencyInjection/EzPublishEzPlatformSolrSearchEngineExtensionTest.php
@@ -10,10 +10,14 @@
  */
 namespace EzSystems\EzPlatformSolrSearchEngineBundle\Tests\DependencyInjection;
 
+use EzSystems\EzPlatformSolrSearchEngineBundle\DependencyInjection\Configuration;
 use EzSystems\EzPlatformSolrSearchEngineBundle\DependencyInjection\EzSystemsEzPlatformSolrSearchEngineExtension;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
+/**
+ * @psalm-import-type SolrHttpClientConfigArray from EzSystemsEzPlatformSolrSearchEngineExtension
+ */
 class EzPublishEzPlatformSolrSearchEngineExtensionTest extends AbstractExtensionTestCase
 {
     /**
@@ -649,5 +653,46 @@ class EzPublishEzPlatformSolrSearchEngineExtensionTest extends AbstractExtension
             'ez_search_engine_solr.connection.connection1.boost_factor_map_id',
             $map
         );
+    }
+
+    /**
+     * @dataProvider getDataForTestHttpClientConfiguration
+     *
+     * @psalm-param SolrHttpClientConfigArray $httpClientConfig
+     */
+    public function testHttpClientConfiguration(array $config): void
+    {
+        $this->load(
+            [
+                'http_client' => $config,
+            ]
+        );
+
+        $this->assertContainerBuilderHasParameter(
+            'ibexa.solr.http_client.timeout',
+            $config['timeout'],
+        );
+
+        $this->assertContainerBuilderHasParameter(
+            'ibexa.solr.http_client.max_retries',
+            $config['max_retries'],
+        );
+    }
+
+    public function getDataForTestHttpClientConfiguration(): iterable
+    {
+        yield 'default values' => [
+            [
+                'timeout' => Configuration::SOLR_HTTP_CLIENT_DEFAULT_TIMEOUT,
+                'max_retries' => Configuration::SOLR_HTTP_CLIENT_DEFAULT_MAX_RETRIES,
+            ],
+        ];
+
+        yield 'custom values' => [
+            [
+                'timeout' => 16,
+                'max_retries' => 2,
+            ],
+        ];
     }
 }


### PR DESCRIPTION
| Question                                  | Answer |
| ---------------------------------------- | ------------------ |
| **JIRA issue**                          | [IBX-3863](https://issues.ibexa.co/browse/IBX-3863) |
| **Type**                                   | improvement |
| **Target Ibexa version** | `v3.3`+ |
| **BC breaks**                          | no |

When switching to Symfony HTTP Client to handle Solr queries in #235. I didn't introduce any possibility to configure Client's timeout nor number of max retries. There are some edge cases which show that this parameter might work-around performance issues.

### Documentation

~Solr~ Ibexa Solr Bundle uses Symfony HTTP Client to fetch and update Solr index. It's possible to configure timeout and number of max retries for that client using Solr Bundle's Semantic Configuration:

v3.3:
```yaml
ez_search_engine_solr:
    http_client:
        timeout: 30
        max_retries: 5
```

v4.x:
```yaml
ibexa_solr:
    http_client:
        timeout: 30
        max_retries: 5
```

### QA

You can test timeout change by mocking Solr service
```
$ nc -vv -l 8983
```
and then trying to perform e.g. reindexing
```
php ./bin/console ibexa:reindex --processes 1 -n
```

See that modifying both `timeout` and `max_retries` affect the wait time and the amount of tries before failure.

## Open questions

Given this rather should be avoided, preferring proper performance fixes, should we:
- [x] Document those parameters?
- [x] Provide Semantic configuration instead of parameters (only if we decide to document)

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly.
- [x] Asked for a review