### PR TITLE
IBX-5133: Allowed Solr tests to be executed against different hostname

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,13 +11,13 @@ on:
 jobs:
     cs-fix:
         name: Run code style check
-        runs-on: "ubuntu-20.04"
+        runs-on: "ubuntu-22.04"
         strategy:
             matrix:
                 php:
                     - '8.0'
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
 
             - name: Setup PHP Action
               uses: shivammathur/setup-php@v2
@@ -27,16 +27,16 @@ jobs:
                   extensions: 'pdo_sqlite, gd'
                   tools: cs2pr
 
-            - uses: "ramsey/composer-install@v1"
+            - uses: ramsey/composer-install@v2
               with:
-                  dependency-versions: "highest"
+                  dependency-versions: highest
 
             - name: Run code style check
               run: composer run-script check-cs -- --format=checkstyle | cs2pr
 
     tests:
         name: Unit tests
-        runs-on: "ubuntu-20.04"
+        runs-on: "ubuntu-22.04"
         timeout-minutes: 15
 
         strategy:
@@ -49,7 +49,7 @@ jobs:
                     - '8.1'
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
 
             - name: Setup PHP Action
               uses: shivammathur/setup-php@v2
@@ -59,9 +59,9 @@ jobs:
                   extensions: pdo_sqlite, gd
                   tools: cs2pr
 
-            - uses: "ramsey/composer-install@v1"
+            - uses: ramsey/composer-install@v2
               with:
-                  dependency-versions: "highest"
+                  dependency-versions: highest
 
             - name: Setup problem matchers for PHPUnit
               run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ on:
     push:
         branches:
             - main
+            - run-test
             - '[0-9]+.[0-9]+'
     pull_request: ~
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,6 @@ on:
     push:
         branches:
             - main
-            - run-test
             - '[0-9]+.[0-9]+'
     pull_request: ~
 

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -4,7 +4,6 @@ on:
     push:
         branches:
             - main
-            - run-test
             - '[0-9]+.[0-9]+'
     pull_request: ~
 

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -4,13 +4,14 @@ on:
     push:
         branches:
             - main
+            - run-test
             - '[0-9]+.[0-9]+'
     pull_request: ~
 
 jobs:
     solr-integration:
         name: "Integration tests"
-        runs-on: "ubuntu-20.04"
+        runs-on: "ubuntu-22.04"
         strategy:
             fail-fast: false
             matrix:
@@ -34,7 +35,7 @@ jobs:
               name: "Set up single core"
               run: echo "SOLR_CORES=collection1" >> $GITHUB_ENV
 
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
 
             - name: Setup PHP Action
               uses: shivammathur/setup-php@v2
@@ -42,9 +43,9 @@ jobs:
                   php-version: 7.4
                   coverage: none
 
-            - uses: "ramsey/composer-install@v1"
+            - uses: ramsey/composer-install@v2
               with:
-                  dependency-versions: "highest"
+                  dependency-versions: highest
 
             - name: Init Solr
               run: ./.github/init_solr.sh

--- a/composer.json
+++ b/composer.json
@@ -62,8 +62,6 @@
         }
     },
     "config": {
-        "allow-plugins": {
-            "*": false
-        }
+        "allow-plugins": false
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
     },
     "config": {
         "allow-plugins": {
-            "php-http/discovery": false
+            "*": false
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -60,5 +60,10 @@
         "branch-alias": {
             "dev-master": "3.3.x-dev"
         }
+    },
+    "config": {
+        "allow-plugins": {
+            "php-http/discovery": false
+        }
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,6 +6,7 @@
          convertWarningsToExceptions="true">
     <php>
         <ini name="error_reporting" value="-1" />
+        <env name="SOLR_HOST" value="localhost" />
     </php>
     <testsuites>
         <testsuite name="Solr search engine tests">

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,7 +6,6 @@
          convertWarningsToExceptions="true">
     <php>
         <ini name="error_reporting" value="-1" />
-        <env name="SOLR_HOST" value="localhost" />
     </php>
     <testsuites>
         <testsuite name="Solr search engine tests">

--- a/tests/bundle/DependencyInjection/EzPublishEzPlatformSolrSearchEngineExtensionTest.php
+++ b/tests/bundle/DependencyInjection/EzPublishEzPlatformSolrSearchEngineExtensionTest.php
@@ -658,7 +658,7 @@ class EzPublishEzPlatformSolrSearchEngineExtensionTest extends AbstractExtension
     /**
      * @dataProvider getDataForTestHttpClientConfiguration
      *
-     * @phpstan-param SolrHttpClientConfigArray $httpClientConfig
+     * @phpstan-param SolrHttpClientConfigArray $config
      */
     public function testHttpClientConfiguration(array $config): void
     {
@@ -679,6 +679,9 @@ class EzPublishEzPlatformSolrSearchEngineExtensionTest extends AbstractExtension
         );
     }
 
+    /**
+     * @return iterable<string, array<SolrHttpClientConfigArray>>
+     */
     public function getDataForTestHttpClientConfiguration(): iterable
     {
         yield 'default values' => [

--- a/tests/lib/Resources/config/cloud.yml
+++ b/tests/lib/Resources/config/cloud.yml
@@ -33,7 +33,7 @@ services:
         arguments:
             -
                 scheme: http
-                host: localhost
+                host: "%test.ibexa.solr.host%"
                 port: 8983
                 path: /solr
                 core: core0
@@ -45,7 +45,7 @@ services:
         arguments:
             -
                 scheme: http
-                host: localhost
+                host: "%test.ibexa.solr.host%"
                 port: 8983
                 path: /solr
                 core: core1
@@ -57,7 +57,7 @@ services:
         arguments:
             -
                 scheme: http
-                host: localhost
+                host: "%test.ibexa.solr.host%"
                 port: 8983
                 path: /solr
                 core: core2
@@ -69,7 +69,7 @@ services:
         arguments:
             -
                 scheme: http
-                host: localhost
+                host: "%test.ibexa.solr.host%"
                 port: 8983
                 path: /solr
                 core: core3

--- a/tests/lib/Resources/config/cloud.yml
+++ b/tests/lib/Resources/config/cloud.yml
@@ -33,7 +33,7 @@ services:
         arguments:
             -
                 scheme: http
-                host: "%test.ibexa.solr.host%"
+                host: '%test.ibexa.solr.host%'
                 port: 8983
                 path: /solr
                 core: core0
@@ -45,7 +45,7 @@ services:
         arguments:
             -
                 scheme: http
-                host: "%test.ibexa.solr.host%"
+                host: '%test.ibexa.solr.host%'
                 port: 8983
                 path: /solr
                 core: core1
@@ -57,7 +57,7 @@ services:
         arguments:
             -
                 scheme: http
-                host: "%test.ibexa.solr.host%"
+                host: '%test.ibexa.solr.host%'
                 port: 8983
                 path: /solr
                 core: core2
@@ -69,7 +69,7 @@ services:
         arguments:
             -
                 scheme: http
-                host: "%test.ibexa.solr.host%"
+                host: '%test.ibexa.solr.host%'
                 port: 8983
                 path: /solr
                 core: core3

--- a/tests/lib/Resources/config/multicore_dedicated.yml
+++ b/tests/lib/Resources/config/multicore_dedicated.yml
@@ -32,7 +32,7 @@ services:
         arguments:
             -
                 scheme: http
-                host: "%test.ibexa.solr.host%"
+                host: '%test.ibexa.solr.host%'
                 port: 8983
                 path: /solr
                 core: core0
@@ -44,7 +44,7 @@ services:
         arguments:
             -
                 scheme: http
-                host: "%test.ibexa.solr.host%"
+                host: '%test.ibexa.solr.host%'
                 port: 8983
                 path: /solr
                 core: core1
@@ -56,7 +56,7 @@ services:
         arguments:
             -
                 scheme: http
-                host: "%test.ibexa.solr.host%"
+                host: '%test.ibexa.solr.host%'
                 port: 8983
                 path: /solr
                 core: core2
@@ -68,7 +68,7 @@ services:
         arguments:
             -
                 scheme: http
-                host: "%test.ibexa.solr.host%"
+                host: '%test.ibexa.solr.host%'
                 port: 8983
                 path: /solr
                 core: core3
@@ -80,7 +80,7 @@ services:
         arguments:
             -
                 scheme: http
-                host: "%test.ibexa.solr.host%"
+                host: '%test.ibexa.solr.host%'
                 port: 8983
                 path: /solr
                 core: core4
@@ -92,7 +92,7 @@ services:
         arguments:
             -
                 scheme: http
-                host: "%test.ibexa.solr.host%"
+                host: '%test.ibexa.solr.host%'
                 port: 8983
                 path: /solr
                 core: core5

--- a/tests/lib/Resources/config/multicore_dedicated.yml
+++ b/tests/lib/Resources/config/multicore_dedicated.yml
@@ -32,7 +32,7 @@ services:
         arguments:
             -
                 scheme: http
-                host: localhost
+                host: "%test.ibexa.solr.host%"
                 port: 8983
                 path: /solr
                 core: core0
@@ -44,7 +44,7 @@ services:
         arguments:
             -
                 scheme: http
-                host: localhost
+                host: "%test.ibexa.solr.host%"
                 port: 8983
                 path: /solr
                 core: core1
@@ -56,7 +56,7 @@ services:
         arguments:
             -
                 scheme: http
-                host: localhost
+                host: "%test.ibexa.solr.host%"
                 port: 8983
                 path: /solr
                 core: core2
@@ -68,7 +68,7 @@ services:
         arguments:
             -
                 scheme: http
-                host: localhost
+                host: "%test.ibexa.solr.host%"
                 port: 8983
                 path: /solr
                 core: core3
@@ -80,7 +80,7 @@ services:
         arguments:
             -
                 scheme: http
-                host: localhost
+                host: "%test.ibexa.solr.host%"
                 port: 8983
                 path: /solr
                 core: core4
@@ -92,7 +92,7 @@ services:
         arguments:
             -
                 scheme: http
-                host: localhost
+                host: "%test.ibexa.solr.host%"
                 port: 8983
                 path: /solr
                 core: core5

--- a/tests/lib/Resources/config/multicore_shared.yml
+++ b/tests/lib/Resources/config/multicore_shared.yml
@@ -27,7 +27,7 @@ services:
         arguments:
             -
                 scheme: http
-                host: "%test.ibexa.solr.host%"
+                host: '%test.ibexa.solr.host%'
                 port: 8983
                 path: /solr
                 core: core0
@@ -39,7 +39,7 @@ services:
         arguments:
             -
                 scheme: http
-                host: "%test.ibexa.solr.host%"
+                host: '%test.ibexa.solr.host%'
                 port: 8983
                 path: /solr
                 core: core1
@@ -51,7 +51,7 @@ services:
         arguments:
             -
                 scheme: http
-                host: "%test.ibexa.solr.host%"
+                host: '%test.ibexa.solr.host%'
                 port: 8983
                 path: /solr
                 core: core2
@@ -63,7 +63,7 @@ services:
         arguments:
             -
                 scheme: http
-                host: "%test.ibexa.solr.host%"
+                host: '%test.ibexa.solr.host%'
                 port: 8983
                 path: /solr
                 core: core3

--- a/tests/lib/Resources/config/multicore_shared.yml
+++ b/tests/lib/Resources/config/multicore_shared.yml
@@ -27,7 +27,7 @@ services:
         arguments:
             -
                 scheme: http
-                host: localhost
+                host: "%test.ibexa.solr.host%"
                 port: 8983
                 path: /solr
                 core: core0
@@ -39,7 +39,7 @@ services:
         arguments:
             -
                 scheme: http
-                host: localhost
+                host: "%test.ibexa.solr.host%"
                 port: 8983
                 path: /solr
                 core: core1
@@ -51,7 +51,7 @@ services:
         arguments:
             -
                 scheme: http
-                host: localhost
+                host: "%test.ibexa.solr.host%"
                 port: 8983
                 path: /solr
                 core: core2
@@ -63,7 +63,7 @@ services:
         arguments:
             -
                 scheme: http
-                host: localhost
+                host: "%test.ibexa.solr.host%"
                 port: 8983
                 path: /solr
                 core: core3

--- a/tests/lib/Resources/config/single_core.yml
+++ b/tests/lib/Resources/config/single_core.yml
@@ -26,7 +26,7 @@ services:
         arguments:
             -
                 scheme: http
-                host: "%test.ibexa.solr.host%"
+                host: '%test.ibexa.solr.host%'
                 port: 8983
                 path: /solr
                 core: collection1

--- a/tests/lib/Resources/config/single_core.yml
+++ b/tests/lib/Resources/config/single_core.yml
@@ -26,7 +26,7 @@ services:
         arguments:
             -
                 scheme: http
-                host: localhost
+                host: "%test.ibexa.solr.host%"
                 port: 8983
                 path: /solr
                 core: collection1

--- a/tests/lib/SetupFactory/LegacySetupFactory.php
+++ b/tests/lib/SetupFactory/LegacySetupFactory.php
@@ -63,6 +63,8 @@ class LegacySetupFactory extends CoreLegacySetupFactory
      */
     protected function externalBuildContainer(ContainerBuilder $containerBuilder): void
     {
+        $containerBuilder->setParameter('test.ibexa.solr.host', getenv('SOLR_HOST') ?: 'localhost');
+
         $settingsPath = __DIR__ . '/../../../lib/Resources/config/container/';
         $testSettingsPath = __DIR__ . '/../Resources/config/';
 


### PR DESCRIPTION
https://issues.ibexa.co/browse/IBX-5133

This PR allows usage of `SOLR_HOST` environment variable to control the actual hostname of the Solr instance.

`env(SOLR_HOST)` notation in the service declaration files was attempted, but failed. Apparently our custom service container does not properly resolve environment variables in it's expressions, so I have dropped the idea of trying to fix it after a few attempts.