### PR TITLE
[Composer] Fixed failing integration tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,12 +25,13 @@
     },
     "require-dev": {
         "ezsystems/doctrine-dbal-schema": "^1.0@dev",
-        "phpunit/phpunit": "^8.2",
-        "matthiasnoback/symfony-dependency-injection-test": "^4.1",
         "ezsystems/ezplatform-code-style": "^0.1.0",
+        "league/flysystem-memory": "^1.0",
+        "matthiasnoback/symfony-dependency-injection-test": "^4.1",
         "phpstan/phpstan": "^1.8",
         "phpstan/phpstan-phpunit": "^1.1",
-        "phpstan/phpstan-symfony": "^1.2"
+        "phpstan/phpstan-symfony": "^1.2",
+        "phpunit/phpunit": "^8.2"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,10 @@
     },
     "scripts": {
         "test": "phpunit --bootstrap tests/bootstrap.php -c phpunit.xml",
-        "test-integration-solr": "phpunit --bootstrap tests/bootstrap.php -c vendor/ezsystems/ezplatform-kernel/phpunit-integration-legacy-solr.xml",
+        "test-integration-solr": [
+            "Composer\\Config::disableProcessTimeout",
+            "phpunit --bootstrap tests/bootstrap.php -c vendor/ezsystems/ezplatform-kernel/phpunit-integration-legacy-solr.xml"
+        ],
         "fix-cs": "php-cs-fixer fix -v --show-progress=estimating",
         "check-cs": "php-cs-fixer fix --dry-run -v --show-progress=estimating",
         "phpstan": "phpstan analyse"

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
         "phpstan/phpstan": "^1.8",
         "phpstan/phpstan-phpunit": "^1.1",
         "phpstan/phpstan-symfony": "^1.2",
-        "phpunit/phpunit": "^8.2"
+        "phpunit/phpunit": "^8.2",
+        "symfony/proxy-manager-bridge": "^5.4"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
| Question                 | Answer                                              |
|--------------------------|-----------------------------------------------------|
| **JIRA issue**           | n/a |
| **Requires** | ezsystems/ezplatform-kernel#387
| **Type**                 | feature/bug/improvement                             |
| **Target Ibexa version** | `v3.3`+             |
| **BC breaks**            | no                                              |

For more details about the failure see ezsystems/ezplatform-kernel#387. Here I managed to get this working by smaller changes than anticipated:
- [x] Added `league/flysystem-memory` as some tests are executed using the new IbexaTestKernel and require it.
- [x] Added `symfony/proxy-manager-bridge` to resolve circular reference exception
- [x] Disabled process timeout for integration tests, the same way kernel does.


### Known issues

As stated in ezsystems/ezplatform-kernel#387, we need to rethink the way we had those tests organized. It seems we need some more common shared search base tests so we don't rely on tests from kernel (by principle PHPUnit tests are not supposed to be executed externally). Maybe ibexa/test-core is a good place for that, but then it would be for Ibexa 4.x+ only.

I've also spotted locally the following E_NOTICE level error:
```
1) eZ\Publish\API\Repository\Tests\SearchEngineIndexingTest::testIndexContentWithNullField
Undefined property: stdClass::$content_name_s

./lib/ResultExtractor/NativeResultExtractor.php:56
./lib/ResultExtractor/NativeResultExtractor.php:36
./lib/ResultExtractor.php:188
./lib/ResultExtractor.php:70
./lib/Handler.php:154
./vendor/ezsystems/ezplatform-kernel/eZ/Publish/Core/Repository/SearchService.php:179
./vendor/ezsystems/ezplatform-kernel/eZ/Publish/Core/Repository/SearchService.php:98
./vendor/ezsystems/ezplatform-kernel/eZ/Publish/SPI/Repository/Decorator/SearchServiceDecorator.php:33
./vendor/ezsystems/ezplatform-kernel/eZ/Publish/Core/Repository/SiteAccessAware/SearchService.php:54
./vendor/ezsystems/ezplatform-kernel/eZ/Publish/API/Repository/Tests/SearchEngineIndexingTest.php:618
```
Seems CI has different error reporting settings, so leaving this one for later. The production code needs to trust less in the response fields returned by Solr Gateway.


#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review.